### PR TITLE
Fixed most crashes and corrected a few structs

### DIFF
--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -66,7 +66,7 @@ void __cdecl InitDead()
 	}
 	v16 = 0;
 	v4 = v0;
-	memset(&dead[v0], misfiledata[16].mAnimData[0], 8u);
+	memset32(&dead[v0], misfiledata[16].mAnimData[0], 8u);
 	_LOBYTE(dead[v4]._deadtrans) = 0;
 	dead[v4]._deadFrame = 8;
 	v5 = misfiledata[18].mAnimData[0];
@@ -74,7 +74,7 @@ void __cdecl InitDead()
 	dead[v4].field_28 = 32;
 	v6 = v0 + 1;
 	spurtndx = v0 + 1;
-	memset(&dead[v6], v5, 8u);
+	memset32(&dead[v6], v5, 8u);
 	_LOBYTE(dead[v6]._deadtrans) = 0;
 	stonendx = v0 + 2;
 	v7 = nummonsters;

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -66,10 +66,10 @@ void __cdecl InitDead()
 	}
 	v16 = 0;
 	v4 = v0;
-	memset(&dead[v0], misfiledata[16].mAnimCel[0], 8u);
+	memset(&dead[v0], misfiledata[16].mAnimData[0], 8u);
 	_LOBYTE(dead[v4]._deadtrans) = 0;
 	dead[v4]._deadFrame = 8;
-	v5 = misfiledata[18].mAnimCel[0];
+	v5 = misfiledata[18].mAnimData[0];
 	dead[v4].field_24 = 128;
 	dead[v4].field_28 = 32;
 	v6 = v0 + 1;
@@ -93,7 +93,7 @@ void __cdecl InitDead()
 				v10 = monster[v9].MType;
 				v11 = (char *)(v8 - 8);
 				v15 = (int *)8;
