### PR TITLE
Remove the "fear factor"

### DIFF
--- a/Source/appfat.cpp
+++ b/Source/appfat.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/appfat.h
+++ b/Source/appfat.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //appfat
 extern int appfat_terminated; // weak

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //automap
 extern short automaptype[512];

--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/capture.h
+++ b/Source/capture.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 void __cdecl CaptureScreen();
 bool __fastcall CaptureHdr(HANDLE hFile, short width, int height);

--- a/Source/codec.cpp
+++ b/Source/codec.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/codec.h
+++ b/Source/codec.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 int __fastcall codec_decode(void *pbSrcDst, int size, char *pszPassword);
 void __fastcall codec_init_key(int unused, char *pszPassword);

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/control.h
+++ b/Source/control.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //control
 extern char sgbNextTalkSave; // weak

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/cursor.h
+++ b/Source/cursor.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //cursor
 extern int cursH; // weak

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/dead.h
+++ b/Source/dead.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //dead
 extern int spurtndx; // weak

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/debug.h
+++ b/Source/debug.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //debug
 extern void *pSquareCel;

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //diablo
 extern int diablo_cpp_init_value; // weak

--- a/Source/doom.cpp
+++ b/Source/doom.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/doom.h
+++ b/Source/doom.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //doom
 extern int doom_quest_time; // weak

--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/drlg_l1.h
+++ b/Source/drlg_l1.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //drlg_l1
 extern char L5dungeon[80][80];

--- a/Source/drlg_l2.cpp
+++ b/Source/drlg_l2.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/drlg_l2.h
+++ b/Source/drlg_l2.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //drlg_l2
 extern int nSx1;

--- a/Source/drlg_l3.cpp
+++ b/Source/drlg_l3.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/drlg_l3.h
+++ b/Source/drlg_l3.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //drlg_l3
 extern char lavapool; // weak

--- a/Source/drlg_l4.cpp
+++ b/Source/drlg_l4.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/drlg_l4.h
+++ b/Source/drlg_l4.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //drlg_l4
 extern int diabquad1x; // weak

--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/dthread.h
+++ b/Source/dthread.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //dthread
 extern int dthread_cpp_init_value; // weak

--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/dx.h
+++ b/Source/dx.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //dx
 extern void *sgpBackBuf;

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/effects.h
+++ b/Source/effects.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //effects
 extern int effects_cpp_init_value; // weak

--- a/Source/encrypt.cpp
+++ b/Source/encrypt.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/encrypt.h
+++ b/Source/encrypt.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //encrypt
 extern int encrypt_table[1280];

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //offset 0
 //pCelBuff->pFrameTable[0]

--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/error.h
+++ b/Source/error.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //error
 extern char msgtable[80];

--- a/Source/fault.cpp
+++ b/Source/fault.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/fault.h
+++ b/Source/fault.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //fault
 //int dword_52B9F4;

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/gamemenu.h
+++ b/Source/gamemenu.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 void __cdecl gamemenu_previous();
 void __cdecl gamemenu_enable_single();

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //gendung
 extern short level_frame_types[2048];

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/gmenu.h
+++ b/Source/gmenu.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //gmenu
 extern void *optbar_cel;

--- a/Source/help.cpp
+++ b/Source/help.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/help.h
+++ b/Source/help.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //help
 extern int help_select_line; // weak

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/init.h
+++ b/Source/init.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //init
 extern _SNETVERSIONDATA fileinfo;

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/interfac.h
+++ b/Source/interfac.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //interfac
 extern void *sgpBackCel;

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //inv
 extern int invflag;

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/items.h
+++ b/Source/items.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //items
 extern int itemactive[127];

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //lighting
 extern LightListStruct VisionList[32];

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/loadsave.h
+++ b/Source/loadsave.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //loadsave
 extern void *tbuff;

--- a/Source/logging.cpp
+++ b/Source/logging.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/logging.h
+++ b/Source/logging.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //logging
 extern int log_cpp_init_value; // weak

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/mainmenu.h
+++ b/Source/mainmenu.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //mainmenu
 extern int mainmenu_cpp_init_value; // weak

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/minitext.h
+++ b/Source/minitext.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //minitext
 extern int qtexty; // weak

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //missile
 extern int missileactive[125];

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //monster
 extern int MissileFileFlag; // weak

--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/movie.h
+++ b/Source/movie.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //movie
 extern int movie_cpp_init_value; // weak

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/mpqapi.h
+++ b/Source/mpqapi.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //mpqapi
 extern int mpqapi_cpp_init_value; // weak

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //msg
 extern int sgdwOwnerWait; // weak

--- a/Source/msgcmd.cpp
+++ b/Source/msgcmd.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/msgcmd.h
+++ b/Source/msgcmd.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //msgcmd
 extern int msgcmd_cpp_init_value; // weak

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //multi
 extern char gbSomebodyWonGameKludge; // weak

--- a/Source/nthread.cpp
+++ b/Source/nthread.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/nthread.h
+++ b/Source/nthread.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //nthread
 extern int nthread_cpp_init_value; // weak

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //objects
 extern int trapid; // weak

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //pack
 extern int pack_cpp_init_value; // weak

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/palette.h
+++ b/Source/palette.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //palette
 extern PALETTEENTRY logical_palette[256];

