### PR TITLE
Implement memset32 and fix compilation errors for storm.h

### DIFF
--- a/3rdParty/Storm/Source/storm.h
+++ b/3rdParty/Storm/Source/storm.h
@@ -163,10 +163,10 @@ SNetGetPlayerName(
  *
  *  Returns TRUE if the function was called successfully and FALSE otherwise.
  */
-BOOL
-STORMAPI
-SNetGetProviderCaps(
-      PCAPS providerCaps);
+//BOOL
+//STORMAPI
+//SNetGetProviderCaps(
+//      PCAPS providerCaps);
 
 /*  SNetGetTurnsInTransit @ 115
  *
@@ -306,14 +306,14 @@ typedef struct _storm_head
  *
  *  Returns TRUE if the function was called successfully and FALSE otherwise.
  */
-BOOL
-STORMAPI
-SNetInitializeProvider(
-      DWORD       providerName,
-      client_info  *gameClientInfo,
-      user_info    *userData,
-      battle_info  *bnCallbacks,
-      module_info  *moduleData);
+//BOOL
+//STORMAPI
+//SNetInitializeProvider(
+//      DWORD       providerName,
+//      client_info  *gameClientInfo,
+//      user_info    *userData,
+//      battle_info  *bnCallbacks,
+//      module_info  *moduleData);
 
 
 BOOL STORMAPI SNetJoinGame(int id, char *gameName, char *gamePassword, char *playerName, char *userStats, int *playerid);
@@ -354,7 +354,7 @@ typedef struct _s_evt
 
 
 // @TODO: "type" is unknown.
-HANDLE STORMAPI SNetRegisterEventHandler(int type, void (STORMAPI *sEvent)(PS_EVT));
+//HANDLE STORMAPI SNetRegisterEventHandler(int type, void (STORMAPI *sEvent)(PS_EVT));
 
 int  STORMAPI SNetSelectGame(int a1, int a2, int a3, int a4, int a5, int *playerid);
 

--- a/defs.h
+++ b/defs.h
@@ -29,18 +29,15 @@
 #ifndef IDA_GARBAGE
 #define IDA_GARBAGE
 
-// note to self: only works for x86, originally used this way by the devs
-inline void memset32(void *s, unsigned int i, size_t n)
-{
-	__asm {
-		mov ecx, n
-		mov eax, i
-		mov edi, s
-		rep stosd
-	}
+#include <stdint.h>
 
-	//for(x = 0; x < n; x++)
-	//	(DWORD)s[x] = i;
+// note to self: only works for x86, originally used this way by the devs
+inline void memset32(void *s, unsigned int c, size_t n)
+{
+	uint32_t *p = (uint32_t*)s;
+	for (int i = 0; i < n; i++) {
+		p[i] = c;
+	}
 }
 
 typedef          __int64 ll;


### PR DESCRIPTION
Now Golem works on Linux as well.

Three functions were declared twice in storm.h, comment out one of each.

---

Source/../defs.h: In function ‘void memset32(void*, unsigned int, size_t)’:
Source/../defs.h:35:8: error: expected ‘(’ before ‘{’ token
  __asm {
        ^
Source/../defs.h:36:3: error: ‘mov’ was not declared in this scope
   mov ecx, n

---

Source/../3rdParty/Storm/Source/storm.h:1300:15: error: conflicting declaration of C function ‘int SNetGetProviderCaps(_SNETCAPS*)’
 int __stdcall SNetGetProviderCaps(struct _SNETCAPS *);

---

Source/../3rdParty/Storm/Source/storm.h:1297:18: error: conflicting declaration of C function ‘void* SNetRegisterEventHandler(int, void (__attribute__((__stdcall__)) *)(_SNETEVENT*))’
 void * __stdcall SNetRegisterEventHandler(int,void (__stdcall*)(struct _SNETEVENT *));

---

Source/../3rdParty/Storm/Source/storm.h:1299:15: error: conflicting declaration of C function ‘int SNetInitializeProvider(long unsigned int, _SNETPROGRAMDATA*, _SNETPLAYERDATA*, _SNETUIDATA*, _SNETVERSIONDATA*)’
 int __stdcall SNetInitializeProvider(unsigned long,struct _SNETPROGRAMDATA *,struct _SNETPLAYERDATA *,struct _SNETUIDATA *,struct _SNETVERSIONDATA *);

---

Source/multi.cpp:1046:75: error: cannot convert ‘_SNETPROGRAMDATA*’ to ‘client_info* {aka _client_info*}’ for argument ‘2’ to ‘BOOL SNetInitializeProvider(DWORD, client_info*, user_info*, battle_info*, module_info*)’