-				v14 = &v10->Anims[4].Frames[1];
+				v14 = v10->Anims[4].Frames;
 				do
 				{
 					v12 = v14;

--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -1959,7 +1959,7 @@ void __fastcall L5VertWall(int i, int j, char p, int dy)
 		_LOWORD(v13) = v9;
 		_LOBYTE(v9) = v19;
 		v14 = (unsigned int)(dy - 1) >> 2;
-		memset(v12, v13, v14);
+		memset32(v12, v13, v14);
 		memset(&v12[4 * v14], v13, ((_BYTE)dy - 1) & 3);
 		v11 = dy;
 		v4 = v18;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -2743,9 +2743,9 @@ void __fastcall SetupItem(int i)
 
 	it = ItemCAnimTbl[item[i]._iCurs];
 	item[i]._iAnimWidth = 96;
-	item[i]._iAnimXOff = 16;
+	item[i]._iAnimWidth2 = 16;
 	il = ItemAnimLs[it];
-	item[i].ItemFrame = Item2Frm[it];
+	item[i]._iAnimData = Item2Frm[it];
 	item[i]._iAnimLen = il;
 	item[i]._iIdentified = 0;
 	item[i]._iPostDraw = 0;
@@ -3507,11 +3507,11 @@ void __fastcall RespawnItem(int i, bool FlipFlag)
 	int il; // eax
 
 	item[i]._iAnimWidth = 96;
-	item[i]._iAnimXOff = 16;
+	item[i]._iAnimWidth2 = 16;
 	it = ItemCAnimTbl[item[i]._iCurs];
 	il = ItemAnimLs[it];
 	item[i]._iAnimLen = il;
-	item[i].ItemFrame = Item2Frm[it];
+	item[i]._iAnimData = Item2Frm[it];
 	item[i]._iPostDraw = 0;
 	item[i]._iRequest = 0;
 
@@ -3634,7 +3634,7 @@ void __cdecl FreeItemGFX()
 //----- (00422BCF) --------------------------------------------------------
 void __fastcall GetItemFrm(int i)
 {
-	item[i].ItemFrame = Item2Frm[ItemCAnimTbl[item[i]._iCurs]];
+	item[i]._iAnimData = Item2Frm[ItemCAnimTbl[item[i]._iCurs]];
 }
 
 //----- (00422BF0) --------------------------------------------------------

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -2142,10 +2142,10 @@ void __fastcall SetMissAnim(int mi, int animtype)
 	missile[v2]._miAnimLen = v8;
 	v9 = misfiledata[0].mAnimWidth[v6];
 	missile[v2]._miAnimFlags = v4;
-	v10 = misfiledata[0].mAnimCel[v6];
+	v10 = misfiledata[0].mAnimData[v6];
 	missile[v2]._miAnimWidth = v9;
 	v11 = misfiledata[0].mAnimWidth2[v6];
-	missile[v2]._miAnimCel = v10;
+	missile[v2]._miAnimData = v10;
 	missile[v2]._miAnimDelay = v7;
 	missile[v2]._miAnimWidth2 = v11;
 	missile[v2]._miAnimFrame = 1;
@@ -2180,7 +2180,7 @@ void __fastcall LoadMissileGFX(int mi)
 		v3 = 0;
 		if ( v1->mAnimFAmt )
 		{
-			v4 = v1->mAnimCel;
+			v4 = v1->mAnimData;
 			do
 			{
 				v5 = (int)&v2[*(_DWORD *)&v2[4 * v3++]];
@@ -2196,15 +2196,15 @@ void __fastcall LoadMissileGFX(int mi)
 		if ( v6 == 1 )
 		{
 			sprintf(arglist, "Missiles\\%s.CL2", v1->mName);
-			if ( !v1->mAnimCel[0] )
-				v1->mAnimCel[0] = (int)LoadFileInMem(arglist, 0);
+			if ( !v1->mAnimData[0] )
+				v1->mAnimData[0] = (int)LoadFileInMem(arglist, 0);
 		}
 		else
 		{
 			v7 = 0;
 			if ( v6 )
 			{
-				v8 = (unsigned int *)v1->mAnimCel;
+				v8 = (unsigned int *)v1->mAnimData;
 				do
 				{
 					v9 = v7 + 1;
@@ -2253,11 +2253,11 @@ void __fastcall FreeMissileGFX(int mi)
 	v1 = mi;
 	if ( misfiledata[mi].mFlags & 4 )
 	{
-		v2 = misfiledata[v1].mAnimCel[0];
+		v2 = misfiledata[v1].mAnimData[0];
 		if ( v2 )
 		{
 			mem_free_dbg((void *)(v2 - 4 * misfiledata[v1].mAnimFAmt));
-			misfiledata[v1].mAnimCel[0] = 0;
+			misfiledata[v1].mAnimData[0] = 0;
 		}
 	}
 	else
@@ -2265,7 +2265,7 @@ void __fastcall FreeMissileGFX(int mi)
 		v3 = 0;
 		if ( misfiledata[v1].mAnimFAmt )
 		{
-			v4 = (void **)misfiledata[v1].mAnimCel;
+			v4 = (void **)misfiledata[v1].mAnimData;
 			do
 			{
 				v5 = *v4;
@@ -3523,7 +3523,7 @@ void __fastcall AddRhino(int mi, int sx, int sy, int dx, int dy, int midir, int 
 	int v9; // esi
 	CMonster *v10; // eax
 	char v11; // cl
-	int v12; // edi
+	AnimStruct *v12; // edi
 	int v13; // eax
 	CMonster *v14; // ecx
 	char v15; // cl
@@ -3536,20 +3536,20 @@ void __fastcall AddRhino(int mi, int sx, int sy, int dx, int dy, int midir, int 
 	v11 = v10->mtype;
 	if ( v10->mtype < MT_HORNED || v11 > MT_OBLORD )
 	{
-		if ( v11 < MT_NSNAKE || (v12 = (int)v10->Anims[2].Frames, v11 > MT_GSNAKE) )
-			v12 = (int)v10->Anims[1].Frames;
+		if ( v11 < MT_NSNAKE || (v12 = &v10->Anims[2], v11 > MT_GSNAKE) )
+			v12 = &v10->Anims[1];
 	}
 	else
 	{
-		v12 = (int)v10->Anims[5].Frames;
+		v12 = &v10->Anims[5];
 	}
 	GetMissileVel(i, sx, sy, dx, dy, 18);
 	v13 = i;
 	missile[v13]._miAnimFlags = 0;
 	missile[v13]._mimfnum = midir;
-	missile[v13]._miAnimCel = *(_DWORD *)(v12 + 4 * midir + 4);
-	missile[v13]._miAnimDelay = *(_DWORD *)(v12 + 40);
-	missile[v13]._miAnimLen = *(_DWORD *)(v12 + 36);
+	missile[v13]._miAnimData = v12->Frames[midir];
+	missile[v13]._miAnimDelay = v12->Delay;
+	missile[v13]._miAnimLen = v12->Rate;
 	v14 = monster[v9].MType;
 	missile[v13]._miAnimWidth = v14->flags_1;
 	missile[v13]._miAnimWidth2 = v14->flags_2;
@@ -3588,7 +3588,7 @@ void __fastcall miss_null_32(int mi, int sx, int sy, int dx, int dy, int midir, 
 	v12 = v10;
 	missile[v12]._mimfnum = midir;
 	missile[v12]._miAnimFlags = 0;
-	missile[v12]._miAnimCel = v11->Frames[midir + 1];
+	missile[v12]._miAnimData = v11->Frames[midir];
 	missile[v12]._miAnimDelay = v11->Delay;
 	missile[v12]._miAnimLen = v11->Rate;
 	v13 = monster[id].MType;
@@ -6715,9 +6715,9 @@ void __fastcall mi_null_32(int i)
 		missile[v2]._miyvel = -missile[v2]._miyvel;
 		v14 = opposite[v13];
 		missile[v2]._mimfnum = v14;
-		v15 = monster[v4].MType->Anims[1].Frames[v14 + 1];
+		v15 = monster[v4].MType->Anims[1].Frames[v14];
 		++missile[v2]._miVar2;
-		missile[v2]._miAnimCel = v15;
+		missile[v2]._miAnimData = v15;
 		if ( v10 > 0 )
 			missile[v2]._miVar1 |= 1u;
 	}
@@ -7675,7 +7675,7 @@ void __cdecl missiles_process_charge()
 	bool v4; // zf
 	CMonster *v5; // eax
 	char v6; // dl
-	int v7; // eax
+	AnimStruct *v7; // eax
 
 	v0 = nummissiles;
 	for ( i = 0; i < v0; ++i )
@@ -7683,7 +7683,7 @@ void __cdecl missiles_process_charge()
 		v2 = missileactive[i];
 		v3 = missile[v2]._mimfnum;
 		v4 = missile[v2]._mitype == MIS_RHINO;
-		missile[v2]._miAnimCel = misfiledata[0].mAnimCel[v3 + 59 * _LOBYTE(missile[v2]._miAnimType)];
+		missile[v2]._miAnimData = misfiledata[0].mAnimData[v3 + 59 * _LOBYTE(missile[v2]._miAnimType)];
 		if ( v4 )
 		{
 			v5 = monster[missile[v2]._misource].MType;
@@ -7691,15 +7691,15 @@ void __cdecl missiles_process_charge()
 			if ( v5->mtype < MT_HORNED || v6 > MT_OBLORD )
 			{
 				if ( v6 < MT_NSNAKE || v6 > MT_GSNAKE )
-					v7 = (int)v5->Anims[1].Frames;
+					v7 = &v5->Anims[1];
 				else
-					v7 = (int)v5->Anims[2].Frames;
+					v7 = &v5->Anims[2];
 			}
 			else
 			{
-				v7 = (int)v5->Anims[5].Frames;
+				v7 = &v5->Anims[5];
 			}
-			missile[v2]._miAnimCel = *(_DWORD *)(v7 + 4 * v3 + 4);
+			missile[v2]._miAnimData = v7->Frames[v3];
 		}
 	}
 }

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -375,7 +375,7 @@ void __fastcall InitMonsterTRN(int monst, int special)
 	int v6; // ebp
 	unsigned char v7; // al
 	int v8; // edi
-	char **v9; // ebx
+	AnimStruct *v9; // ebx
 	signed int v10; // [esp+8h] [ebp-8h]
 	int v11; // [esp+Ch] [ebp-4h]
 
@@ -399,14 +399,14 @@ void __fastcall InitMonsterTRN(int monst, int special)
 			{
 				v10 = 8;
 				v8 = 44 * v6 + monst * 328;
-				v9 = (char **)((char *)&Monsters[0].Anims[0].Frames[1] + v8);
+				v9 = (AnimStruct *)((char *)Monsters[0].Anims + v8 + 4);
 				do
 				{
 					Cl2ApplyTrans(
-						*v9,
+						(char *)v9->CMem,
 						(char *)Monsters[monst].trans_file,
 						*(int *)((char *)&Monsters[0].Anims[0].Rate + v8));
-					++v9;
+					v9 = (AnimStruct *)((char *)v9 + 4);
 					--v10;
 				}
 				while ( v10 );
@@ -658,9 +658,9 @@ void __fastcall InitMonsterGFX(int monst)
 	v2 = (unsigned char)Monsters[monst].mtype;
 	v31 = v2;
 	v3 = v2 << 7;
-	v4 = &Monsters[monst].Anims[0].Frames[1];
+	v4 = Monsters[monst].Anims[0].Frames;
 	v5 = (int *)((char *)monsterdata[0].Frames + v3);
-	v30 = &Monsters[monst].Anims[0].Frames[1];
+	v30 = Monsters[monst].Anims[0].Frames;
 	v28 = (int *)((char *)monsterdata[0].Frames + v3);
 	do
 	{
@@ -838,7 +838,7 @@ void __fastcall InitMonster(int i, int rd, int mtype, int x, int y)
 	monster[v6].mName = v9;
 	monster[v6].MType = monst;
 	monster[v6].MData = v8;
-	monster[v6]._mAFNum = monst->Anims[0].Frames[rd + 1];
+	monster[v6]._mAFNum = monst->Anims[0].Frames[rd];
 	v10 = monst->Anims[0].Delay;
 	monster[v6]._mAnimDelay = v10;
 	monster[v6]._mAnimCnt = random(88, v10 - 1);
@@ -893,7 +893,7 @@ void __fastcall InitMonster(int i, int rd, int mtype, int x, int y)
 	monster[v6]._mFlags = v21;
 	if ( monster[v6]._mAi == AI_GARG )
 	{
-		v22 = monst->Anims[5].Frames[v5 + 1];
+		v22 = monst->Anims[5].Frames[v5];
 		monster[v6]._mFlags |= 4u;
 		monster[v6]._mAFNum = v22;
 		monster[v6]._mAnimFrame = 1;
@@ -1525,7 +1525,7 @@ void __fastcall PlaceGroup(int mtype, int num, unsigned char leaderf, int leader
 					if ( monster[v18]._mAi != AI_GARG )
 					{
 						v21 = nummonsters;
-						v22 = monster[v18].MType->Anims[0].Frames[monster[v18]._mdir + 1];
+						v22 = monster[v18].MType->Anims[0].Frames[monster[v18]._mdir];
 						monster[v18]._mAFNum = v22;
 						_LOBYTE(v22) = 88;
 						monster[v21]._mAnimFrame = random(v22, monster[v21]._mAnimLen - 1) + 1;
@@ -1922,7 +1922,7 @@ void __fastcall NewMonsterAnim(int i, AnimStruct *anim, int md)
 	int v5; // edx
 
 	v3 = &monster[i];
-	v3->_mAFNum = anim->Frames[md + 1];
+	v3->_mAFNum = anim->Frames[md];
 	v4 = anim->Rate;
 	v3->_mAnimCnt = 0;
 	v3->_mAnimLen = v4;
@@ -3075,7 +3075,7 @@ void __fastcall M_StartHeal(int i)
 	if ( !monster[v1].MType )
 		TermMsg("M_StartHeal: Monster %d \"%s\" MType NULL", v1, monster[v2].mName);
 	v3 = monster[v2].MType;
-	v4 = v3->Anims[5].Frames[monster[v2]._mdir + 1];
+	v4 = v3->Anims[5].Frames[monster[v2]._mdir];
 	monster[v2]._mAFNum = v4;
 	v5 = v3->Anims[5].Rate;
 	monster[v2]._mFlags |= 2u;
@@ -3147,9 +3147,9 @@ int __fastcall M_DoStand(int i)
 	v3 = monster[v2].MType;
 	v4 = monster[v2]._mdir;
 	if ( v3->mtype == MT_GOLEM )
-		v5 = v3->Anims[1].Frames[v4 + 1];
+		v5 = v3->Anims[1].Frames[v4];
 	else
-		v5 = v3->Anims[0].Frames[v4 + 1];
+		v5 = v3->Anims[0].Frames[v4];
 	monster[v2]._mAFNum = v5;
 	if ( monster[v2]._mAnimFrame == monster[v2]._mAnimLen )
 		M_Enemy(v1);
@@ -4336,7 +4336,7 @@ int __fastcall M_DoDelay(int i)
 		TermMsg("M_DoDelay: Monster %d \"%s\" MType NULL", v1, monster[v2].mName);
 	v3 = M_GetDir(v1);
 	v4 = monster[v2]._mAi == AI_LAZURUS;
-	monster[v2]._mAFNum = monster[v2].MType->Anims[0].Frames[v3 + 1];
+	monster[v2]._mAFNum = monster[v2].MType->Anims[0].Frames[v3];
 	if ( v4 )
 	{
 		v5 = monster[v2]._mVar2;
@@ -4870,7 +4870,7 @@ void __fastcall MAI_Zombie(int i)
 				M_StartAttack(arglist);
 			}
 			if ( v3->_mmode == MM_STAND )
-				v3->_mAFNum = v3->MType->Anims[0].Frames[v3->_mdir + 1];
+				v3->_mAFNum = v3->MType->Anims[0].Frames[v3->_mdir];
 		}
 	}
 }
@@ -4948,7 +4948,7 @@ LABEL_10:
 		}
 LABEL_16:
 		if ( v2->_mmode == MM_STAND )
-			v2->_mAFNum = v2->MType->Anims[0].Frames[v7 + 1];
+			v2->_mAFNum = v2->MType->Anims[0].Frames[v7];
 	}
 }
 
@@ -5082,7 +5082,7 @@ void __fastcall MAI_Snake(int i)
 					M_StartAttack(arglist);
 LABEL_49:
 					if ( esi3->_mmode == MM_STAND )
-						esi3->_mAFNum = esi3->MType->Anims[0].Frames[esi3->_mdir + 1];
+						esi3->_mAFNum = esi3->MType->Anims[0].Frames[esi3->_mdir];
 					return;
 				}
 				_LOBYTE(v16) = 105;
@@ -5312,7 +5312,7 @@ void __fastcall MAI_Bat(int i)
 				}
 			}
 			if ( esi3->_mmode == MM_STAND )
-				esi3->_mAFNum = esi3->MType->Anims[0].Frames[midir + 1];
+				esi3->_mAFNum = esi3->MType->Anims[0].Frames[midir];
 		}
 	}
 }
@@ -5387,7 +5387,7 @@ void __fastcall MAI_SkelBow(int i)
 			}
 		}
 		if ( v2->_mmode == MM_STAND )