--- a/Source/path.cpp
+++ b/Source/path.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/path.h
+++ b/Source/path.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //path
 extern PATHNODE path_nodes[300];

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/pfile.h
+++ b/Source/pfile.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //pfile
 extern int pfile_cpp_init_value;

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/player.h
+++ b/Source/player.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //player
 extern int plr_lframe_size; // idb

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/plrmsg.h
+++ b/Source/plrmsg.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //plrmsg
 extern int plrmsg_ticks; // weak

--- a/Source/portal.cpp
+++ b/Source/portal.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/portal.h
+++ b/Source/portal.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //portal
 extern PortalStruct portal[4];

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/quests.h
+++ b/Source/quests.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //quests
 extern int qtopline; // idb

--- a/Source/restrict.cpp
+++ b/Source/restrict.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/restrict.h
+++ b/Source/restrict.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 bool __cdecl SystemSupported();
 bool __cdecl RestrictedTest();

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/scrollrt.h
+++ b/Source/scrollrt.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //scrollrt
 extern int light_table_index; // weak

--- a/Source/setmaps.cpp
+++ b/Source/setmaps.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/setmaps.h
+++ b/Source/setmaps.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 int __fastcall ObjIndex(int x, int y);
 void __cdecl AddSKingObjs();

--- a/Source/sha.cpp
+++ b/Source/sha.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/sha.h
+++ b/Source/sha.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 /*
  *  Define the SHA1 circular left shift macro

--- a/Source/sound.cpp
+++ b/Source/sound.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/sound.h
+++ b/Source/sound.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //sound
 extern float sound_cpp_init_value;

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/spells.h
+++ b/Source/spells.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 int __fastcall GetManaAmount(int id, int sn);
 void __fastcall UseMana(int id, int sn);

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/stores.h
+++ b/Source/stores.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //stores
 extern int stextup; // weak

--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/sync.h
+++ b/Source/sync.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //sync
 extern short sync_word_6AA708[200];

--- a/Source/textdat.cpp
+++ b/Source/textdat.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/textdat.h
+++ b/Source/textdat.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 extern TextDataStruct alltext[259];
 extern int gdwAllTextEntries;

--- a/Source/themes.cpp
+++ b/Source/themes.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/themes.h
+++ b/Source/themes.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //themes
 extern int numthemes; // idb

--- a/Source/tmsg.cpp
+++ b/Source/tmsg.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/tmsg.h
+++ b/Source/tmsg.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //tmsg
 extern TMsg *sgpTimedMsgHead;

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/town.h
+++ b/Source/town.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 void __fastcall town_clear_upper_buf(int a1);
 void __fastcall town_clear_low_buf(int y_related);

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/towners.h
+++ b/Source/towners.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //towners
 extern int storeflag; // weak

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/track.h
+++ b/Source/track.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //track
 extern bool sgbIsScrolling; // weak

--- a/Source/trigs.cpp
+++ b/Source/trigs.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/trigs.h
+++ b/Source/trigs.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //trigs
 extern int trigflag[5];

--- a/Source/wave.cpp
+++ b/Source/wave.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/wave.h
+++ b/Source/wave.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 //wave
 extern int wave_cpp_init_value; // weak

--- a/Source/world.cpp
+++ b/Source/world.cpp
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 #include "../types.h"
 

--- a/Source/world.h
+++ b/Source/world.h
@@ -1,13 +1,4 @@
-/*
- * UNPUBLISHED -- Rights  reserved  under  the  copyright  laws  of the
- * United States.  Use  of a copyright notice is precautionary only and
- * does not imply publication or disclosure.
- *
- * THIS DOCUMENTATION CONTAINS CONFIDENTIAL AND PROPRIETARY INFORMATION
- * OF    BLIZZARD   ENTERTAINMENT.    ANY   DUPLICATION,  MODIFICATION,
- * DISTRIBUTION, OR DISCLOSURE IS STRICTLY PROHIBITED WITHOUT THE PRIOR
- * EXPRESS WRITTEN PERMISSION OF BLIZZARD ENTERTAINMENT.
- */
+//HEADER_GOES_HERE
 
 void __fastcall drawTopArchesUpperScreen(void *a1);
 void __fastcall drawBottomArchesUpperScreen(void *a1, int a2);


### PR DESCRIPTION
I initially typed up some scary looking notice to make it look like this code came from Blizzard. Mainly so no one thinks "oh this is written from scratch so I can make my own mod/x and sell it!"
(And yes, many people **still** think this is a mod of some kind even though it's all reversed)

Someone sent an email saying this was a bad idea on the legal side to include such a notice, and I agreed so it's been removed. Don't want to jeopardize the future development of this project.

I'll eventually add a more appropriate header, one which will describe what each file does in depth.

I'd also like to find out the original author of each CPP file. According to the link below, David Brevik wrote 90% of the game. (The last 10% was probably the disastrous world.cpp)
https://news.ycombinator.com/item?id=16279766