-			v2->_mAFNum = v2->MType->Anims[0].Frames[v17 + 1];
+			v2->_mAFNum = v2->MType->Anims[0].Frames[v17];
 	}
 }
 
@@ -5444,7 +5444,7 @@ void __fastcall MAI_Fat(int i)
 			}
 		}
 		if ( v2->_mmode == MM_STAND )
-			v2->_mAFNum = v2->MType->Anims[0].Frames[md + 1];
+			v2->_mAFNum = v2->MType->Anims[0].Frames[md];
 	}
 }
 
@@ -5545,7 +5545,7 @@ void __fastcall MAI_Sneak(int i)
 			if ( v2->_mmode == MM_STAND )
 			{
 				if ( abs(v17) >= 2 || abs(v4) >= 2 || v15 >= 4 * (unsigned char)v2->_mint + 10 )
-					v2->_mAFNum = v2->MType->Anims[0].Frames[md + 1];
+					v2->_mAFNum = v2->MType->Anims[0].Frames[md];
 				else
 					M_StartAttack(arglist);
 			}
@@ -5814,7 +5814,7 @@ void __fastcall MAI_Cleaver(int i)
 		else
 			M_StartAttack(arglist);
 		if ( v2->_mmode == MM_STAND )
-			v2->_mAFNum = v2->MType->Anims[0].Frames[v7 + 1];
+			v2->_mAFNum = v2->MType->Anims[0].Frames[v7];
 	}
 }
 
@@ -5948,7 +5948,7 @@ LABEL_26:
 			}
 		}
 		if ( v3->_mmode == MM_STAND )
-			v3->_mAFNum = v3->MType->Anims[0].Frames[md + 1];
+			v3->_mAFNum = v3->MType->Anims[0].Frames[md];
 	}
 }
 
@@ -6031,7 +6031,7 @@ void __fastcall MAI_Ranged(int i, int missile_type, unsigned char special)
 				}
 				else
 				{
-					monster[v4]._mAFNum = monster[v4].MType->Anims[0].Frames[v20 + 1];
+					monster[v4]._mAFNum = monster[v4].MType->Anims[0].Frames[v20];
 				}
 			}
 		}
@@ -6918,7 +6918,7 @@ LABEL_26:
 			}
 		}
 		if ( v2->_mmode == MM_STAND )
-			v2->_mAFNum = v2->MType->Anims[0].Frames[md + 1];
+			v2->_mAFNum = v2->MType->Anims[0].Frames[md];
 	}
 }
 // 679660: using guessed type char gbMaxPlayers;
@@ -7084,7 +7084,7 @@ LABEL_23:
 			}
 		}
 		if ( esi3->_mmode == MM_STAND )
-			esi3->_mAFNum = esi3->MType->Anims[0].Frames[esi3->_mdir + 1];
+			esi3->_mAFNum = esi3->MType->Anims[0].Frames[esi3->_mdir];
 	}
 }
 
@@ -7319,7 +7319,7 @@ void __fastcall MAI_Garbud(int i)
 			MAI_Round(arglist, 1u);
 		monster[v2]._mdir = v8;
 		if ( monster[v2]._mmode == MM_STAND )
-			monster[v2]._mAFNum = monster[v2].MType->Anims[0].Frames[v8 + 1];
+			monster[v2]._mAFNum = monster[v2].MType->Anims[0].Frames[v8];
 	}
 }
 
@@ -7378,7 +7378,7 @@ void __fastcall MAI_Zhar(int i)
 			MAI_Counselor(arglist);
 		monster[v2]._mdir = v11;
 		if ( monster[v2]._mmode == MM_STAND )
-			monster[v2]._mAFNum = monster[v2].MType->Anims[0].Frames[v11 + 1];
+			monster[v2]._mAFNum = monster[v2].MType->Anims[0].Frames[v11];
 	}
 }
 
@@ -7438,7 +7438,7 @@ void __fastcall MAI_SnotSpil(int i)
 		}
 		monster[v2]._mdir = v5;
 		if ( monster[v2]._mmode == MM_STAND )
-			monster[v2]._mAFNum = monster[v2].MType->Anims[0].Frames[v5 + 1];
+			monster[v2]._mAFNum = monster[v2].MType->Anims[0].Frames[v5];
 	}
 }
 // 5CF330: using guessed type int setpc_h;
@@ -7509,7 +7509,7 @@ LABEL_29:
 		monster[v2]._mdir = v5;
 		v8 = monster[v2]._mmode;
 		if ( v8 == MM_STAND || v8 == MM_TALK )
-			monster[v2]._mAFNum = monster[v2].MType->Anims[0].Frames[v5 + 1];
+			monster[v2]._mAFNum = monster[v2].MType->Anims[0].Frames[v5];
 	}
 }
 // 679660: using guessed type char gbMaxPlayers;
@@ -7552,7 +7552,7 @@ LABEL_10:
 			MAI_Succ(ia);
 		monster[v2]._mdir = v5;
 		if ( monster[v2]._mmode == MM_STAND )
-			monster[v2]._mAFNum = monster[v2].MType->Anims[0].Frames[v5 + 1];
+			monster[v2]._mAFNum = monster[v2].MType->Anims[0].Frames[v5];
 	}
 }
 // 679660: using guessed type char gbMaxPlayers;
@@ -7596,7 +7596,7 @@ void __fastcall MAI_Lachdanan(int i)
 		}
 		monster[v2]._mdir = v6;
 		if ( monster[v2]._mmode == MM_STAND )
-			monster[v2]._mAFNum = monster[v2].MType->Anims[0].Frames[v6 + 1];
+			monster[v2]._mAFNum = monster[v2].MType->Anims[0].Frames[v6];
 	}
 }
 
@@ -7639,7 +7639,7 @@ void __fastcall MAI_Warlord(int i)
 		monster[v2]._mdir = v5;
 		v7 = monster[v2]._mmode;
 		if ( v7 == MM_STAND || v7 == MM_TALK )
-			monster[v2]._mAFNum = monster[v2].MType->Anims[0].Frames[v5 + 1];
+			monster[v2]._mAFNum = monster[v2].MType->Anims[0].Frames[v5];
 	}
 }
 
@@ -8386,22 +8386,22 @@ void __fastcall SyncMonsterAnim(int i)
 		case MM_STAND:
 		case MM_DELAY:
 		case MM_TALK:
-			v10 = v5->Anims[0].Frames[v9 + 1];
+			v10 = v5->Anims[0].Frames[v9];
 			goto LABEL_13;
 		case MM_WALK:
 		case MM_WALK2:
 		case MM_WALK3:
-			v10 = v5->Anims[1].Frames[v9 + 1];
+			v10 = v5->Anims[1].Frames[v9];
 			goto LABEL_13;
 		case MM_ATTACK:
 		case MM_RATTACK:
-			v10 = v5->Anims[2].Frames[v9 + 1];
+			v10 = v5->Anims[2].Frames[v9];
 			goto LABEL_13;
 		case MM_GOTHIT:
-			v10 = v5->Anims[3].Frames[v9 + 1];
+			v10 = v5->Anims[3].Frames[v9];
 			goto LABEL_13;
 		case MM_DEATH:
-			v10 = v5->Anims[4].Frames[v9 + 1];
+			v10 = v5->Anims[4].Frames[v9];
 			goto LABEL_13;
 		case MM_SATTACK:
 		case MM_FADEIN:
@@ -8409,18 +8409,18 @@ void __fastcall SyncMonsterAnim(int i)
 		case MM_SPSTAND:
 		case MM_RSPATTACK:
 		case MM_HEAL:
-			v10 = v5->Anims[5].Frames[v9 + 1];
+			v10 = v5->Anims[5].Frames[v9];
 LABEL_13:
 			monster[v2]._mAFNum = v10;
 			return;
 		case MM_CHARGE:
-			v11 = v5->Anims[2].Frames[v9 + 1];
+			v11 = v5->Anims[2].Frames[v9];
 			monster[v2]._mAnimFrame = 1;
 			monster[v2]._mAFNum = v11;
 			v12 = v5->Anims[2].Rate;
 			break;
 		default:
-			v13 = v5->Anims[0].Frames[v9 + 1];
+			v13 = v5->Anims[0].Frames[v9];
 			monster[v2]._mAnimFrame = 1;
 			monster[v2]._mAFNum = v13;
 			v12 = v5->Anims[0].Rate;

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -685,7 +685,7 @@ void __fastcall InitMonsterGFX(int monst)
 			}
 			else
 			{
-				memset(v4, (int)v7, 8u);
+				memset32(v4, (int)v7, 8u);
 				v4 = v30;
 			}
 			v5 = v28;

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1846,7 +1846,7 @@ void __fastcall SetupObject(int i, int x, int y, int ot)
 	v8 = 0;
 	while ( v7 != v6 )
 		v7 = ObjFileList[v8++ + 1];
-	object[v4]._oAnimCel = pObjCels[v8];
+	object[v4]._oAnimData = pObjCels[v8];
 	v9 = AllObjects[v5].oAnimFlag;
 	object[v4]._oAnimFlag = v9;
 	if ( v9 )
@@ -7270,7 +7270,7 @@ void __fastcall SyncObjectAnim(int o)
 	v3 = 0;
 	while ( v2 != (char)AllObjects[object[o]._otype].ofindex )
 		v2 = ObjFileList[v3++ + 1];
-	object[o]._oAnimCel = pObjCels[v3];
+	object[o]._oAnimData = pObjCels[v3];
 	if ( v1 <= OBJ_BOOK2R )
 	{
 		if ( v1 != OBJ_BOOK2R )

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -133,7 +133,7 @@ void __fastcall DrawMissile(int x, int y, int sx, int sy, int a5, int a6, int de
 			v11 = &missile[v10];
 			if ( v11->_mix == v26 && v11->_miy == v7 && v11->_miPreFlag == del_flag && v11->_miDrawFlag )
 			{
-				v12 = (char *)v11->_miAnimCel;
+				v12 = (char *)v11->_miAnimData;
 				if ( !v12 )
 					return;
 				v13 = v11->_miAnimFrame;
@@ -165,7 +165,7 @@ void __fastcall DrawMissile(int x, int y, int sx, int sy, int a5, int a6, int de
 		{
 			if ( v16->_miDrawFlag )
 			{
-				v17 = (char *)v16->_miAnimCel;
+				v17 = (char *)v16->_miAnimData;
 				if ( v17 )
 				{
 					v18 = v16->_miAnimFrame;
@@ -233,7 +233,7 @@ void __fastcall DrawClippedMissile(int x, int y, int sx, int sy, int a5, int a6,
 			v11 = &missile[v10];
 			if ( v11->_mix == v26 && v11->_miy == v7 && v11->_miPreFlag == a7 && v11->_miDrawFlag )
 			{
-				v12 = (char *)v11->_miAnimCel;
+				v12 = (char *)v11->_miAnimData;
 				if ( !v12 )
 					return;
 				v13 = v11->_miAnimFrame;
@@ -265,7 +265,7 @@ void __fastcall DrawClippedMissile(int x, int y, int sx, int sy, int a5, int a6,
 		{
 			if ( v16->_miDrawFlag )
 			{
-				v17 = (char *)v16->_miAnimCel;
+				v17 = (char *)v16->_miAnimData;
 				if ( v17 )
 				{
 					v18 = v16->_miAnimFrame;
@@ -367,7 +367,7 @@ void __fastcall DrawPlayer(int pnum, int x, int y, int px, int py, int animdata,
 						Cl2DecodeFrm1(
 							px + plr[v13]._pAnimWidth2 - misfiledata[9].mAnimWidth2[0],
 							py,
-							(char *)misfiledata[9].mAnimCel[0],
+							(char *)misfiledata[9].mAnimData[0],
 							1,
 							misfiledata[9].mAnimWidth[0],
 							a9,
@@ -380,7 +380,7 @@ void __fastcall DrawPlayer(int pnum, int x, int y, int px, int py, int animdata,
 						Cl2DecodeFrm3(
 							px + plr[v13]._pAnimWidth2 - misfiledata[9].mAnimWidth2[0],
 							py,
-							(char *)misfiledata[9].mAnimCel[0],
+							(char *)misfiledata[9].mAnimData[0],
 							1,
 							misfiledata[9].mAnimWidth[0],
 							a9,
@@ -399,7 +399,7 @@ void __fastcall DrawPlayer(int pnum, int x, int y, int px, int py, int animdata,
 						Cl2DecodeLightTbl(
 							px + plr[v13]._pAnimWidth2 - misfiledata[9].mAnimWidth2[0],
 							py,
-							(char *)misfiledata[9].mAnimCel[0],
+							(char *)misfiledata[9].mAnimData[0],
 							1,
 							misfiledata[9].mAnimWidth[0],
 							a9,
@@ -449,7 +449,7 @@ void __fastcall DrawClippedPlayer(int pnum, int x, int y, int px, int py, int an
 						Cl2DecodeFrm4(
 							px + plr[v13]._pAnimWidth2 - misfiledata[9].mAnimWidth2[0],
 							py,
-							(char *)misfiledata[9].mAnimCel[0],
+							(char *)misfiledata[9].mAnimData[0],
 							1,
 							misfiledata[9].mAnimWidth[0],
 							a9,
@@ -462,7 +462,7 @@ void __fastcall DrawClippedPlayer(int pnum, int x, int y, int px, int py, int an
 						Cl2DecodeFrm5(
 							px + plr[v13]._pAnimWidth2 - misfiledata[9].mAnimWidth2[0],
 							py,
-							(char *)misfiledata[9].mAnimCel[0],
+							(char *)misfiledata[9].mAnimData[0],
 							1,
 							misfiledata[9].mAnimWidth[0],
 							a9,
@@ -481,7 +481,7 @@ void __fastcall DrawClippedPlayer(int pnum, int x, int y, int px, int py, int an
 						Cl2DecodeFrm6(
 							px + plr[v13]._pAnimWidth2 - misfiledata[9].mAnimWidth2[0],
 							py,
-							(char *)misfiledata[9].mAnimCel[0],
+							(char *)misfiledata[9].mAnimData[0],
 							1,
 							misfiledata[9].mAnimWidth[0],
 							a9,
@@ -998,7 +998,7 @@ void __fastcall scrollrt_draw_clipped_dungeon(char *a1, int sx, int sy, int a4, 
 		if ( v7 )
 		{
 			v11 = &dead[(v7 & 0x1F) - 1];
-			v12 = (int *)v11->_deadAnim[(v7 >> 5) & 7];
+			v12 = (int *)v11->_deadData[(v7 >> 5) & 7];
 			v13 = a4 - v11->field_28;
 			if ( v12 )
 			{
@@ -1021,16 +1021,16 @@ void __fastcall scrollrt_draw_clipped_dungeon(char *a1, int sx, int sy, int a4, 
 		v16 = &item[v49-1];
 		if ( !v16->_iPostDraw && (unsigned char)v49 <= 0x7Fu )
 		{
-			v17 = (char *)v16->ItemFrame;
+			v17 = (char *)v16->_iAnimData;
 			if ( v17 )
 			{
 				v18 = v16->_iAnimFrame;
 				if ( v18 >= 1 && *(_DWORD *)v17 <= 0x32u && v18 <= *(_DWORD *)v17 )
 				{
-					v19 = a4 - v16->_iAnimXOff;
+					v19 = a4 - v16->_iAnimWidth2;
 					if ( v49 - 1 == pcursitem )
 						CelDrawHdrClrHL(181, v19, a5, v17, v16->_iAnimFrame, v16->_iAnimWidth, 0, 8);
-					Cel2DecodeHdrLight(v19, a5, (char *)v16->ItemFrame, v16->_iAnimFrame, v16->_iAnimWidth, 0, 8);
+					Cel2DecodeHdrLight(v19, a5, (char *)v16->_iAnimData, v16->_iAnimFrame, v16->_iAnimWidth, 0, 8);
 				}
 			}
 		}
@@ -1158,19 +1158,19 @@ void __fastcall scrollrt_draw_clipped_dungeon(char *a1, int sx, int sy, int a4, 
 		{
 			if ( (unsigned char)v49 <= 0x7Fu )
 			{
-				v37 = (char *)v36->ItemFrame;
+				v37 = (char *)v36->_iAnimData;
 				if ( v37 )
 				{
 					v38 = v36->_iAnimFrame;
 					if ( v38 >= 1 && *(_DWORD *)v37 <= 0x32u && v38 <= *(_DWORD *)v37 )
 					{
-						v39 = a4 - v36->_iAnimXOff;
+						v39 = a4 - v36->_iAnimWidth2;
 						if ( v49 - 1 == pcursitem )
 							CelDrawHdrClrHL(181, v39, a5, v37, v36->_iAnimFrame, v36->_iAnimWidth, 0, 8);
 						Cel2DecodeHdrLight(
 							v39,
 							a5,
-							(char *)v36->ItemFrame,
+							(char *)v36->_iAnimData,
 							v36->_iAnimFrame,
 							v36->_iAnimWidth,
 							0,
@@ -1294,7 +1294,7 @@ void __fastcall DrawClippedObject(int x, int y, int a3, int a4, int pre_flag, in
 	}
 	if ( v9 < 0x7Fu )
 	{
-		v15 = (char *)object[v10]._oAnimCel;
+		v15 = (char *)object[v10]._oAnimData;
 		if ( v15 )
 		{
 			v16 = object[v10]._oAnimFrame;
@@ -1304,7 +1304,7 @@ void __fastcall DrawClippedObject(int x, int y, int a3, int a4, int pre_flag, in
 					CelDrawHdrClrHL(194, v12, v11, v15, v16, object[v10]._oAnimWidth, a6, dir);
 				v19 = object[v10]._oAnimWidth;
 				v18 = object[v10]._oAnimFrame;
-				v17 = (char *)object[v10]._oAnimCel;
+				v17 = (char *)object[v10]._oAnimData;
 				if ( object[v10]._oLight )
 					Cel2DecodeHdrLight(v12, v11, v17, v18, v19, a6, dir);
 				else
@@ -1676,7 +1676,7 @@ void __fastcall scrollrt_draw_clipped_dungeon_2(char *buffer, int x, int y, int 
 		if ( v9 )
 		{
 			v14 = &dead[(v9 & 0x1F) - 1];
-			v15 = (int *)v14->_deadAnim[(v9 >> 5) & 7];
+			v15 = (int *)v14->_deadData[(v9 >> 5) & 7];
 			v16 = v13 - v14->field_28;
 			if ( v15 )
 			{
@@ -1699,16 +1699,16 @@ void __fastcall scrollrt_draw_clipped_dungeon_2(char *buffer, int x, int y, int 
 		v19 = &item[v52-1];
 		if ( !v19->_iPostDraw && (unsigned char)v52 <= 0x7Fu )
 		{
-			v20 = (char *)v19->ItemFrame;
+			v20 = (char *)v19->_iAnimData;
 			if ( v20 )
 			{
 				v21 = v19->_iAnimFrame;
 				if ( v21 >= 1 && *(_DWORD *)v20 <= 0x32u && v21 <= *(_DWORD *)v20 )
 				{
-					v22 = v13 - v19->_iAnimXOff;
+					v22 = v13 - v19->_iAnimWidth2;
 					if ( v52 - 1 == pcursitem )
 						CelDrawHdrClrHL(181, v22, sy, v20, v19->_iAnimFrame, v19->_iAnimWidth, a5, 8);
-					Cel2DecodeHdrLight(v22, sy, (char *)v19->ItemFrame, v19->_iAnimFrame, v19->_iAnimWidth, a5, 8);
+					Cel2DecodeHdrLight(v22, sy, (char *)v19->_iAnimData, v19->_iAnimFrame, v19->_iAnimWidth, a5, 8);
 				}
 			}
 		}
@@ -1838,19 +1838,19 @@ void __fastcall scrollrt_draw_clipped_dungeon_2(char *buffer, int x, int y, int 
 		{
 			if ( (unsigned char)v52 <= 0x7Fu )
 			{
-				v40 = (char *)v39->ItemFrame;
+				v40 = (char *)v39->_iAnimData;
 				if ( v40 )
 				{
 					v41 = v39->_iAnimFrame;
 					if ( v41 >= 1 && *(_DWORD *)v40 <= 0x32u && v41 <= *(_DWORD *)v40 )
 					{
-						v42 = v13 - v39->_iAnimXOff;
+						v42 = v13 - v39->_iAnimWidth2;
 						if ( v52 - 1 == pcursitem )
 							CelDrawHdrClrHL(181, v42, sy, v40, v41, v39->_iAnimWidth, a5, 8);
 						Cel2DecodeHdrLight(
 							v42,
 							sy,
-							(char *)v39->ItemFrame,
+							(char *)v39->_iAnimData,
 							v39->_iAnimFrame,
 							v39->_iAnimWidth,
 							a5,
@@ -2281,7 +2281,7 @@ void __fastcall scrollrt_draw_dungeon(char *buffer, int x, int y, int a4, int a5
 		if ( v9 )
 		{
 			v13 = &dead[(v9 & 0x1F) - 1];
-			v14 = (int *)v13->_deadAnim[(v9 >> 5) & 7];
+			v14 = (int *)v13->_deadData[(v9 >> 5) & 7];
 			v15 = sx - v13->field_28;
 			if ( v14 )
 			{
@@ -2304,16 +2304,16 @@ void __fastcall scrollrt_draw_dungeon(char *buffer, int x, int y, int a4, int a5
 		v18 = &item[v51-1];
 		if ( !v18->_iPostDraw && (unsigned char)v51 <= 0x7Fu )
 		{
-			v19 = (char *)v18->ItemFrame;
+			v19 = (char *)v18->_iAnimData;
 			if ( v19 )
 			{
 				v20 = v18->_iAnimFrame;
 				if ( v20 >= 1 && *(_DWORD *)v19 <= 0x32u && v20 <= *(_DWORD *)v19 )
 				{
-					v21 = sx - v18->_iAnimXOff;
+					v21 = sx - v18->_iAnimWidth2;
 					if ( v51 - 1 == pcursitem )
 						CelDecodeClr(181, v21, sy, v19, v18->_iAnimFrame, v18->_iAnimWidth, 0, a5);
-					CelDecodeHdrLightOnly(v21, sy, (char *)v18->ItemFrame, v18->_iAnimFrame, v18->_iAnimWidth, 0, a5);
+					CelDecodeHdrLightOnly(v21, sy, (char *)v18->_iAnimData, v18->_iAnimFrame, v18->_iAnimWidth, 0, a5);
 				}
 			}
 		}
@@ -2441,19 +2441,19 @@ void __fastcall scrollrt_draw_dungeon(char *buffer, int x, int y, int a4, int a5
 		{
 			if ( (unsigned char)v51 <= 0x7Fu )
 			{
-				v39 = (char *)v38->ItemFrame;
+				v39 = (char *)v38->_iAnimData;
 				if ( v39 )
 				{
 					v40 = v38->_iAnimFrame;
 					if ( v40 >= 1 && *(_DWORD *)v39 <= 0x32u && v40 <= *(_DWORD *)v39 )
 					{
-						v41 = sx - v38->_iAnimXOff;
+						v41 = sx - v38->_iAnimWidth2;
 						if ( v51 - 1 == pcursitem )
 							CelDecodeClr(181, v41, sy, v39, v38->_iAnimFrame, v38->_iAnimWidth, 0, a5);
 						CelDecodeHdrLightOnly(
 							v41,
 							sy,
-							(char *)v38->ItemFrame,
+							(char *)v38->_iAnimData,
 							v38->_iAnimFrame,
 							v38->_iAnimWidth,
 							0,
@@ -2575,7 +2575,7 @@ void __fastcall DrawObject(int x, int y, int a3, int a4, int pre_flag, int a6, i
 	}
 	if ( v9 < 0x7Fu )
 	{
-		v15 = (char *)object[v10]._oAnimCel;
+		v15 = (char *)object[v10]._oAnimData;
 		if ( v15 )
 		{
 			v16 = object[v10]._oAnimFrame;
@@ -2588,7 +2588,7 @@ void __fastcall DrawObject(int x, int y, int a3, int a4, int pre_flag, int a6, i
 					CelDecodeHdrLightOnly(
 						v12,
 						v11,
-						(char *)object[v10]._oAnimCel,
+						(char *)object[v10]._oAnimData,
 						object[v10]._oAnimFrame,
 						object[v10]._oAnimWidth,
 						a6,
@@ -2596,7 +2596,7 @@ void __fastcall DrawObject(int x, int y, int a3, int a4, int pre_flag, int a6, i
 				}
 				else
 				{
-					v17 = (char *)object[v10]._oAnimCel;
+					v17 = (char *)object[v10]._oAnimData;
 					if ( v17 )
 						CelDrawHdrOnly(v12, v11, v17, object[v10]._oAnimFrame, object[v10]._oAnimWidth, a6, dir);
 				}

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -178,18 +178,18 @@ void __fastcall town_draw_clipped_town(void *unused, int x, int y, int sx, int s
 	{
 		v9 = v8 - 1;
 		v10 = v9;
-		v11 = sx - item[v10]._iAnimXOff;
+		v11 = sx - item[v10]._iAnimWidth2;
 		if ( v9 == pcursitem )
 			CelDrawHdrClrHL(
 				181,
 				v11,
 				sy,
-				(char *)item[v10].ItemFrame,
+				(char *)item[v10]._iAnimData,
 				item[v10]._iAnimFrame,
 				item[v10]._iAnimWidth,
 				0,
 				8);
-		Cel2DrawHdrOnly(v11, sy, (char *)item[v10].ItemFrame, item[v10]._iAnimFrame, item[v10]._iAnimWidth, 0, 8);
+		Cel2DrawHdrOnly(v11, sy, (char *)item[v10]._iAnimData, item[v10]._iAnimFrame, item[v10]._iAnimWidth, 0, 8);
 	}
 	if ( dFlags[0][v7] & 0x10 )
 	{
@@ -200,12 +200,12 @@ void __fastcall town_draw_clipped_town(void *unused, int x, int y, int sx, int s
 				166,
 				v13,
 				sy,
-				(char *)towner[v12]._tAnimCel,
+				(char *)towner[v12]._tAnimData,
 				towner[v12]._tAnimFrame,
 				towner[v12]._tAnimWidth,
 				0,
 				8);
-		Cel2DrawHdrOnly(v13, sy, (char *)towner[v12]._tAnimCel, towner[v12]._tAnimFrame, towner[v12]._tAnimWidth, 0, 8);
+		Cel2DrawHdrOnly(v13, sy, (char *)towner[v12]._tAnimData, towner[v12]._tAnimFrame, towner[v12]._tAnimWidth, 0, 8);
 	}
 	v14 = dMonster[0][v7];
 	if ( v14 > 0 )
@@ -218,12 +218,12 @@ void __fastcall town_draw_clipped_town(void *unused, int x, int y, int sx, int s
 				166,
 				v17,
 				sy,
-				(char *)towner[v16]._tAnimCel,
+				(char *)towner[v16]._tAnimData,
 				towner[v16]._tAnimFrame,
 				towner[v16]._tAnimWidth,
 				0,
 				8);
-		Cel2DrawHdrOnly(v17, sy, (char *)towner[v16]._tAnimCel, towner[v16]._tAnimFrame, towner[v16]._tAnimWidth, 0, 8);
+		Cel2DrawHdrOnly(v17, sy, (char *)towner[v16]._tAnimData, towner[v16]._tAnimFrame, towner[v16]._tAnimWidth, 0, 8);
 	}
 	if ( dFlags[0][v7] & 0x20 )
 	{
@@ -481,18 +481,18 @@ void __fastcall town_draw_clipped_town_2(int x, int y, int a3, int a4, int a5, i
 	{
 		v11 = v10 - 1;
 		v12 = v11;
-		v13 = sx - item[v12]._iAnimXOff;
+		v13 = sx - item[v12]._iAnimWidth2;
 		if ( v11 == pcursitem )
 			CelDrawHdrClrHL(
 				181,
 				v13,
 				sy,
-				(char *)item[v12].ItemFrame,
+				(char *)item[v12]._iAnimData,
 				item[v12]._iAnimFrame,
 				item[v12]._iAnimWidth,
 				a5,
 				8);
-		Cel2DrawHdrOnly(v13, sy, (char *)item[v12].ItemFrame, item[v12]._iAnimFrame, item[v12]._iAnimWidth, a5, 8);
+		Cel2DrawHdrOnly(v13, sy, (char *)item[v12]._iAnimData, item[v12]._iAnimFrame, item[v12]._iAnimWidth, a5, 8);
 	}
 	if ( dFlags[0][v9] & 0x10 )
 	{
@@ -503,12 +503,12 @@ void __fastcall town_draw_clipped_town_2(int x, int y, int a3, int a4, int a5, i
 				166,
 				v15,
 				sy,
-				(char *)towner[v14]._tAnimCel,
+				(char *)towner[v14]._tAnimData,
 				towner[v14]._tAnimFrame,
 				towner[v14]._tAnimWidth,
 				a5,
 				8);
-		Cel2DrawHdrOnly(v15, sy, (char *)towner[v14]._tAnimCel, towner[v14]._tAnimFrame, towner[v14]._tAnimWidth, a5, 8);
+		Cel2DrawHdrOnly(v15, sy, (char *)towner[v14]._tAnimData, towner[v14]._tAnimFrame, towner[v14]._tAnimWidth, a5, 8);
 	}
 	v16 = dMonster[0][v9];
 	if ( v16 > 0 )
@@ -521,12 +521,12 @@ void __fastcall town_draw_clipped_town_2(int x, int y, int a3, int a4, int a5, i
 				166,
 				v19,
 				sy,
-				(char *)towner[v18]._tAnimCel,
+				(char *)towner[v18]._tAnimData,
 				towner[v18]._tAnimFrame,
 				towner[v18]._tAnimWidth,
 				a5,
 				8);
-		Cel2DrawHdrOnly(v19, sy, (char *)towner[v18]._tAnimCel, towner[v18]._tAnimFrame, towner[v18]._tAnimWidth, a5, 8);
+		Cel2DrawHdrOnly(v19, sy, (char *)towner[v18]._tAnimData, towner[v18]._tAnimFrame, towner[v18]._tAnimWidth, a5, 8);
 	}
 	if ( dFlags[0][v9] & 0x20 )
 	{
@@ -777,26 +777,26 @@ void __fastcall town_draw_town_all(void *buffer, int x, int y, int a4, int dir, 
 	if ( dItem[x][y] )
 	{
 		id = dItem[x][y] - 1;
-		xx = sx - item[id]._iAnimXOff;
+		xx = sx - item[id]._iAnimWidth2;
 		if ( id == pcursitem )
-			CelDecodeClr(181, xx, sy, (char *)item[id].ItemFrame, item[id]._iAnimFrame, item[id]._iAnimWidth, 0, dir);
-		CelDrawHdrOnly(xx, sy, (char *)item[id].ItemFrame, item[id]._iAnimFrame, item[id]._iAnimWidth, 0, dir);
+			CelDecodeClr(181, xx, sy, (char *)item[id]._iAnimData, item[id]._iAnimFrame, item[id]._iAnimWidth, 0, dir);
+		CelDrawHdrOnly(xx, sy, (char *)item[id]._iAnimData, item[id]._iAnimFrame, item[id]._iAnimWidth, 0, dir);
 	}
 	if ( dFlags[x][y] & 0x10 )
 	{
 		id = -1 - dMonster[x][y-1]; // -1 - *(&dword_52D204 + v9); /* check */
 		xx = sx - towner[id]._tAnimWidth2;
 		if ( id == pcursmonst )
-			CelDecodeClr(166, xx, sy, (char *)towner[id]._tAnimCel, towner[id]._tAnimFrame, towner[id]._tAnimWidth, 0, dir);
-		CelDrawHdrOnly(xx, sy, (char *)towner[id]._tAnimCel, towner[id]._tAnimFrame, towner[id]._tAnimWidth, 0, dir);
+			CelDecodeClr(166, xx, sy, (char *)towner[id]._tAnimData, towner[id]._tAnimFrame, towner[id]._tAnimWidth, 0, dir);
+		CelDrawHdrOnly(xx, sy, (char *)towner[id]._tAnimData, towner[id]._tAnimFrame, towner[id]._tAnimWidth, 0, dir);
 	}
 	if ( dMonster[x][y] > 0 )
 	{
 		id = dMonster[x][y] - 1;
 		xx = sx - towner[id]._tAnimWidth2;
 		if ( id == pcursmonst )
-			CelDecodeClr(166, xx, sy, (char *)towner[id]._tAnimCel, towner[id]._tAnimFrame, towner[id]._tAnimWidth, 0, dir);
-		CelDrawHdrOnly(xx, sy, (char *)towner[id]._tAnimCel, towner[id]._tAnimFrame, towner[id]._tAnimWidth, 0, dir);
+			CelDecodeClr(166, xx, sy, (char *)towner[id]._tAnimData, towner[id]._tAnimFrame, towner[id]._tAnimWidth, 0, dir);
+		CelDrawHdrOnly(xx, sy, (char *)towner[id]._tAnimData, towner[id]._tAnimFrame, towner[id]._tAnimWidth, 0, dir);
 	}
 	if ( dFlags[x][y] & 0x20 )
 	{

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -362,7 +362,7 @@ void __fastcall NewTownerAnim(int tnum, void *pAnim, int numFrames, int Delay)
 	v4 = tnum;
 	towner[v4]._tAnimCnt = 0;
 	towner[v4]._tAnimLen = numFrames;
-	towner[v4]._tAnimCel = pAnim;
+	towner[v4]._tAnimData = pAnim;
 	towner[v4]._tAnimFrame = 1;
 	towner[v4]._tAnimDelay = Delay;
 }

--- a/TODO
+++ b/TODO
@@ -11,12 +11,11 @@
 1000 - The Cathedral doesn't generate correctly, sometimes crashing
 1001 - Sometimes dungeon will crash on loading if previous levels loaded (DrawClippedObject)
 1002 - Golem usually crashes, or appears invisible if summoned
-1003 - Stone cursed monsters frequently crash when killed
-1004 - Some CEL functions were written in ASM and have been disabled (engine.cpp)
-1005 - After being in the dungeon for awhile, the 'Control Panel' will sometimes
+1003 - Some CEL functions were written in ASM and have been disabled (engine.cpp)
+1004 - After being in the dungeon for awhile, the 'Control Panel' will sometimes
        corrupt and be filled with glitched colors (likely a buffer overflow)
-1006 - Timed messages are broken and have been disabled (tmsg.cpp)
-1007 - Server commands are broken and have been disabled (msgcmd.cpp)
+1005 - Timed messages are broken and have been disabled (tmsg.cpp)
+1006 - Server commands are broken and have been disabled (msgcmd.cpp)
 
 2000 - Rooms/halls don't generate correctly in the Catacombs
 2001 - The last seal in Lazarus' Lair doesn't trigger the video/teleport

--- a/TODO
+++ b/TODO
@@ -8,16 +8,9 @@
  2xxx       Minor bugs (noticeable but can be avoided)
  3xxx       Code issues (incorrect code that still compiles/works)
 
-1000 - The Cathedral doesn't generate correctly, sometimes crashing
-1001 - Sometimes dungeon will crash on loading if previous levels loaded (DrawClippedObject)
-1002 - Golem usually crashes, or appears invisible if summoned
-1003 - Some CEL functions were written in ASM and have been disabled (engine.cpp)
-1004 - After being in the dungeon for awhile, the 'Control Panel' will sometimes
-       corrupt and be filled with glitched colors (likely a buffer overflow)
-1005 - Timed messages are broken and have been disabled (tmsg.cpp)
-1006 - Server commands are broken and have been disabled (msgcmd.cpp)
+1000 - Sometimes dungeon will crash on loading if previous levels loaded (DrawClippedObject)
 
-2000 - Rooms/halls don't generate correctly in the Catacombs
+2000 - Generation of Cathedral/Catacombs is slightly inaccurate
 2001 - The last seal in Lazarus' Lair doesn't trigger the video/teleport
 2002 - White pixels on monsters/cathedral/catacombs (palette entry 256?)
 2003 - Swapping items in inventory sometimes deletes the item
@@ -26,6 +19,11 @@
 2006 - Objects should darken with radius instead of being fully lit
 2007 - Automap sometimes draws incorrectly, check 'engine_draw_automap_pixels'
        *Bad args ECX/EDX for 'engine_draw_pixel' (engine.cpp)
+2008 - After being in the dungeon for awhile, the 'Control Panel' will sometimes
+       corrupt and be filled with glitched colors (likely a buffer overflow)
+2009 - Some CEL functions were written in ASM and have been disabled (engine.cpp)
+2010 - Timed messages are broken and have been disabled (tmsg.cpp)
+2011 - Server commands are broken and have been disabled (msgcmd.cpp)
 
 3000 - Critical sections should be constructors using CCritSect
 3001 - Function 'DRLG_L4TransFix', decompile and check (Test: seed 2349839 level 13)

--- a/defs.h
+++ b/defs.h
@@ -28,6 +28,21 @@
 /////////////////////////////////////////////////////////////////////////
 #ifndef IDA_GARBAGE
 #define IDA_GARBAGE
+
+// note to self: only works for x86, originally used this way by the devs
+inline void memset32(void *s, unsigned int i, size_t n)
+{
+	__asm {
+		mov ecx, n
+		mov eax, i
+		mov edi, s
+		rep stosd
+	}
+
+	//for(x = 0; x < n; x++)
+	//	(DWORD)s[x] = i;
+}
+
 typedef          __int64 ll;
 typedef unsigned __int64 ull;
 

--- a/structs.h
+++ b/structs.h
@@ -127,7 +127,7 @@ struct MisFileData
 	unsigned char mAnimFAmt;
 	char *mName;
 	int mFlags;
-	int mAnimCel[16]; // unsigned char *mAnimData[16]
+	int mAnimData[16]; // unsigned char *
 	unsigned char mAnimDelay[16];
 	unsigned char mAnimLen[16];
 	int mAnimWidth[16];
@@ -309,11 +309,11 @@ struct ItemStruct
 	int _ix;
 	int _iy;
 	int _iAnimFlag;
-	int ItemFrame; // unsigned char *_iAnimData
+	int _iAnimData; // unsigned char *
 	int _iAnimLen;
 	int _iAnimFrame;
 	int _iAnimWidth;
-	int _iAnimXOff; // width 2?
+	int _iAnimWidth2; // width 2?
 	int offs002C;
 	char _iSelFlag;
 	int _iPostDraw;
@@ -375,7 +375,7 @@ struct ItemStruct
 
 struct DeadStruct
 {
-	int _deadAnim[8]; // unsigned char *_deadData
+	int _deadData[8]; // unsigned char *
 	int _deadFrame;
 	int field_24; // width
 	int field_28; // cel or fnum _deadtype?
@@ -453,7 +453,7 @@ struct MissileStruct
 	int _miDelFlag;
 	int _miAnimType;
 	int _miAnimFlags;
-	int _miAnimCel; // unsigned char *_miAnimData
+	int _miAnimData; // unsigned char *
 	int _miAnimDelay;
 	int _miAnimLen;
 	int _miAnimWidth;
@@ -485,8 +485,8 @@ struct MissileStruct
 
 struct AnimStruct
 {
-	// int CMem
-	int Frames[9]; // int CMem, unsigned char *Frames[8]
+	int CMem; // [unsigned] char * ??
+	int Frames[8]; // unsigned char *
 	int Rate;
 	int Delay;
 };
@@ -725,7 +725,7 @@ struct ObjectStruct
 	int _oy;
 	int _oLight;
 	int _oAnimFlag;
-	int _oAnimCel; // unsigned char *_oAnimData
+	int _oAnimData; // unsigned char *
 	int _oAnimDelay;
 	int _oAnimCnt;
 	int _oAnimLen;
@@ -1002,7 +1002,7 @@ struct TownerStruct
 	int _txvel;
 	int _tyvel;
 	int _tdir;
-	void *_tAnimCel; // unsigned char *_tAnimData
+	void *_tAnimData; // unsigned char *
 	int _tAnimDelay;
 	int _tAnimCnt;
 	int _tAnimLen;


### PR DESCRIPTION
Stupid me, the decompiler originally output memset32 and I replaced it with memset thinking they were the same thing. Turns out it was the cause of most crashes. Golem and Stone Curse now work correctly, and dungeon generation of the Cathedral is now correct and won't crash. memset32 is x86 specific, but can be easily replaced with a `for ` loop.

Also corrected the names of a few struct members, based on assert strings.