### PR TITLE
Add include guards, prepare for XRef

### DIFF
--- a/Source/appfat.cpp
+++ b/Source/appfat.cpp
@@ -31,7 +31,6 @@ bool __cdecl appfat_cpp_free(void *a1)
 }
 */
 
-//----- (0040102A) --------------------------------------------------------
 char *__fastcall GetErr(int error_code)
 {
 	int v1; // edi
@@ -64,7 +63,6 @@ char *__fastcall GetErr(int error_code)
 	return sz_error_buf;
 }
 
-//----- (004010CE) --------------------------------------------------------
 void __fastcall GetDDErr(int error_code, char *error_buf, int error_buf_len)
 {
 	const char *v3; // eax
@@ -494,7 +492,6 @@ LABEL_182:
 	strncpy(error_buf, v3, error_buf_len);
 }
 
-//----- (00401831) --------------------------------------------------------
 void __fastcall GetDSErr(int error_code, char *error_buf, int error_buf_len)
 {
 	const char *v3; // eax
@@ -558,7 +555,6 @@ LABEL_29:
 	strncpy(error_buf, v3, error_buf_len);
 }
 
-//----- (0040193A) --------------------------------------------------------
 char *__cdecl GetLastErr()
 {
 	int v0; // eax
@@ -567,7 +563,6 @@ char *__cdecl GetLastErr()
 	return GetErr(v0);
 }
 
-//----- (00401947) --------------------------------------------------------
 void TermMsg(char *pszFmt, ...)
 {
 	va_list arglist; // [esp+8h] [ebp+8h]
@@ -580,7 +575,6 @@ void TermMsg(char *pszFmt, ...)
 	exit(1);
 }
 
-//----- (00401975) --------------------------------------------------------
 void __fastcall MsgBox(char *pszFmt, va_list va)
 {
 	char Text[256]; // [esp+0h] [ebp-100h]
@@ -591,7 +585,6 @@ void __fastcall MsgBox(char *pszFmt, va_list va)
 	MessageBoxA(ghMainWnd, Text, "ERROR", MB_TASKMODAL|MB_ICONHAND);
 }
 
-//----- (004019C7) --------------------------------------------------------
 void __cdecl FreeDlg()
 {
 	if ( terminating && cleanup_thread_id != GetCurrentThreadId() )
@@ -611,7 +604,6 @@ void __cdecl FreeDlg()
 // 4B7A38: using guessed type int cleanup_thread_id;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00401A30) --------------------------------------------------------
 void DrawDlg(char *pszFmt, ...)
 {
 	char text[256]; // [esp+0h] [ebp-100h]
@@ -622,7 +614,6 @@ void DrawDlg(char *pszFmt, ...)
 	SDrawMessageBox(text, "Diablo", MB_TASKMODAL|MB_ICONEXCLAMATION);
 }
 
-//----- (00401A65) --------------------------------------------------------
 void __fastcall DDErrDlg(int error_code, int log_line_nr, char *log_file_path)
 {
 	int v3; // esi
@@ -636,7 +627,6 @@ void __fastcall DDErrDlg(int error_code, int log_line_nr, char *log_file_path)
 	}
 }
 
-//----- (00401A88) --------------------------------------------------------
 void __fastcall DSErrDlg(int error_code, int log_line_nr, char *log_file_path)
 {
 	int v3; // esi
@@ -650,7 +640,6 @@ void __fastcall DSErrDlg(int error_code, int log_line_nr, char *log_file_path)
 	}
 }
 
-//----- (00401AAB) --------------------------------------------------------
 void __fastcall CenterDlg(HWND hDlg)
 {
 	LONG v1; // esi
@@ -677,7 +666,6 @@ void __fastcall CenterDlg(HWND hDlg)
 	}
 }
 
-//----- (00401B3D) --------------------------------------------------------
 void __fastcall TermDlg(int template_id, int error_code, char *log_file_path, int log_line_nr)
 {
 	int v4; // ebx
@@ -701,7 +689,6 @@ void __fastcall TermDlg(int template_id, int error_code, char *log_file_path, in
 	TermMsg(0);
 }
 
-//----- (00401BCA) --------------------------------------------------------
 bool __stdcall FuncDlg(HWND hDlg, UINT uMsg, WPARAM wParam, char *text)
 {
 	if ( uMsg == WM_INITDIALOG )
@@ -724,7 +711,6 @@ bool __stdcall FuncDlg(HWND hDlg, UINT uMsg, WPARAM wParam, char *text)
 	return 1;
 }
 
-//----- (00401C0F) --------------------------------------------------------
 void __fastcall TextDlg(HWND hDlg, char *text)
 {
 	char *v2; // esi
@@ -737,7 +723,6 @@ void __fastcall TextDlg(HWND hDlg, char *text)
 		SetDlgItemTextA(v3, 1000, v2);
 }
 
-//----- (00401C2E) --------------------------------------------------------
 void __fastcall ErrDlg(template_id template_id, int error_code, char *log_file_path, int log_line_nr)
 {
 	char *v4; // esi
@@ -758,7 +743,6 @@ void __fastcall ErrDlg(template_id template_id, int error_code, char *log_file_p
 	DialogBoxParamA(ghInst, (LPCSTR)v6, ghMainWnd, (DLGPROC)FuncDlg, (LPARAM)dwInitParam);
 }
 
-//----- (00401C9C) --------------------------------------------------------
 void __fastcall FileErrDlg(char *error)
 {
 	char *v1; // esi
@@ -772,7 +756,6 @@ void __fastcall FileErrDlg(char *error)
 	TermMsg(0);
 }
 
-//----- (00401CE1) --------------------------------------------------------
 void __fastcall DiskFreeDlg(char *error)
 {
 	char *v1; // esi
@@ -784,7 +767,6 @@ void __fastcall DiskFreeDlg(char *error)
 	TermMsg(0);
 }
 
-//----- (00401D1D) --------------------------------------------------------
 bool __cdecl InsertCDDlg()
 {
 	int v0; // edi
@@ -797,7 +779,6 @@ bool __cdecl InsertCDDlg()
 	return v0 == 1;
 }
 
-//----- (00401D68) --------------------------------------------------------
 void __fastcall DirErrDlg(char *error)
 {
 	char *v1; // esi

--- a/Source/appfat.h
+++ b/Source/appfat.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __APPFAT_H__
+#define __APPFAT_H__
 
-//appfat
 extern int appfat_terminated; // weak
 extern char sz_error_buf[256];
 extern int terminating; // weak
@@ -26,3 +27,5 @@ void __fastcall FileErrDlg(char *error);
 void __fastcall DiskFreeDlg(char *error);
 bool __cdecl InsertCDDlg();
 void __fastcall DirErrDlg(char *error);
+
+#endif /* __APPFAT_H__ */

--- a/Source/automap.cpp
+++ b/Source/automap.cpp
@@ -17,7 +17,6 @@ int AutoMapYPos; // weak
 int AMPlayerX; // weak
 int AMPlayerY; // weak
 
-//----- (00401DA4) --------------------------------------------------------
 void __cdecl InitAutomapOnce()
 {
 	automapflag = 0;
@@ -34,7 +33,6 @@ void __cdecl InitAutomapOnce()
 // 4B84C4: using guessed type int AMPlayerX;
 // 4B84C8: using guessed type int AMPlayerY;
 
-//----- (00401DE8) --------------------------------------------------------
 void __cdecl InitAutomap()
 {
 	signed int v0; // edi
@@ -124,7 +122,6 @@ void __cdecl InitAutomap()
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (00401EF4) --------------------------------------------------------
 void __cdecl StartAutomap()
 {
 	AutoMapXOfs = 0;
@@ -134,7 +131,6 @@ void __cdecl StartAutomap()
 // 4B84B0: using guessed type int AutoMapXOfs;
 // 4B84B4: using guessed type int AutoMapYOfs;
 
-//----- (00401F0D) --------------------------------------------------------
 void __cdecl AutomapUp()
 {
 	--AutoMapXOfs;
@@ -143,7 +139,6 @@ void __cdecl AutomapUp()
 // 4B84B0: using guessed type int AutoMapXOfs;
 // 4B84B4: using guessed type int AutoMapYOfs;
 
-//----- (00401F1A) --------------------------------------------------------
 void __cdecl AutomapDown()
 {
 	++AutoMapXOfs;
@@ -152,7 +147,6 @@ void __cdecl AutomapDown()
 // 4B84B0: using guessed type int AutoMapXOfs;
 // 4B84B4: using guessed type int AutoMapYOfs;
 
-//----- (00401F27) --------------------------------------------------------
 void __cdecl AutomapLeft()
 {
 	--AutoMapXOfs;
@@ -161,7 +155,6 @@ void __cdecl AutomapLeft()
 // 4B84B0: using guessed type int AutoMapXOfs;
 // 4B84B4: using guessed type int AutoMapYOfs;
 
-//----- (00401F34) --------------------------------------------------------
 void __cdecl AutomapRight()
 {
 	++AutoMapXOfs;
@@ -170,7 +163,6 @@ void __cdecl AutomapRight()
 // 4B84B0: using guessed type int AutoMapXOfs;
 // 4B84B4: using guessed type int AutoMapYOfs;
 
-//----- (00401F41) --------------------------------------------------------
 void __cdecl AutomapZoomIn()
 {
 	if ( AutoMapScale < 200 )
@@ -189,7 +181,6 @@ void __cdecl AutomapZoomIn()
 // 4B84C4: using guessed type int AMPlayerX;
 // 4B84C8: using guessed type int AMPlayerY;
 
-//----- (00401F80) --------------------------------------------------------
 void __cdecl AutomapZoomOut()
 {
 	if ( AutoMapScale > 50 )
@@ -208,7 +199,6 @@ void __cdecl AutomapZoomOut()
 // 4B84C4: using guessed type int AMPlayerX;
 // 4B84C8: using guessed type int AMPlayerY;
 
-//----- (00401FBD) --------------------------------------------------------
 void __cdecl DrawAutomap()
 {
 	int v0; // eax
@@ -391,7 +381,6 @@ void __cdecl DrawAutomap()
 // 69BD04: using guessed type int questlog;
 // 69CF0C: using guessed type int screen_buf_end;
 
-//----- (00402233) --------------------------------------------------------
 void __fastcall DrawAutomapType(int screen_x, int screen_y, short automap_type)
 {
 	short v3; // al
@@ -628,7 +617,6 @@ LABEL_36:
 // 4B84C4: using guessed type int AMPlayerX;
 // 4B84C8: using guessed type int AMPlayerY;
 
-//----- (004029A8) --------------------------------------------------------
 void __cdecl DrawAutomapPlr()
 {
 	int v0; // ebx
@@ -782,7 +770,6 @@ LABEL_25:
 // 4B8968: using guessed type int sbookflag;
 // 69BD04: using guessed type int questlog;
 
-//----- (00402D83) --------------------------------------------------------
 short __fastcall GetAutomapType(int tx, int ty, bool view)
 {
 	int v3; // edi
@@ -830,7 +817,6 @@ short __fastcall GetAutomapType(int tx, int ty, bool view)
 	return v7;
 }
 
-//----- (00402E4A) --------------------------------------------------------
 void __cdecl DrawAutomapGame()
 {
 	int v0; // esi
@@ -867,7 +853,6 @@ void __cdecl DrawAutomapGame()
 // 5CF31D: using guessed type char setlevel;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00402F27) --------------------------------------------------------
 void __fastcall SetAutomapView(int x, int y)
 {
 	signed int v2; // esi
@@ -964,7 +949,6 @@ LABEL_35:
 // 4B7E40: using guessed type int AMdword_4B7E40;
 // 4B7E44: using guessed type int AMdword_4B7E44;
 
-//----- (004030DD) --------------------------------------------------------
 void __cdecl AutomapZoomReset()
 {
 	AutoMapXOfs = 0;

--- a/Source/automap.h
+++ b/Source/automap.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __AUTOMAP_H__
+#define __AUTOMAP_H__
 
-//automap
 extern short automaptype[512];
 extern int AMdword_4B7E40; // weak
 extern int AMdword_4B7E44; // weak
@@ -32,3 +33,5 @@ short __fastcall GetAutomapType(int tx, int ty, bool view);
 void __cdecl DrawAutomapGame();
 void __fastcall SetAutomapView(int x, int y);
 void __cdecl AutomapZoomReset();
+
+#endif /* __AUTOMAP_H__ */

--- a/Source/capture.cpp
+++ b/Source/capture.cpp
@@ -2,7 +2,6 @@
 
 #include "../types.h"
 
-//----- (0040311B) --------------------------------------------------------
 void __cdecl CaptureScreen()
 {
 	int v4; // edi
@@ -38,7 +37,6 @@ void __cdecl CaptureScreen()
 // 40311B: could not find valid save-restore pair for edi
 // 40311B: could not find valid save-restore pair for esi
 
-//----- (00403204) --------------------------------------------------------
 bool __fastcall CaptureHdr(HANDLE hFile, short width, int height)
 {
 	short v3; // si
@@ -62,7 +60,6 @@ bool __fastcall CaptureHdr(HANDLE hFile, short width, int height)
 	return WriteFile(v4, &Buffer, 0x80u, &lpNumBytes, NULL) && lpNumBytes == 128;
 }
 
-//----- (00403294) --------------------------------------------------------
 bool __fastcall CapturePal(HANDLE hFile, PALETTEENTRY *palette)
 {
 	BYTE *v2; // eax
@@ -88,7 +85,6 @@ bool __fastcall CapturePal(HANDLE hFile, PALETTEENTRY *palette)
 	return WriteFile(hFile, Buffer, 0x301u, &lpNumBytes, 0) && lpNumBytes == 769;
 }
 
-//----- (004032FD) --------------------------------------------------------
 bool __fastcall CapturePix(HANDLE hFile, short width, short height, short stride, char *pixels)
 {
 	int v5; // esi
@@ -117,7 +113,6 @@ bool __fastcall CapturePix(HANDLE hFile, short width, short height, short stride
 	return 0;
 }
 
-//----- (0040336A) --------------------------------------------------------
 char *__fastcall CaptureEnc(char *src, char *dst, int width)
 {
 	int v3; // esi
@@ -155,7 +150,6 @@ LABEL_13:
 	return dst;
 }
 
-//----- (004033A8) --------------------------------------------------------
 HANDLE __fastcall CaptureFile(char *dst_path)
 {
 	char *v1; // edi
@@ -192,7 +186,6 @@ HANDLE __fastcall CaptureFile(char *dst_path)
 }
 // 4033A8: using guessed type char var_64[100];
 
-//----- (00403470) --------------------------------------------------------
 void __fastcall RedPalette(PALETTEENTRY *pal)
 {
 	int i; // eax

--- a/Source/capture.h
+++ b/Source/capture.h
@@ -1,4 +1,6 @@
 //HEADER_GOES_HERE
+#ifndef __CAPTURE_H__
+#define __CAPTURE_H__
 
 void __cdecl CaptureScreen();
 bool __fastcall CaptureHdr(HANDLE hFile, short width, int height);
@@ -7,3 +9,5 @@ bool __fastcall CapturePix(HANDLE hFile, short width, short height, short stride
 char *__fastcall CaptureEnc(char *src, char *dst, int width);
 HANDLE __fastcall CaptureFile(char *dst_path);
 void __fastcall RedPalette(PALETTEENTRY *pal);
+
+#endif /* __CAPTURE_H__ */

--- a/Source/codec.cpp
+++ b/Source/codec.cpp
@@ -2,7 +2,6 @@
 
 #include "../types.h"
 
-//----- (004034D9) --------------------------------------------------------
 int __fastcall codec_decode(void *pbSrcDst, int size, char *pszPassword)
 {
 	unsigned int v3; // ebx
@@ -65,7 +64,6 @@ LABEL_14:
 }
 // 4034D9: using guessed type char var_98[128];
 
-//----- (004035DB) --------------------------------------------------------
 void __fastcall codec_init_key(int unused, char *pszPassword)
 {
 	char *v2; // edi
@@ -125,7 +123,6 @@ void __fastcall codec_init_key(int unused, char *pszPassword)
 // 4035DB: using guessed type char var_58[64];
 // 4035DB: using guessed type char dst[20];
 
-//----- (004036AC) --------------------------------------------------------
 int __fastcall codec_get_encoded_len(int dwSrcBytes)
 {
 	if ( dwSrcBytes & 0x3F )
@@ -133,7 +130,6 @@ int __fastcall codec_get_encoded_len(int dwSrcBytes)
 	return dwSrcBytes + 8;
 }
 
-//----- (004036BE) --------------------------------------------------------
 void __fastcall codec_encode(void *pbSrcDst, int size, int size_64, char *pszPassword)
 {
 	char *v4; // esi

--- a/Source/codec.h
+++ b/Source/codec.h
@@ -1,6 +1,10 @@
 //HEADER_GOES_HERE
+#ifndef __CODEC_H__
+#define __CODEC_H__
 
 int __fastcall codec_decode(void *pbSrcDst, int size, char *pszPassword);
 void __fastcall codec_init_key(int unused, char *pszPassword);
 int __fastcall codec_get_encoded_len(int dwSrcBytes);
 void __fastcall codec_encode(void *pbSrcDst, int size, int size_64, char *pszPassword);
+
+#endif /* __CODEC_H__ */

--- a/Source/control.cpp
+++ b/Source/control.cpp
@@ -191,7 +191,6 @@ int SpellPages[6][7] =
 	{ -1,			  -1,			 -1,			  -1,			-1,			 -1,			-1 }
 };
 
-//----- (004037D4) --------------------------------------------------------
 void __fastcall DrawSpellCel(int xp, int yp, char *Trans, int nCel, int w)
 {
 	char *v5; // ebx
@@ -276,7 +275,6 @@ LABEL_12:
 	while ( v6 != (char *)v18 );
 }
 
-//----- (0040387E) --------------------------------------------------------
 void __fastcall SetSpellTrans(char t)
 {
 	signed int v1; // eax
@@ -370,7 +368,6 @@ void __fastcall SetSpellTrans(char t)
 	}
 }
 
-//----- (004039C7) --------------------------------------------------------
 void __cdecl DrawSpell()
 {
 	int v0; // ebp
@@ -405,7 +402,6 @@ void __cdecl DrawSpell()
 		DrawSpellCel(629, 631, (char *)pSpellCels, (char)SpellITbl[v3], 56);
 }
 
-//----- (00403A8E) --------------------------------------------------------
 void __cdecl DrawSpellList()
 {
 	int v0; // esi
@@ -630,7 +626,6 @@ LABEL_68:
 // 4B8834: using guessed type int pSpell;
 // 4B8954: using guessed type int pSplType;
 
-//----- (00403F69) --------------------------------------------------------
 void __cdecl SetSpell()
 {
 	int v0; // eax
@@ -650,7 +645,6 @@ void __cdecl SetSpell()
 // 4B8C98: using guessed type int spselflag;
 // 52571C: using guessed type int drawpanflag;
 
-//----- (00403FAC) --------------------------------------------------------
 void __fastcall SetSpeedSpell(int slot)
 {
 	int v1; // esi
@@ -683,7 +677,6 @@ void __fastcall SetSpeedSpell(int slot)
 // 4B8834: using guessed type int pSpell;
 // 4B8954: using guessed type int pSplType;
 
-//----- (00404017) --------------------------------------------------------
 void __fastcall ToggleSpell(int slot)
 {
 	int v1; // eax
@@ -754,7 +747,6 @@ void __fastcall ToggleSpell(int slot)
 }
 // 52571C: using guessed type int drawpanflag;
 
-//----- (004040DA) --------------------------------------------------------
 void __fastcall CPrintString(int No, unsigned char pszStr, int Just)
 {
 	int *v3; // ebx
@@ -953,7 +945,6 @@ LABEL_15:
 	}
 }
 
-//----- (00404218) --------------------------------------------------------
 void __fastcall AddPanelString(char *str, int just)
 {
 	strcpy(&panelstr[64 * pnumlines], str);
@@ -963,7 +954,6 @@ void __fastcall AddPanelString(char *str, int just)
 		pnumlines++;
 }
 
-//----- (0040424A) --------------------------------------------------------
 void __cdecl ClearPanel()
 {
 	pnumlines = 0;
@@ -971,7 +961,6 @@ void __cdecl ClearPanel()
 }
 // 4B8824: using guessed type int pinfoflag;
 
-//----- (00404259) --------------------------------------------------------
 void __fastcall DrawPanelBox(int x, int y, int w, int h, int sx, int sy)
 {
 	char *v6; // esi
@@ -1005,7 +994,6 @@ void __fastcall DrawPanelBox(int x, int y, int w, int h, int sx, int sy)
 	while ( v8 );
 }
 
-//----- (004042CA) --------------------------------------------------------
 void __fastcall SetFlaskHeight(char *buf, int min, int max, int c, int r)
 {
 	char *v5; // esi
@@ -1025,7 +1013,6 @@ void __fastcall SetFlaskHeight(char *buf, int min, int max, int c, int r)
 	while ( v7 );
 }
 
-//----- (0040431B) --------------------------------------------------------
 void __fastcall DrawFlask(void *a1, int a2, int a3, void *a4, int a5, int a6)
 {
 	char *v6; // esi
@@ -1058,7 +1045,6 @@ void __fastcall DrawFlask(void *a1, int a2, int a3, void *a4, int a5, int a6)
 	while ( v8 );
 }
 
-//----- (0040435B) --------------------------------------------------------
 void __cdecl DrawLifeFlask()
 {
 	signed __int64 v0; // rax
@@ -1078,7 +1064,6 @@ void __cdecl DrawLifeFlask()
 		DrawFlask(pBtmBuff, 640, 640 * v2 + 2029, gpBuffer, 768 * v2 + 383405, 13 - v2);
 }
 
-//----- (004043F4) --------------------------------------------------------
 void __cdecl UpdateLifeFlask()
 {
 	signed __int64 v0; // rax
@@ -1102,7 +1087,6 @@ LABEL_8:
 		goto LABEL_8;
 }
 
-//----- (00404475) --------------------------------------------------------
 void __cdecl DrawManaFlask()
 {
 	int v0; // eax
@@ -1121,7 +1105,6 @@ void __cdecl DrawManaFlask()
 		DrawFlask(pBtmBuff, 640, 640 * v2 + 2395, gpBuffer, 768 * v2 + 383771, 13 - v2);
 }
 
-//----- (004044F6) --------------------------------------------------------
 void __cdecl control_update_life_mana()
 {
 	int v0; // esi
@@ -1144,7 +1127,6 @@ void __cdecl control_update_life_mana()
 	plr[v0]._pHPPer = (signed __int64)((double)plr[v0]._pHitPoints / (double)plr[v0]._pMaxHP * 80.0);
 }
 
-//----- (0040456A) --------------------------------------------------------
 void __cdecl UpdateManaFlask()
 {
 	signed int v0; // edi
@@ -1171,7 +1153,6 @@ void __cdecl UpdateManaFlask()
 	DrawSpell();
 }
 
-//----- (00404616) --------------------------------------------------------
 void __cdecl InitControlPan()
 {
 	size_t v0; // esi
@@ -1284,7 +1265,6 @@ void __cdecl InitControlPan()
 // 4B8C98: using guessed type int spselflag;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00404934) --------------------------------------------------------
 void __cdecl ClearCtrlPan()
 {
 	DrawPanelBox(0, sgbPlrTalkTbl + 16, 0x280u, 0x80u, 64, 512);
@@ -1292,7 +1272,6 @@ void __cdecl ClearCtrlPan()
 }
 // 4B8840: using guessed type int sgbPlrTalkTbl;
 
-//----- (00404959) --------------------------------------------------------
 void __cdecl DrawCtrlPan()
 {
 	signed int v0; // edi
@@ -1326,7 +1305,6 @@ void __cdecl DrawCtrlPan()
 // 484368: using guessed type int FriendlyMode;
 // 4B8A7C: using guessed type int numpanbtns;
 
-//----- (00404A0A) --------------------------------------------------------
 void __cdecl DoSpeedBook()
 {
 	int v0; // eax
@@ -1421,7 +1399,6 @@ void __cdecl DoSpeedBook()
 }
 // 4B8C98: using guessed type int spselflag;
 
-//----- (00404B52) --------------------------------------------------------
 void __cdecl DoPanBtn()
 {
 	int v0; // edx
@@ -1465,7 +1442,6 @@ void __cdecl DoPanBtn()
 // 4B8C90: using guessed type int panbtndown;
 // 4B8C98: using guessed type int spselflag;
 
-//----- (00404BEB) --------------------------------------------------------
 void __fastcall control_set_button_down(int btn_id)
 {
 	panbtn[btn_id] = 1;
@@ -1474,7 +1450,6 @@ void __fastcall control_set_button_down(int btn_id)
 }
 // 4B8C90: using guessed type int panbtndown;
 
-//----- (00404C00) --------------------------------------------------------
 void __cdecl control_check_btn_press()
 {
 	int v0; // edx
@@ -1498,7 +1473,6 @@ void __cdecl control_check_btn_press()
 	}
 }
 
-//----- (00404C74) --------------------------------------------------------
 void __cdecl DoAutoMap()
 {
 	if ( currlevel || gbMaxPlayers != 1 )
@@ -1515,7 +1489,6 @@ void __cdecl DoAutoMap()
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00404CA0) --------------------------------------------------------
 void __cdecl CheckPanelInfo()
 {
 	int v0; // edi
@@ -1656,7 +1629,6 @@ LABEL_54:
 // 4B8C98: using guessed type int spselflag;
 // 4B8CB8: using guessed type char pcursinvitem;
 
-//----- (00404FE4) --------------------------------------------------------
 void __cdecl CheckBtnUp()
 {
 	signed int v0; // esi
@@ -1753,7 +1725,6 @@ void __cdecl CheckBtnUp()
 // 646D00: using guessed type char qtextflag;
 // 69BD04: using guessed type int questlog;
 
-//----- (00405181) --------------------------------------------------------
 void __cdecl FreeControlPan()
 {
 	void *v0; // ecx
@@ -1823,7 +1794,6 @@ void __cdecl FreeControlPan()
 	mem_free_dbg(v15);
 }
 
-//----- (00405295) --------------------------------------------------------
 int __fastcall control_WriteStringToBuffer(char *str)
 {
 	signed int v1; // edx
@@ -1842,7 +1812,6 @@ int __fastcall control_WriteStringToBuffer(char *str)
 	return 0;
 }
 
-//----- (004052C8) --------------------------------------------------------
 void __cdecl DrawInfoBox()
 {
 	int v0; // ecx
@@ -1978,7 +1947,6 @@ LABEL_33:
 // 4B8CC2: using guessed type char pcursplr;
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (004055BC) --------------------------------------------------------
 void __fastcall control_print_info_str(int y, char *str, bool center, int lines)
 {
 	int v4; // edi
@@ -2036,7 +2004,6 @@ LABEL_14:
 }
 // 4B883C: using guessed type int infoclr;
 
-//----- (00405681) --------------------------------------------------------
 void __fastcall PrintGameStr(int x, int y, char *str, int color)
 {
 	char *v4; // edi
@@ -2056,7 +2023,6 @@ void __fastcall PrintGameStr(int x, int y, char *str, int color)
 	}
 }
 
-//----- (004056D8) --------------------------------------------------------
 void __cdecl DrawChr()
 {
 	char v0; // al
@@ -2307,7 +2273,6 @@ void __cdecl DrawChr()
 	ADD_PlrStringXY(143, 332, 174, a4, a5[0]);
 }
 
-//----- (00406058) --------------------------------------------------------
 void __fastcall ADD_PlrStringXY(int x, int y, int width, char *pszStr, char col)
 {
 	int v5; // eax
@@ -2359,7 +2324,6 @@ void __fastcall ADD_PlrStringXY(int x, int y, int width, char *pszStr, char col)
 	}
 }
 
-//----- (0040610F) --------------------------------------------------------
 void __fastcall MY_PlrStringXY(int x, int y, int width, char *pszStr, char col, int base)
 {
 	char *v6; // ebx
@@ -2411,7 +2375,6 @@ void __fastcall MY_PlrStringXY(int x, int y, int width, char *pszStr, char col, 
 	}
 }
 
-//----- (004061CA) --------------------------------------------------------
 void __cdecl CheckLvlBtn()
 {
 	if ( !lvlbtndown && MouseX >= 40 && MouseX <= 81 && MouseY >= 313 && MouseY <= 335 )
@@ -2419,7 +2382,6 @@ void __cdecl CheckLvlBtn()
 }
 // 4B851C: using guessed type int lvlbtndown;
 
-//----- (00406200) --------------------------------------------------------
 void __cdecl ReleaseLvlBtn()
 {
 	if ( MouseX >= 40 && MouseX <= 81 && MouseY >= 313 && MouseY <= 335 )
@@ -2428,7 +2390,6 @@ void __cdecl ReleaseLvlBtn()
 }
 // 4B851C: using guessed type int lvlbtndown;
 
-//----- (00406234) --------------------------------------------------------
 void __cdecl DrawLevelUpIcon()
 {
 	int v0; // esi
@@ -2443,7 +2404,6 @@ void __cdecl DrawLevelUpIcon()
 // 4B851C: using guessed type int lvlbtndown;
 // 6AA705: using guessed type char stextflag;
 
-//----- (0040627A) --------------------------------------------------------
 void __cdecl CheckChrBtns()
 {
 	int v0; // esi
@@ -2519,7 +2479,6 @@ LABEL_12:
 }
 // 4B87A8: using guessed type int chrbtnactive;
 
-//----- (00406366) --------------------------------------------------------
 void __cdecl ReleaseChrBtns()
 {
 	signed int v0; // esi
@@ -2577,7 +2536,6 @@ LABEL_16:
 }
 // 4B87A8: using guessed type int chrbtnactive;
 
-//----- (00406408) --------------------------------------------------------
 void __cdecl DrawDurIcon()
 {
 	int v0; // edx
@@ -2601,7 +2559,6 @@ void __cdecl DrawDurIcon()
 // 4B8968: using guessed type int sbookflag;
 // 69BD04: using guessed type int questlog;
 
-//----- (0040648E) --------------------------------------------------------
 int __fastcall DrawDurIcon4Item(ItemStruct *pItem, int x, int c)
 {
 	int v3; // eax
@@ -2668,7 +2625,6 @@ LABEL_18:
 	return v4 - 40;
 }
 
-//----- (00406508) --------------------------------------------------------
 void __cdecl RedBack()
 {
 	int v0; // eax
@@ -2732,7 +2688,6 @@ void __cdecl RedBack()
 // 525728: using guessed type int light4flag;
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (00406592) --------------------------------------------------------
 int __fastcall GetSBookTrans(int ii, unsigned char townok)
 {
 	int v2; // edi
@@ -2764,7 +2719,6 @@ int __fastcall GetSBookTrans(int ii, unsigned char townok)
 	return result;
 }
 
-//----- (00406667) --------------------------------------------------------
 void __cdecl DrawSpellBook()
 {
 	int v0; // edi
@@ -2844,7 +2798,6 @@ void __cdecl DrawSpellBook()
 }
 // 4B8950: using guessed type int sbooktab;
 
-//----- (004068F4) --------------------------------------------------------
 void __fastcall PrintSBookStr(int x, int y, bool cjustflag, char *pszStr, int bright)
 {
 	char *v5; // ebx
@@ -2897,7 +2850,6 @@ LABEL_14:
 	}
 }
 
-//----- (004069B6) --------------------------------------------------------
 void __cdecl CheckSBook()
 {
 	signed int v0; // ecx
@@ -2942,7 +2894,6 @@ void __cdecl CheckSBook()
 // 4B8950: using guessed type int sbooktab;
 // 52571C: using guessed type int drawpanflag;
 
-//----- (00406AF8) --------------------------------------------------------
 char *__fastcall get_pieces_str(int nGold)
 {
 	char *result; // eax
@@ -2953,7 +2904,6 @@ char *__fastcall get_pieces_str(int nGold)
 	return result;
 }
 
-//----- (00406B08) --------------------------------------------------------
 void __fastcall DrawGoldSplit(int amount)
 {
 	int v1; // ebp
@@ -2992,7 +2942,6 @@ void __fastcall DrawGoldSplit(int amount)
 	frame_4B8800 = (frame_4B8800 & 7) + 1;
 }
 
-//----- (00406C40) --------------------------------------------------------
 void __fastcall control_drop_gold(int vkey)
 {
 	char v1; // bl
@@ -3053,7 +3002,6 @@ void __fastcall control_drop_gold(int vkey)
 // 4B84DC: using guessed type int dropGoldFlag;
 // 406C40: using guessed type char var_8[8];
 
-//----- (00406D6E) --------------------------------------------------------
 void __fastcall control_remove_gold(int pnum, int gold_index)
 {
 	int v2; // edi
@@ -3096,7 +3044,6 @@ void __fastcall control_remove_gold(int pnum, int gold_index)
 	plr[v3]._pGold = v8;
 }
 
-//----- (00406E24) --------------------------------------------------------
 void __fastcall control_set_gold_curs(int pnum)
 {
 	int v1; // ecx
@@ -3127,7 +3074,6 @@ void __fastcall control_set_gold_curs(int pnum)
 	SetCursor(*v3 + 12);
 }
 
-//----- (00406E6A) --------------------------------------------------------
 void __cdecl DrawTalkPan()
 {
 	int v0; // esi
@@ -3216,7 +3162,6 @@ LABEL_18:
 // 4B8840: using guessed type int sgbPlrTalkTbl;
 // 4B8960: using guessed type int talkflag;
 
-//----- (00407071) --------------------------------------------------------
 char *__fastcall control_print_talk_msg(char *msg, int x, int y, int *a4, int just)
 {
 	int v5; // edx
@@ -3253,7 +3198,6 @@ char *__fastcall control_print_talk_msg(char *msg, int x, int y, int *a4, int ju
 	return v6;
 }
 
-//----- (004070F3) --------------------------------------------------------
 int __cdecl control_check_talk_btn()
 {
 	int v0; // ecx
@@ -3279,7 +3223,6 @@ int __cdecl control_check_talk_btn()
 }
 // 4B8960: using guessed type int talkflag;
 
-//----- (0040714D) --------------------------------------------------------
 void __cdecl control_release_talk_btn()
 {
 	signed int v0; // ecx
@@ -3312,7 +3255,6 @@ void __cdecl control_release_talk_btn()
 }
 // 4B8960: using guessed type int talkflag;
 
-//----- (004071C0) --------------------------------------------------------
 void __cdecl control_reset_talk_msg()
 {
 	int v0; // edi
@@ -3331,7 +3273,6 @@ void __cdecl control_reset_talk_msg()
 		NetSendCmdString(v0, sgszTalkMsg);
 }
 
-//----- (004071FA) --------------------------------------------------------
 void __cdecl control_type_message()
 {
 	if ( gbMaxPlayers != 1 )
@@ -3354,7 +3295,6 @@ void __cdecl control_type_message()
 // 52571C: using guessed type int drawpanflag;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00407241) --------------------------------------------------------
 void __cdecl control_reset_talk()
 {
 	talkflag = 0;
@@ -3365,7 +3305,6 @@ void __cdecl control_reset_talk()
 // 4B8960: using guessed type int talkflag;
 // 52571C: using guessed type int drawpanflag;
 
-//----- (0040725A) --------------------------------------------------------
 int __fastcall control_talk_last_key(int a1)
 {
 	char v1; // bl
@@ -3385,7 +3324,6 @@ int __fastcall control_talk_last_key(int a1)
 // 4B8960: using guessed type int talkflag;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0040729A) --------------------------------------------------------
 int __fastcall control_presskeys(int a1)
 {
 	signed int v1; // eax
@@ -3424,7 +3362,6 @@ LABEL_15:
 // 4B8960: using guessed type int talkflag;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00407304) --------------------------------------------------------
 void __cdecl control_press_enter()
 {
 	signed int v0; // esi
@@ -3472,7 +3409,6 @@ void __cdecl control_press_enter()
 // 4B84CC: using guessed type char sgbNextTalkSave;
 // 4B84CD: using guessed type char sgbTalkSavePos;
 
-//----- (004073C2) --------------------------------------------------------
 void __fastcall control_up_down(char a1)
 {
 	unsigned char v1; // al

--- a/Source/control.h
+++ b/Source/control.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __CONTROL_H__
+#define __CONTROL_H__
 
-//control
 extern char sgbNextTalkSave; // weak
 extern char sgbTalkSavePos; // weak
 extern void *pDurIcons;
@@ -136,3 +137,5 @@ extern char *PanBtnHotKey[8];
 extern char *PanBtnStr[8];
 extern RECT32 attribute_inc_rects[4];
 extern int SpellPages[6][7];
+
+#endif /* __CONTROL_H__ */

--- a/Source/cursor.cpp
+++ b/Source/cursor.cpp
@@ -388,14 +388,12 @@ int InvItemHeight[180] =
   84
 };
 
-//----- (0040740A) --------------------------------------------------------
 void __cdecl InitCursor()
 {
 	pCursCels = LoadFileInMem("Data\\Inv\\Objcurs.CEL", 0);
 	ClearCursor();
 }
 
-//----- (00407420) --------------------------------------------------------
 void __cdecl FreeCursor()
 {
 	void *v0; // ecx
@@ -406,7 +404,6 @@ void __cdecl FreeCursor()
 	ClearCursor();
 }
 
-//----- (00407437) --------------------------------------------------------
 void __fastcall SetICursor(int i)
 {
 	int v1; // ecx
@@ -420,7 +417,6 @@ void __fastcall SetICursor(int i)
 // 4B8CB4: using guessed type int icursH;
 // 4B8CBC: using guessed type int icursW;
 
-//----- (0040746B) --------------------------------------------------------
 void __fastcall SetCursor(int i)
 {
 	int v1; // eax
@@ -433,7 +429,6 @@ void __fastcall SetCursor(int i)
 }
 // 4B8C9C: using guessed type int cursH;
 
-//----- (00407493) --------------------------------------------------------
 void __cdecl InitLevelCursor()
 {
 	SetCursor(CURSOR_HAND);
@@ -451,7 +446,6 @@ void __cdecl InitLevelCursor()
 // 4B8CC2: using guessed type char pcursplr;
 // 4B8CCC: using guessed type int dword_4B8CCC;
 
-//----- (004074D0) --------------------------------------------------------
 void __cdecl CheckTown()
 {
 	int v0; // ecx
@@ -495,7 +489,6 @@ void __cdecl CheckTown()
 	}
 }
 
-//----- (004075FD) --------------------------------------------------------
 void __cdecl CheckRportal()
 {
 	int v0; // ecx
@@ -543,7 +536,6 @@ void __cdecl CheckRportal()
 }
 // 5CF31D: using guessed type char setlevel;
 
-//----- (00407729) --------------------------------------------------------
 void __cdecl CheckCursMove()
 {
 	int v0; // esi

--- a/Source/cursor.h
+++ b/Source/cursor.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __CURSOR_H__
+#define __CURSOR_H__
 
-//cursor
 extern int cursH; // weak
 extern int icursH28; // idb
 extern int cursW; // idb
@@ -31,3 +32,5 @@ void __cdecl CheckCursMove();
 /* data */
 extern int InvItemWidth[180];
 extern int InvItemHeight[180];
+
+#endif /* __CURSOR_H__ */

--- a/Source/dead.cpp
+++ b/Source/dead.cpp
@@ -6,7 +6,6 @@ int spurtndx; // weak
 DeadStruct dead[31];
 int stonendx;
 
-//----- (004084A6) --------------------------------------------------------
 void __cdecl InitDead()
 {
 	int v0; // ebx
@@ -108,13 +107,11 @@ void __cdecl InitDead()
 }
 // 4B8CD8: using guessed type int spurtndx;
 
-//----- (0040865C) --------------------------------------------------------
 void __fastcall AddDead(int dx, int dy, char dv, int ddir)
 {
 	dDead[dx][dy] = (dv & 0x1F) + 32 * ddir;
 }
 
-//----- (0040867D) --------------------------------------------------------
 void __cdecl SetDead()
 {
 	int v0; // eax

--- a/Source/dead.h
+++ b/Source/dead.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __DEAD_H__
+#define __DEAD_H__
 
-//dead
 extern int spurtndx; // weak
 extern DeadStruct dead[31];
 extern int stonendx;
@@ -8,3 +9,5 @@ extern int stonendx;
 void __cdecl InitDead();
 void __fastcall AddDead(int dx, int dy, char dv, int ddir);
 void __cdecl SetDead();
+
+#endif /* __DEAD_H__ */

--- a/Source/debug.cpp
+++ b/Source/debug.cpp
@@ -6,7 +6,6 @@ void *pSquareCel;
 char dMonsDbg[17][112][112];
 char dFlagDbg[17][112][112];
 
-//----- (004086F4) --------------------------------------------------------
 void __cdecl LoadDebugGFX()
 {
 	if ( visiondebug )
@@ -14,7 +13,6 @@ void __cdecl LoadDebugGFX()
 }
 // 525720: using guessed type int visiondebug;
 
-//----- (0040870F) --------------------------------------------------------
 void __cdecl FreeDebugGFX()
 {
 	void *v0; // ecx
@@ -24,7 +22,6 @@ void __cdecl FreeDebugGFX()
 	mem_free_dbg(v0);
 }
 
-//----- (00408721) --------------------------------------------------------
 void __cdecl CheckDungeonClear()
 {
 	int i;

--- a/Source/debug.h
+++ b/Source/debug.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __DEBUG_H__
+#define __DEBUG_H__
 
-//debug
 extern void *pSquareCel;
 extern char dMonsDbg[17][112][112];
 extern char dFlagDbg[17][112][112];
@@ -19,3 +20,5 @@ void __fastcall PrintDebugMonster(int m);
 void __cdecl GetDebugMonster();
 void __cdecl NextDebugMonster();
 #endif
+
+#endif /* __DEBUG_H__ */

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -67,7 +67,6 @@ char *spszMsgTbl[4] =
 }; // weak
 char *spszMsgKeyTbl[4] = { "F9", "F10", "F11", "F12" }; // weak
 
-//----- (004087B6) --------------------------------------------------------
 struct diablo_cpp_init
 {
 	diablo_cpp_init()
@@ -78,7 +77,6 @@ struct diablo_cpp_init
 // 479BF8: using guessed type int diablo_inf;
 // 525514: using guessed type int diablo_cpp_init_value;
 
-//----- (004087C1) --------------------------------------------------------
 void __cdecl FreeGameMem()
 {
 	void *v0; // ecx
@@ -110,7 +108,6 @@ void __cdecl FreeGameMem()
 	FreeTownerGFX();
 }
 
-//----- (00408838) --------------------------------------------------------
 int __fastcall diablo_init_menu(int a1, int bSinglePlayer)
 {
 	int v2; // esi
@@ -149,7 +146,6 @@ LABEL_11:
 // 5256E8: using guessed type int dword_5256E8;
 // 678640: using guessed type char byte_678640;
 
-//----- (004088E2) --------------------------------------------------------
 void __fastcall run_game_loop(int uMsg)
 {
 	//int v3; // eax
@@ -235,7 +231,6 @@ void __fastcall run_game_loop(int uMsg)
 // 52571C: using guessed type int drawpanflag;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00408A8C) --------------------------------------------------------
 void __fastcall start_game(int uMsg)
 {
 	cineflag = 0;
@@ -255,7 +250,6 @@ void __fastcall start_game(int uMsg)
 // 525718: using guessed type char cineflag;
 // 525748: using guessed type char sgbMouseDown;
 
-//----- (00408ADB) --------------------------------------------------------
 void __cdecl free_game()
 {
 	int i; // esi
@@ -276,7 +270,6 @@ void __cdecl free_game()
 	FreeGameMem();
 }
 
-//----- (00408B1E) --------------------------------------------------------
 bool __cdecl diablo_get_not_running()
 {
 	SetLastError(0);
@@ -284,7 +277,6 @@ bool __cdecl diablo_get_not_running()
 	return GetLastError() != ERROR_ALREADY_EXISTS;
 }
 
-//----- (00408B4A) --------------------------------------------------------
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
 {
 	HINSTANCE v4; // esi
@@ -350,7 +342,6 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 	return 0;
 }
 
-//----- (00408CB1) --------------------------------------------------------
 void __fastcall diablo_parse_flags(char *args)
 {
 #ifdef _DEBUG
@@ -477,7 +468,6 @@ void __fastcall diablo_parse_flags(char *args)
 // 52A548: using guessed type char gbBackBuf;
 // 52A549: using guessed type char gbEmulate;
 
-//----- (00408D61) --------------------------------------------------------
 void __cdecl diablo_init_screen()
 {
 	int v0; // ecx
@@ -503,7 +493,6 @@ void __cdecl diablo_init_screen()
 }
 // 69CEFC: using guessed type int scrollrt_cpp_init_value;
 
-//----- (00408DB1) --------------------------------------------------------
 HWND __fastcall diablo_find_window(LPCSTR lpClassName)
 {
 	HWND result; // eax
@@ -528,7 +517,6 @@ HWND __fastcall diablo_find_window(LPCSTR lpClassName)
 	return result;
 }
 
-//----- (00408DF4) --------------------------------------------------------
 void __fastcall diablo_reload_process(HMODULE hModule)
 {
 	char *i; // eax
@@ -614,7 +602,6 @@ LABEL_23:
 	}
 }
 
-//----- (00408FCF) --------------------------------------------------------
 int __cdecl PressEscKey()
 {
 	int result; // eax
@@ -674,7 +661,6 @@ LABEL_10:
 // 646D00: using guessed type char qtextflag;
 // 6AA705: using guessed type char stextflag;
 
-//----- (0040905E) --------------------------------------------------------
 LRESULT __stdcall DisableInputWndProc(HWND hWnd, int uMsg, int wParam, int lParam)
 {
 	bool v5; // zf
@@ -737,7 +723,6 @@ LABEL_23:
 }
 // 525748: using guessed type char sgbMouseDown;
 
-//----- (00409131) --------------------------------------------------------
 int __stdcall GM_Game(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
 	if ( uMsg > WM_LBUTTONDOWN )
@@ -854,7 +839,6 @@ int __stdcall GM_Game(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 // 525748: using guessed type char sgbMouseDown;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (004093B2) --------------------------------------------------------
 bool __fastcall LeftMouseDown(int a1)
 {
 	int v1; // edi
@@ -1059,7 +1043,6 @@ LABEL_98:
 // 69BD04: using guessed type int questlog;
 // 6AA705: using guessed type char stextflag;
 
-//----- (004097EC) --------------------------------------------------------
 bool __cdecl TryIconCurs()
 {
 	unsigned char v0; // dl
@@ -1137,7 +1120,6 @@ LABEL_26:
 // 4B8CC1: using guessed type char pcursobj;
 // 4B8CC2: using guessed type char pcursplr;
 
-//----- (00409963) --------------------------------------------------------
 void __cdecl LeftMouseUp()
 {
 	gmenu_left_mouse(0);
@@ -1156,7 +1138,6 @@ void __cdecl LeftMouseUp()
 // 4B8C90: using guessed type int panbtndown;
 // 6AA705: using guessed type char stextflag;
 
-//----- (004099A8) --------------------------------------------------------
 void __cdecl RightMouseDown()
 {
 	if ( !gmenu_exception() && sgnTimeoutCurs == CURSOR_NONE && PauseMode != 2 && !plr[myplr]._pInvincible )
@@ -1196,7 +1177,6 @@ void __cdecl RightMouseDown()
 // 52575C: using guessed type int doomflag;
 // 6AA705: using guessed type char stextflag;
 
-//----- (00409A8E) --------------------------------------------------------
 bool __fastcall PressSysKey(int wParam)
 {
 	if ( gmenu_exception() || wParam != VK_F10 )
@@ -1205,7 +1185,6 @@ bool __fastcall PressSysKey(int wParam)
 	return 1;
 }
 
-//----- (00409AB0) --------------------------------------------------------
 void __fastcall diablo_hotkey_msg(int dwMsg)
 {
 	int v1; // esi
@@ -1230,14 +1209,12 @@ void __fastcall diablo_hotkey_msg(int dwMsg)
 // 48437C: using guessed type char *spszMsgKeyTbl[4];
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00409B51) --------------------------------------------------------
 void __fastcall ReleaseKey(int vkey)
 {
 	if ( vkey == VK_SNAPSHOT )
 		CaptureScreen();
 }
 
-//----- (00409B5C) --------------------------------------------------------
 void __fastcall PressKey(int vkey)
 {
 	int v1; // esi
@@ -1482,7 +1459,6 @@ LABEL_101:
 // 69BD04: using guessed type int questlog;
 // 6AA705: using guessed type char stextflag;
 
-//----- (00409F43) --------------------------------------------------------
 void __cdecl diablo_pause_game()
 {
 	if ( (unsigned char)gbMaxPlayers <= 1u )
@@ -1504,7 +1480,6 @@ void __cdecl diablo_pause_game()
 // 525740: using guessed type int PauseMode;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00409F7F) --------------------------------------------------------
 void __fastcall PressChar(int vkey)
 {
 	int v1; // ebx
@@ -1816,7 +1791,6 @@ LABEL_27:
 // 69BD04: using guessed type int questlog;
 // 6AA705: using guessed type char stextflag;
 
-//----- (0040A391) --------------------------------------------------------
 void __cdecl LoadLvlGFX()
 {
 	unsigned char *v0; // eax
@@ -1877,7 +1851,6 @@ LABEL_14:
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0040A4B4) --------------------------------------------------------
 void __cdecl LoadAllGFX()
 {
 	pSpeedCels = DiabloAllocPtr(0x100000);
@@ -1889,7 +1862,6 @@ void __cdecl LoadAllGFX()
 	IncProgress();
 }
 
-//----- (0040A4E1) --------------------------------------------------------
 void __fastcall CreateLevel(int lvldir)
 {
 	int hnd; // cl
@@ -1934,7 +1906,6 @@ void __fastcall CreateLevel(int lvldir)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0040A5A4) --------------------------------------------------------
 void __fastcall LoadGameLevel(bool firstflag, int lvldir)
 {
 	int v2; // ebp
@@ -2172,7 +2143,6 @@ LABEL_72:
 // 5CF31D: using guessed type char setlevel;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0040AAE3) --------------------------------------------------------
 void __fastcall game_loop(bool startup)
 {
 	int v1; // ecx
@@ -2208,7 +2178,6 @@ void __fastcall game_loop(bool startup)
 // 525650: using guessed type int gbRunGame;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0040AB33) --------------------------------------------------------
 void __cdecl game_logic()
 {
 	if ( PauseMode != 2 )
@@ -2266,7 +2235,6 @@ void __cdecl game_logic()
 // 5BB1ED: using guessed type char leveltype;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0040ABE7) --------------------------------------------------------
 void __fastcall timeout_cursor(bool timeout)
 {
 	if ( timeout )
@@ -2294,7 +2262,6 @@ void __fastcall timeout_cursor(bool timeout)
 // 52571C: using guessed type int drawpanflag;
 // 525748: using guessed type char sgbMouseDown;
 
-//----- (0040AC6B) --------------------------------------------------------
 void __cdecl diablo_color_cyc_logic()
 {
 	DWORD v0; // eax

--- a/Source/diablo.h
+++ b/Source/diablo.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __DIABLO_H__
+#define __DIABLO_H__
 
-//diablo
 extern int diablo_cpp_init_value; // weak
 extern HWND ghMainWnd;
 extern int glMid1Seed[17];
@@ -96,3 +97,5 @@ extern int framestart;
 extern int FriendlyMode; // weak
 extern char *spszMsgTbl[4]; // weak
 extern char *spszMsgKeyTbl[4]; // weak
+
+#endif /* __DIABLO_H__ */

--- a/Source/doom.cpp
+++ b/Source/doom.cpp
@@ -8,7 +8,6 @@ void *pDoomCel;
 int doomflag; // weak
 int DoomQuestState; // idb
 
-//----- (0040ACAD) --------------------------------------------------------
 int __cdecl doom_get_frame_from_time()
 {
 	int result; // eax
@@ -20,13 +19,11 @@ int __cdecl doom_get_frame_from_time()
 	return result;
 }
 
-//----- (0040ACC6) --------------------------------------------------------
 void __cdecl doom_alloc_cel()
 {
 	pDoomCel = DiabloAllocPtr(229376);
 }
 
-//----- (0040ACD6) --------------------------------------------------------
 void __cdecl doom_cleanup()
 {
 	void *v0; // ecx
@@ -36,7 +33,6 @@ void __cdecl doom_cleanup()
 	mem_free_dbg(v0);
 }
 
-//----- (0040ACE8) --------------------------------------------------------
 void __cdecl doom_load_graphics()
 {
 	if ( doom_quest_time == 31 )
@@ -55,7 +51,6 @@ void __cdecl doom_load_graphics()
 }
 // 525750: using guessed type int doom_quest_time;
 
-//----- (0040AD34) --------------------------------------------------------
 void __cdecl doom_init()
 {
 	int v0; // eax
@@ -70,7 +65,6 @@ void __cdecl doom_init()
 // 525750: using guessed type int doom_quest_time;
 // 52575C: using guessed type int doomflag;
 
-//----- (0040AD5E) --------------------------------------------------------
 void __cdecl doom_close()
 {
 	if ( doomflag )
@@ -81,7 +75,6 @@ void __cdecl doom_close()
 }
 // 52575C: using guessed type int doomflag;
 
-//----- (0040AD74) --------------------------------------------------------
 void __cdecl doom_draw()
 {
 	if ( doomflag )

--- a/Source/doom.h
+++ b/Source/doom.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __DOOM_H__
+#define __DOOM_H__
 
-//doom
 extern int doom_quest_time; // weak
 extern int doom_stars_drawn; // weak
 extern void *pDoomCel;
@@ -14,3 +15,5 @@ void __cdecl doom_load_graphics();
 void __cdecl doom_init();
 void __cdecl doom_close();
 void __cdecl doom_draw();
+
+#endif /* __DOOM_H__ */

--- a/Source/drlg_l1.cpp
+++ b/Source/drlg_l1.cpp
@@ -110,7 +110,6 @@ unsigned char PWATERIN[] = { 6, 6, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 13, 1
 /* rdata */
 unsigned char L5ConvTbl[16] = { 22u, 13u, 1u, 13u, 2u, 13u, 13u, 13u, 4u, 13u, 1u, 13u, 2u, 13u, 16u, 13u };
 
-//----- (0040ADD6) --------------------------------------------------------
 void __cdecl DRLG_Init_Globals()
 {
 	char v0; // al
@@ -132,7 +131,6 @@ void __cdecl DRLG_Init_Globals()
 // 525728: using guessed type int light4flag;
 // 646A28: using guessed type int lightflag;
 
-//----- (0040AE79) --------------------------------------------------------
 void __fastcall LoadL1Dungeon(char *sFileName, int vx, int vy)
 {
 	char *v3; // esi
@@ -222,7 +220,6 @@ void __fastcall LoadL1Dungeon(char *sFileName, int vx, int vy)
 // 5D2458: using guessed type int dminx;
 // 5D245C: using guessed type int dminy;
 
-//----- (0040AF65) --------------------------------------------------------
 void __cdecl DRLG_L1Floor()
 {
 	signed int i; // edi
@@ -254,7 +251,6 @@ void __cdecl DRLG_L1Floor()
 	while ( i < 40 );
 }
 
-//----- (0040AFB3) --------------------------------------------------------
 void __cdecl DRLG_L1Pass3()
 {
 	int v0; // eax
@@ -338,7 +334,6 @@ void __cdecl DRLG_L1Pass3()
 	while ( v4 < 40 );
 }
 
-//----- (0040B0A5) --------------------------------------------------------
 void __cdecl DRLG_InitL1Vals()
 {
 	int v0; // esi
@@ -418,7 +413,6 @@ LABEL_23:
 	while ( (signed int)v7 < (signed int)dPiece[1] );
 }
 
-//----- (0040B160) --------------------------------------------------------
 void __fastcall LoadPreL1Dungeon(char *sFileName, int vx, int vy)
 {
 	unsigned char *v3; // ebx
@@ -514,7 +508,6 @@ void __fastcall LoadPreL1Dungeon(char *sFileName, int vx, int vy)
 // 5D2458: using guessed type int dminx;
 // 5D245C: using guessed type int dminy;
 
-//----- (0040B229) --------------------------------------------------------
 void __fastcall CreateL5Dungeon(int rseed, int entry)
 {
 	int v2; // esi
@@ -539,7 +532,6 @@ void __fastcall CreateL5Dungeon(int rseed, int entry)
 // 5D2458: using guessed type int dminx;
 // 5D245C: using guessed type int dminy;
 
-//----- (0040B276) --------------------------------------------------------
 void __cdecl DRLG_LoadL1SP()
 {
 	setloadflag = 0;
@@ -562,7 +554,6 @@ void __cdecl DRLG_LoadL1SP()
 // 5276A4: using guessed type int setloadflag;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0040B2F4) --------------------------------------------------------
 void __cdecl DRLG_FreeL1SP()
 {
 	void *v0; // ecx
@@ -572,7 +563,6 @@ void __cdecl DRLG_FreeL1SP()
 	mem_free_dbg(v0);
 }
 
-//----- (0040B306) --------------------------------------------------------
 void __fastcall DRLG_L5(int entry)
 {
 	signed int v1; // esi
@@ -735,7 +725,6 @@ LABEL_34:
 	DRLG_CheckQuests(setpc_x, setpc_y);
 }
 
-//----- (0040B56F) --------------------------------------------------------
 void __fastcall DRLG_PlaceDoor(int x, int y)
 {
 	int v2; // edi
@@ -831,7 +820,6 @@ LABEL_57:
 	*v8 = -128;
 }
 
-//----- (0040B699) --------------------------------------------------------
 void __cdecl DRLG_L1Shadows()
 {
 	signed int v0; // ebx
@@ -973,7 +961,6 @@ void __cdecl DRLG_L1Shadows()
 	while ( v10 < 40 );
 }
 
-//----- (0040B881) --------------------------------------------------------
 int __fastcall DRLG_PlaceMiniSet(unsigned char *miniset, int tmin, int tmax, int cx, int cy, bool setview, int noquad, int ldir)
 {
 	unsigned char *v8; // ebx
@@ -1201,7 +1188,6 @@ LABEL_57:
 // 5CF320: using guessed type int LvlViewY;
 // 5CF324: using guessed type int LvlViewX;
 
-//----- (0040BAF6) --------------------------------------------------------
 void __cdecl InitL5Dungeon()
 {
 	signed int v0; // edx
@@ -1226,7 +1212,6 @@ void __cdecl InitL5Dungeon()
 	while ( v0 < 40 );
 }
 
-//----- (0040BB18) --------------------------------------------------------
 void __cdecl L5ClearFlags()
 {
 	signed int v0; // ecx
@@ -1250,7 +1235,6 @@ void __cdecl L5ClearFlags()
 	while ( v0 < 40 );
 }
 
-//----- (0040BB33) --------------------------------------------------------
 void __cdecl L5firstRoom()
 {
 	signed int v0; // ebx
@@ -1348,7 +1332,6 @@ void __cdecl L5firstRoom()
 	}
 }
 
-//----- (0040BD66) --------------------------------------------------------
 void __fastcall L5drawRoom(int x, int y, int w, int h)
 {
 	int i; // esi
@@ -1372,7 +1355,6 @@ void __fastcall L5drawRoom(int x, int y, int w, int h)
 	}
 }
 
-//----- (0040BD9D) --------------------------------------------------------
 void __fastcall L5roomGen(int x, int y, int w, int h, bool dir)
 {
 	int v5; // eax
@@ -1490,7 +1472,6 @@ void __fastcall L5roomGen(int x, int y, int w, int h, bool dir)
 	}
 }
 
-//----- (0040BFA4) --------------------------------------------------------
 bool __fastcall L5checkRoom(int x, int y, int width, int height)
 {
 	int v4; // eax
@@ -1523,7 +1504,6 @@ LABEL_10:
 	return 0;
 }
 
-//----- (0040C008) --------------------------------------------------------
 int __cdecl L5GetArea()
 {
 	int rv; // eax
@@ -1551,7 +1531,6 @@ int __cdecl L5GetArea()
 	return rv;
 }
 
-//----- (0040C02A) --------------------------------------------------------
 void __cdecl L5makeDungeon()
 {
 	signed int v0; // edi
@@ -1583,7 +1562,6 @@ void __cdecl L5makeDungeon()
 	while ( v0 < 40 );
 }
 
-//----- (0040C06E) --------------------------------------------------------
 void __cdecl L5makeDmt()
 {
 	signed int v0; // ecx
@@ -1636,7 +1614,6 @@ void __cdecl L5makeDmt()
 	while ( v3 <= 77 );
 }
 
-//----- (0040C0E0) --------------------------------------------------------
 void __cdecl L5AddWall()
 {
 	int v0; // edi
@@ -1707,7 +1684,6 @@ void __cdecl L5AddWall()
 	while ( v0 < 40 );
 }
 
-//----- (0040C23C) --------------------------------------------------------
 int __fastcall L5HWallOk(int i, int j)
 {
 	int v2; // esi
@@ -1759,7 +1735,6 @@ int __fastcall L5HWallOk(int i, int j)
 	return result;
 }
 
-//----- (0040C2DC) --------------------------------------------------------
 int __fastcall L5VWallOk(int i, int j)
 {
 	int v2; // ecx
@@ -1800,7 +1775,6 @@ int __fastcall L5VWallOk(int i, int j)
 	return result;
 }
 
-//----- (0040C35B) --------------------------------------------------------
 void __fastcall L5HorizWall(int i, int j, char p, int dx)
 {
 	int v4; // edi
@@ -1879,7 +1853,6 @@ void __fastcall L5HorizWall(int i, int j, char p, int dx)
 	}
 }
 
-//----- (0040C449) --------------------------------------------------------
 void __fastcall L5VertWall(int i, int j, char p, int dy)
 {
 	int v4; // edi
@@ -1970,7 +1943,6 @@ void __fastcall L5VertWall(int i, int j, char p, int dy)
 	}
 }
 
-//----- (0040C551) --------------------------------------------------------
 void __cdecl L5tileFix()
 {
 	signed int v0; // esi
@@ -2252,7 +2224,6 @@ void __cdecl L5tileFix()
 	while ( v35 < 40 );
 }
 
-//----- (0040C8C0) --------------------------------------------------------
 void __cdecl DRLG_L5Subs()
 {
 	signed int v0; // edi
@@ -2321,7 +2292,6 @@ LABEL_23:
 	while ( v0 < 40 );
 }
 
-//----- (0040C99D) --------------------------------------------------------
 void __cdecl L5FillChambers()
 {
 	int v0; // edi
@@ -2512,7 +2482,6 @@ LABEL_107:
 }
 // 5276A4: using guessed type int setloadflag;
 
-//----- (0040CD86) --------------------------------------------------------
 void __fastcall DRLG_L5GChamber(int sx, int sy, bool topflag, bool bottomflag, bool leftflag, bool rightflag)
 {
 	int v6; // eax
@@ -2602,7 +2571,6 @@ void __fastcall DRLG_L5GChamber(int sx, int sy, bool topflag, bool bottomflag, b
 	dungeon[7][v15 + 7] = 15;
 }
 
-//----- (0040CEC7) --------------------------------------------------------
 void __fastcall DRLG_L5GHall(int x1, int y1, int x2, int y2)
 {
 	int v4; // eax
@@ -2642,7 +2610,6 @@ void __fastcall DRLG_L5GHall(int x1, int y1, int x2, int y2)
 	}
 }
 
-//----- (0040CF17) --------------------------------------------------------
 void __fastcall DRLG_L5SetRoom(int rx1, int ry1)
 {
 	int v2; // edi
@@ -2695,7 +2662,6 @@ void __fastcall DRLG_L5SetRoom(int rx1, int ry1)
 // 5CF330: using guessed type int setpc_h;
 // 5CF334: using guessed type int setpc_w;
 
-//----- (0040CF9C) --------------------------------------------------------
 void __cdecl DRLG_L5FloodTVal()
 {
 	int v0; // ebx
@@ -2733,7 +2699,6 @@ void __cdecl DRLG_L5FloodTVal()
 }
 // 5A5590: using guessed type char TransVal;
 
-//----- (0040D00B) --------------------------------------------------------
 void __fastcall DRLG_L5FTVR(int i, int j, int x, int y, int d)
 {
 	int v5; // ebx
@@ -2839,7 +2804,6 @@ void __fastcall DRLG_L5FTVR(int i, int j, int x, int y, int d)
 }
 // 5A5590: using guessed type char TransVal;
 
-//----- (0040D1FB) --------------------------------------------------------
 void __cdecl DRLG_L5TransFix()
 {
 	signed int v0; // esi
@@ -2906,7 +2870,6 @@ void __cdecl DRLG_L5TransFix()
 	while ( v0 < 40 );
 }
 
-//----- (0040D283) --------------------------------------------------------
 void __cdecl DRLG_L5DirtFix()
 {
 	signed int v0; // ecx
@@ -2941,7 +2904,6 @@ void __cdecl DRLG_L5DirtFix()
 	while ( v0 < 40 );
 }
 
-//----- (0040D2EF) --------------------------------------------------------
 void __cdecl DRLG_L5CornerFix()
 {
 	signed int v0; // esi

--- a/Source/drlg_l1.h
+++ b/Source/drlg_l1.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __DRLG_L1_H__
+#define __DRLG_L1_H__
 
-//drlg_l1
 extern char L5dungeon[80][80];
 extern char mydflags[40][40];
 extern int setloadflag; // weak
@@ -63,3 +64,5 @@ extern unsigned char PWATERIN[];
 
 /* rdata */
 extern unsigned char L5ConvTbl[16];
+
+#endif /* __DRLG_L1_H__ */

--- a/Source/drlg_l2.cpp
+++ b/Source/drlg_l2.cpp
@@ -235,7 +235,6 @@ int Patterns[100][10] =
   { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
 };
 
-//----- (0040D357) --------------------------------------------------------
 void __cdecl InitDungeon()
 {
 	signed int v0; // edx
@@ -260,7 +259,6 @@ void __cdecl InitDungeon()
 	while ( v0 < 40 );
 }
 
-//----- (0040D379) --------------------------------------------------------
 void __cdecl L2LockoutFix()
 {
 	int i; // ecx
@@ -333,7 +331,6 @@ void __cdecl L2LockoutFix()
 	}
 }
 
-//----- (0040D4CC) --------------------------------------------------------
 void __cdecl L2DoorFix()
 {
 	signed int v0; // ecx
@@ -360,7 +357,6 @@ void __cdecl L2DoorFix()
 	while ( v0 < 40 );
 }
 
-//----- (0040D501) --------------------------------------------------------
 void __fastcall LoadL2Dungeon(char *sFileName, int vx, int vy)
 {
 	char *v3; // esi
@@ -541,7 +537,6 @@ void __fastcall LoadL2Dungeon(char *sFileName, int vx, int vy)
 	mem_free_dbg(ptr);
 }
 
-//----- (0040D6C1) --------------------------------------------------------
 void __cdecl DRLG_L2Pass3()
 {
 	int v0; // eax
@@ -625,7 +620,6 @@ void __cdecl DRLG_L2Pass3()
 	while ( v4 < 40 );
 }
 
-//----- (0040D7B3) --------------------------------------------------------
 void __fastcall LoadPreL2Dungeon(char *sFileName, int vx, int vy)
 {
 	char *v3; // esi
@@ -737,7 +731,6 @@ void __fastcall LoadPreL2Dungeon(char *sFileName, int vx, int vy)
 	mem_free_dbg(ptr);
 }
 
-//----- (0040D888) --------------------------------------------------------
 void __fastcall CreateL2Dungeon(int rseed, int entry)
 {
 	int v2; // esi
@@ -793,7 +786,6 @@ LABEL_10:
 // 5D245C: using guessed type int dminy;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0040D94F) --------------------------------------------------------
 void __cdecl DRLG_LoadL2SP()
 {
 	char *v1; // ecx
@@ -821,7 +813,6 @@ void __cdecl DRLG_LoadL2SP()
 }
 // 5B50D8: using guessed type int setloadflag_2;
 
-//----- (0040D9A4) --------------------------------------------------------
 void __cdecl DRLG_FreeL2SP()
 {
 	char *v0; // ecx
@@ -831,7 +822,6 @@ void __cdecl DRLG_FreeL2SP()
 	mem_free_dbg(v0);
 }
 
-//----- (0040D9B6) --------------------------------------------------------
 void __fastcall DRLG_L2(int entry)
 {
 	int v1; // esi
@@ -1043,7 +1033,6 @@ LABEL_21:
 }
 // 5B50D8: using guessed type int setloadflag_2;
 
-//----- (0040E074) --------------------------------------------------------
 bool __fastcall DRLG_L2PlaceMiniSet(char *miniset, int tmin, int tmax, int cx, int cy, bool setview, int ldir)
 {
 	int v7; // ebx
@@ -1233,7 +1222,6 @@ bool __fastcall DRLG_L2PlaceMiniSet(char *miniset, int tmin, int tmax, int cx, i
 // 5CF320: using guessed type int LvlViewY;
 // 5CF324: using guessed type int LvlViewX;
 
-//----- (0040E2D1) --------------------------------------------------------
 void __fastcall DRLG_L2PlaceRndSet(char *miniset, int rndper)
 {
 	char *v2; // ebx
@@ -1402,7 +1390,6 @@ LABEL_34:
 // 5276CC: using guessed type int nSx2;
 // 5276D4: using guessed type int nSy2;
 
-//----- (0040E49C) --------------------------------------------------------
 void __cdecl DRLG_L2Subs()
 {
 	signed int v0; // edi
@@ -1469,7 +1456,6 @@ void __cdecl DRLG_L2Subs()
 // 5276CC: using guessed type int nSx2;
 // 5276D4: using guessed type int nSy2;
 
-//----- (0040E59C) --------------------------------------------------------
 void __cdecl DRLG_L2Shadows()
 {
 	char *v0; // eax
@@ -1538,7 +1524,6 @@ void __cdecl DRLG_L2Shadows()
 }
 // 48489A: using guessed type short word_48489A;
 
-//----- (0040E66B) --------------------------------------------------------
 void __fastcall DRLG_L2SetRoom(int rx1, int ry1)
 {
 	int v2; // edi
@@ -1591,7 +1576,6 @@ void __fastcall DRLG_L2SetRoom(int rx1, int ry1)
 // 5CF330: using guessed type int setpc_h;
 // 5CF334: using guessed type int setpc_w;
 
-//----- (0040E6F0) --------------------------------------------------------
 void __cdecl L2TileFix()
 {
 	signed int v0; // edx
@@ -1629,7 +1613,6 @@ void __cdecl L2TileFix()
 	while ( v0 < 40 );
 }
 
-//----- (0040E74F) --------------------------------------------------------
 bool __cdecl CreateDungeon()
 {
 	int v0; // esi
@@ -1747,7 +1730,6 @@ LABEL_12:
 	return v8;
 }
 
-//----- (0040E8A4) --------------------------------------------------------
 void __fastcall CreateRoom(int nX1, int nY1, int nX2, int nY2, int nRDest, int nHDir, int ForceHW, int nH, int nW)
 {
 	int v9; // esi
@@ -1980,7 +1962,6 @@ LABEL_7:
 // 5276CC: using guessed type int nSx2;
 // 5276D4: using guessed type int nSy2;
 
-//----- (0040ECF9) --------------------------------------------------------
 void __fastcall DefineRoom(int nX1, int nY1, int nX2, int nY2, int ForceHW)
 {
 	int v5; // esi
@@ -2063,7 +2044,6 @@ void __fastcall DefineRoom(int nX1, int nY1, int nX2, int nY2, int ForceHW)
 	}
 }
 
-//----- (0040EE1D) --------------------------------------------------------
 void __fastcall AddHall(int nX1, int nY1, int nX2, int nY2, int nHd)
 {
 	int v5; // edi
@@ -2098,7 +2078,6 @@ void __fastcall AddHall(int nX1, int nY1, int nX2, int nY2, int nHd)
 	}
 }
 
-//----- (0040EEAC) --------------------------------------------------------
 void __fastcall GetHall(int *nX1, int *nY1, int *nX2, int *nY2, int *nHd)
 {
 	HALLNODE *v5; // esi
@@ -2116,7 +2095,6 @@ void __fastcall GetHall(int *nX1, int *nY1, int *nX2, int *nY2, int *nHd)
 	pHallList = v5;
 }
 
-//----- (0040EF09) --------------------------------------------------------
 void __fastcall ConnectHall(int nX1, int nY1, int nX2, int nY2, int nHd)
 {
 	int v5; // edi
@@ -2355,7 +2333,6 @@ LABEL_109:
 	while ( !v34 );
 }
 
-//----- (0040F265) --------------------------------------------------------
 void __fastcall CreateDoorType(int nX, int nY)
 {
 	int v2; // eax
@@ -2381,7 +2358,6 @@ void __fastcall CreateDoorType(int nX, int nY)
 		*v4 = 68;
 }
 
-//----- (0040F2BD) --------------------------------------------------------
 void __fastcall PlaceHallExt(int nX, int nY)
 {
 	char *v2; // eax
@@ -2391,7 +2367,6 @@ void __fastcall PlaceHallExt(int nX, int nY)
 		*v2 = 44;
 }
 
-//----- (0040F2D0) --------------------------------------------------------
 void __fastcall DoPatternCheck(int i, int j)
 {
 	int v2; // edx
@@ -2498,7 +2473,6 @@ LABEL_25:
 	}
 }
 
-//----- (0040F459) --------------------------------------------------------
 bool __cdecl DL2_FillVoids()
 {
 	int i; // eax
@@ -2913,7 +2887,6 @@ LABEL_177:
 	return DL2_NumNoChar() <= 700;
 }
 
-//----- (0040F9B1) --------------------------------------------------------
 bool __fastcall DL2_Cont(bool x1f, bool y1f, bool x2f, bool y2f)
 {
 	bool v4; // zf
@@ -2943,7 +2916,6 @@ LABEL_11:
 	return 0;
 }
 
-//----- (0040F9EE) --------------------------------------------------------
 int __cdecl DL2_NumNoChar()
 {
 	int result; // eax
@@ -2971,7 +2943,6 @@ int __cdecl DL2_NumNoChar()
 	return result;
 }
 
-//----- (0040FA10) --------------------------------------------------------
 void __fastcall DL2_DrawRoom(int x1, int y1, int x2, int y2)
 {
 	int v4; // ebx
@@ -3020,7 +2991,6 @@ void __fastcall DL2_DrawRoom(int x1, int y1, int x2, int y2)
 	}
 }
 
-//----- (0040FA97) --------------------------------------------------------
 void __fastcall DL2_KnockWalls(int x1, int y1, int x2, int y2)
 {
 	int v4; // esi
@@ -3076,7 +3046,6 @@ void __fastcall DL2_KnockWalls(int x1, int y1, int x2, int y2)
 	}
 }
 
-//----- (0040FB6C) --------------------------------------------------------
 void __cdecl DRLG_L2FloodTVal()
 {
 	int v0; // ebx
@@ -3114,7 +3083,6 @@ void __cdecl DRLG_L2FloodTVal()
 }
 // 5A5590: using guessed type char TransVal;
 
-//----- (0040FBDB) --------------------------------------------------------
 void __fastcall DRLG_L2FTVR(int i, int j, int x, int y, int d)
 {
 	int v5; // ebx
@@ -3220,7 +3188,6 @@ void __fastcall DRLG_L2FTVR(int i, int j, int x, int y, int d)
 }
 // 5A5590: using guessed type char TransVal;
 
-//----- (0040FDCB) --------------------------------------------------------
 void __cdecl DRLG_L2TransFix()
 {
 	signed int v0; // esi
@@ -3287,7 +3254,6 @@ void __cdecl DRLG_L2TransFix()
 	while ( v0 < 40 );
 }
 
-//----- (0040FE53) --------------------------------------------------------
 void __cdecl L2DirtFix()
 {
 	signed int v0; // ecx
@@ -3322,7 +3288,6 @@ void __cdecl L2DirtFix()
 	while ( v0 < 40 );
 }
 
-//----- (0040FEBF) --------------------------------------------------------
 void __cdecl DRLG_InitL2Vals()
 {
 	int v0; // edi

--- a/Source/drlg_l2.h
+++ b/Source/drlg_l2.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __DRLG_L2_H__
+#define __DRLG_L2_H__
 
-//drlg_l2
 extern int nSx1;
 extern int nSx2; // weak
 extern int nSy1;
@@ -168,3 +169,5 @@ extern unsigned char CTRDOOR6[];
 extern unsigned char CTRDOOR7[];
 extern unsigned char CTRDOOR8[];
 extern int Patterns[100][10];
+
+#endif /* __DRLG_L2_H__ */

--- a/Source/drlg_l3.cpp
+++ b/Source/drlg_l3.cpp
@@ -75,7 +75,6 @@ unsigned char L3SpawnTbl1[15] = { 0u, 10u, 67u, 5u, 44u, 6u, 9u, 0u, 0u, 28u, 13
 unsigned char L3SpawnTbl2[15] = { 0u, 10u, 3u, 5u, 12u, 6u, 9u, 0u, 0u, 12u, 3u, 6u, 9u, 10u, 5u }; /* local spawntable? */
 unsigned char L3PoolSub[15] = { 0u, 35u, 26u, 36u, 25u, 29u, 34u, 7u, 33u, 28u, 27u, 37u, 32u, 31u, 30u }; /* local poolsub? */
 
-//----- (0040FF81) --------------------------------------------------------
 void __cdecl AddFenceDoors()
 {
 	signed int v0; // esi
@@ -121,7 +120,6 @@ void __cdecl AddFenceDoors()
 	while ( v0 < 40 );
 }
 
-//----- (0040FFEC) --------------------------------------------------------
 void __cdecl FenceDoorFix()
 {
 	signed int v0; // edi
@@ -193,7 +191,6 @@ void __cdecl FenceDoorFix()
 	while ( v0 < 40 );
 }
 
-//----- (00410105) --------------------------------------------------------
 int __cdecl DRLG_L3Anvil()
 {
 	int v0; // esi
@@ -289,7 +286,6 @@ int __cdecl DRLG_L3Anvil()
 // 5CF330: using guessed type int setpc_h;
 // 5CF334: using guessed type int setpc_w;
 
-//----- (00410215) --------------------------------------------------------
 void __cdecl FixL3Warp()
 {
 	int v0; // ecx
@@ -327,7 +323,6 @@ void __cdecl FixL3Warp()
 	}
 }
 
-//----- (0041027D) --------------------------------------------------------
 void __cdecl FixL3HallofHeroes()
 {
 	signed int v0; // ecx
@@ -384,7 +379,6 @@ void __cdecl FixL3HallofHeroes()
 	while ( v3 < 40 );
 }
 
-//----- (004102F1) --------------------------------------------------------
 void __fastcall DRLG_L3LockRec(int x, int y)
 {
 	int v2; // esi
@@ -414,7 +408,6 @@ void __fastcall DRLG_L3LockRec(int x, int y)
 }
 // 528380: using guessed type int lockoutcnt;
 
-//----- (00410344) --------------------------------------------------------
 bool __cdecl DRLG_L3Lockout()
 {
 	int v0; // esi
@@ -456,7 +449,6 @@ bool __cdecl DRLG_L3Lockout()
 }
 // 528380: using guessed type int lockoutcnt;
 
-//----- (004103A1) --------------------------------------------------------
 void __fastcall CreateL3Dungeon(int rseed, int entry)
 {
 	int v2; // esi
@@ -502,7 +494,6 @@ void __fastcall CreateL3Dungeon(int rseed, int entry)
 // 5D2458: using guessed type int dminx;
 // 5D245C: using guessed type int dminy;
 
-//----- (0041044E) --------------------------------------------------------
 void __fastcall DRLG_L3(int entry)
 {
 	int x1; // esi
@@ -663,7 +654,6 @@ LABEL_24:
 }
 // 528378: using guessed type char lavapool;
 
-//----- (0041087F) --------------------------------------------------------
 void __cdecl InitL3Dungeon()
 {
 	int i; // edx
@@ -681,7 +671,6 @@ void __cdecl InitL3Dungeon()
 	}
 }
 
-//----- (004108B5) --------------------------------------------------------
 int __fastcall DRLG_L3FillRoom(int x1, int y1, int x2, int y2)
 {
 	int v4; // esi
@@ -796,7 +785,6 @@ LABEL_12:
 	return 1;
 }
 
-//----- (004109F0) --------------------------------------------------------
 void __fastcall DRLG_L3CreateBlock(int x, int y, int obs, int dir)
 {
 	int v4; // esi
@@ -919,7 +907,6 @@ void __fastcall DRLG_L3CreateBlock(int x, int y, int obs, int dir)
 	}
 }
 
-//----- (00410BC0) --------------------------------------------------------
 void __fastcall DRLG_L3FloorArea(int x1, int y1, int x2, int y2)
 {
 	int i; // esi
@@ -943,7 +930,6 @@ void __fastcall DRLG_L3FloorArea(int x1, int y1, int x2, int y2)
 	}
 }
 
-//----- (00410BF4) --------------------------------------------------------
 void __cdecl DRLG_L3FillDiags()
 {
 	signed int v0; // ebx
@@ -990,7 +976,6 @@ LABEL_11:
 	while ( v0 < 39 );
 }
 
-//----- (00410C65) --------------------------------------------------------
 void __cdecl DRLG_L3FillSingles()
 {
 	signed int v0; // ecx
@@ -1020,7 +1005,6 @@ void __cdecl DRLG_L3FillSingles()
 	while ( v0 < 39 );
 }
 
-//----- (00410CC4) --------------------------------------------------------
 void __cdecl DRLG_L3FillStraights()
 {
 	int v0; // esi
@@ -1242,7 +1226,6 @@ void __cdecl DRLG_L3FillStraights()
 	while ( v17 < 39 );
 }
 
-//----- (00410EDB) --------------------------------------------------------
 void __cdecl DRLG_L3Edges()
 {
 	char *v0; // eax
@@ -1257,7 +1240,6 @@ void __cdecl DRLG_L3Edges()
 	while ( (signed int)v0 < (signed int)&dungeon[40][39] );
 }
 
-//----- (00410EFC) --------------------------------------------------------
 int __cdecl DRLG_L3GetFloorArea()
 {
 	int gfa; // eax
@@ -1275,7 +1257,6 @@ int __cdecl DRLG_L3GetFloorArea()
 	return gfa;
 }
 
-//----- (00410F1F) --------------------------------------------------------
 void __cdecl DRLG_L3MakeMegas()
 {
 	signed int v0; // edi
@@ -1327,7 +1308,6 @@ LABEL_9:
 	while ( (signed int)v5 < (signed int)&dungeon[40][39] );
 }
 
-//----- (00410FAD) --------------------------------------------------------
 void __cdecl DRLG_L3River()
 {
 	signed int v0; // ebx
@@ -1763,7 +1743,6 @@ LABEL_148:
 // 410FAD: using guessed type int var_4E8[100];
 // 410FAD: using guessed type int var_358[98];
 
-//----- (00411614) --------------------------------------------------------
 void __cdecl DRLG_L3Pool()
 {
 	int v0; // ebx
@@ -1865,7 +1844,6 @@ void __cdecl DRLG_L3Pool()
 }
 // 528378: using guessed type char lavapool;
 
-//----- (00411772) --------------------------------------------------------
 int __fastcall DRLG_L3SpawnEdge(int x, int y, int *totarea)
 {
 	int *v3; // ebp
@@ -1936,7 +1914,6 @@ LABEL_18:
 	return 1;
 }
 
-//----- (0041189C) --------------------------------------------------------
 int __fastcall DRLG_L3Spawn(int x, int y, int *totarea)
 {
 	int v3; // edi
@@ -1970,7 +1947,6 @@ int __fastcall DRLG_L3Spawn(int x, int y, int *totarea)
 	return result;
 }
 
-//----- (004119E0) --------------------------------------------------------
 void __cdecl DRLG_L3PoolFix()
 {
 	signed int v0; // esi
@@ -2033,7 +2009,6 @@ void __cdecl DRLG_L3PoolFix()
 	while ( v0 < 40 );
 }
 
-//----- (00411A74) --------------------------------------------------------
 int __fastcall DRLG_L3PlaceMiniSet(unsigned char *miniset, int tmin, int tmax, int cx, int cy, bool setview, int ldir)
 {
 	int v7; // ebx
@@ -2207,7 +2182,6 @@ int __fastcall DRLG_L3PlaceMiniSet(unsigned char *miniset, int tmin, int tmax, i
 // 5CF320: using guessed type int LvlViewY;
 // 5CF324: using guessed type int LvlViewX;
 
-//----- (00411C83) --------------------------------------------------------
 void __fastcall DRLG_L3PlaceRndSet(unsigned char *miniset, int rndper)
 {
 	unsigned char *v2; // ebx
@@ -2345,7 +2319,6 @@ LABEL_33:
 	}
 }
 
-//----- (00411E0E) --------------------------------------------------------
 void __cdecl DRLG_L3Wood()
 {
 	char *v0; // edi
@@ -2649,7 +2622,6 @@ LABEL_112:
 	FenceDoorFix();
 }
 
-//----- (0041223E) --------------------------------------------------------
 bool __fastcall WoodVertU(int i, int y)
 {
 	int v2; // eax
@@ -2676,7 +2648,6 @@ bool __fastcall WoodVertU(int i, int y)
 	return result;
 }
 
-//----- (0041228A) --------------------------------------------------------
 bool __fastcall WoodVertD(int i, int y)
 {
 	int v2; // eax
@@ -2703,7 +2674,6 @@ bool __fastcall WoodVertD(int i, int y)
 	return result;
 }
 
-//----- (004122CE) --------------------------------------------------------
 bool __fastcall WoodHorizL(int x, int j)
 {
 	int v2; // eax
@@ -2730,7 +2700,6 @@ bool __fastcall WoodHorizL(int x, int j)
 	return result;
 }
 
-//----- (0041231A) --------------------------------------------------------
 bool __fastcall WoodHorizR(int x, int j)
 {
 	int v2; // eax
@@ -2757,7 +2726,6 @@ bool __fastcall WoodHorizR(int x, int j)
 	return result;
 }
 
-//----- (0041235E) --------------------------------------------------------
 void __cdecl DRLG_L3Pass3()
 {
 	int v0; // eax
@@ -2855,7 +2823,6 @@ void __cdecl DRLG_L3Pass3()
 	while ( v4 < 40 );
 }
 
-//----- (00412466) --------------------------------------------------------
 void __fastcall LoadL3Dungeon(char *sFileName, int vx, int vy)
 {
 	char *v3; // esi
@@ -2964,7 +2931,6 @@ void __fastcall LoadL3Dungeon(char *sFileName, int vx, int vy)
 // 5D2458: using guessed type int dminx;
 // 5D245C: using guessed type int dminy;
 
-//----- (004125B0) --------------------------------------------------------
 void __fastcall LoadPreL3Dungeon(char *sFileName, int vx, int vy)
 {
 	char *v3; // esi

--- a/Source/drlg_l3.h
+++ b/Source/drlg_l3.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __DRLG_L3_H__
+#define __DRLG_L3_H__
 
-//drlg_l3
 extern char lavapool; // weak
 extern int abyssx; // weak
 extern int lockoutcnt; // weak
@@ -82,3 +83,5 @@ extern unsigned char L3ANVIL[244];
 extern unsigned char L3SpawnTbl1[15]; /* local spawntable? */
 extern unsigned char L3SpawnTbl2[15]; /* local spawntable? */
 extern unsigned char L3PoolSub[15]; /* local poolsub? */
+
+#endif /* __DRLG_L3_H__ */

--- a/Source/drlg_l4.cpp
+++ b/Source/drlg_l4.cpp
@@ -295,7 +295,6 @@ unsigned char L4BTYPES[140] =
 	0,   0,   0,   0,   0,   0,   0,   0,   0,   0
 };
 
-//----- (00412655) --------------------------------------------------------
 void __cdecl DRLG_LoadL4SP()
 {
 	setloadflag_2 = 0;
@@ -313,7 +312,6 @@ void __cdecl DRLG_LoadL4SP()
 // 5B50D8: using guessed type int setloadflag_2;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (004126AD) --------------------------------------------------------
 void __cdecl DRLG_FreeL4SP()
 {
 	char *v0; // ecx
@@ -323,7 +321,6 @@ void __cdecl DRLG_FreeL4SP()
 	mem_free_dbg(v0);
 }
 
-//----- (004126BF) --------------------------------------------------------
 void __fastcall DRLG_L4SetSPRoom(int rx1, int ry1)
 {
 	int v2; // edi
@@ -376,7 +373,6 @@ void __fastcall DRLG_L4SetSPRoom(int rx1, int ry1)
 // 5CF330: using guessed type int setpc_h;
 // 5CF334: using guessed type int setpc_w;
 
-//----- (00412744) --------------------------------------------------------
 void __cdecl L4SaveQuads()
 {
 	char *v0; // esi
@@ -428,7 +424,6 @@ void __cdecl L4SaveQuads()
 // 528A34: using guessed type int l4holdx;
 // 528A38: using guessed type int l4holdy;
 
-//----- (004127D3) --------------------------------------------------------
 void __fastcall DRLG_L4SetRoom(unsigned char *pSetPiece, int rx1, int ry1)
 {
 	int v3; // ebx
@@ -475,7 +470,6 @@ void __fastcall DRLG_L4SetRoom(unsigned char *pSetPiece, int rx1, int ry1)
 	}
 }
 
-//----- (00412831) --------------------------------------------------------
 void __fastcall DRLG_LoadDiabQuads(bool preflag)
 {
 	bool v1; // esi
@@ -523,7 +517,6 @@ void __fastcall DRLG_LoadDiabQuads(bool preflag)
 // 528A34: using guessed type int l4holdx;
 // 528A38: using guessed type int l4holdy;
 
-//----- (00412933) --------------------------------------------------------
 bool __fastcall IsDURWall(char d)
 {
 	bool result; // al
@@ -535,7 +528,6 @@ bool __fastcall IsDURWall(char d)
 	return result;
 }
 
-//----- (00412948) --------------------------------------------------------
 bool __fastcall IsDLLWall(char dd)
 {
 	bool result; // al
@@ -547,7 +539,6 @@ bool __fastcall IsDLLWall(char dd)
 	return result;
 }
 
-//----- (0041295D) --------------------------------------------------------
 void __cdecl L4FixRim()
 {
 	char (*v0)[20]; // eax
@@ -567,7 +558,6 @@ void __cdecl L4FixRim()
 }
 // 52A4DC: using guessed type int dword_52A4DC;
 
-//----- (0041297B) --------------------------------------------------------
 void __cdecl DRLG_L4GeneralFix()
 {
 	signed int v0; // ecx
@@ -592,7 +582,6 @@ void __cdecl DRLG_L4GeneralFix()
 	while ( v0 < 39 );
 }
 
-//----- (004129B0) --------------------------------------------------------
 void __fastcall CreateL4Dungeon(int rseed, int entry)
 {
 	int v2; // esi
@@ -617,7 +606,6 @@ void __fastcall CreateL4Dungeon(int rseed, int entry)
 // 5D2458: using guessed type int dminx;
 // 5D245C: using guessed type int dminy;
 
-//----- (00412A00) --------------------------------------------------------
 void __fastcall DRLG_L4(int entry)
 {
 	signed int v1; // ebp
@@ -854,7 +842,6 @@ LABEL_31:
 // 5B50D8: using guessed type int setloadflag_2;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00412DDD) --------------------------------------------------------
 void __cdecl DRLG_L4Shadows()
 {
 	signed int v0; // esi
@@ -896,7 +883,6 @@ void __cdecl DRLG_L4Shadows()
 	while ( v0 < 40 );
 }
 
-//----- (00412E34) --------------------------------------------------------
 void __cdecl InitL4Dungeon()
 {
 	signed int v0; // edx
@@ -923,7 +909,6 @@ void __cdecl InitL4Dungeon()
 	while ( v0 < 40 );
 }
 
-//----- (00412E7B) --------------------------------------------------------
 void __cdecl L4makeDmt()
 {
 	signed int v0; // ecx
@@ -958,7 +943,6 @@ void __cdecl L4makeDmt()
 	while ( v0 <= 77 );
 }
 
-//----- (00412ECB) --------------------------------------------------------
 void __cdecl L4AddWall()
 {
 	int v0; // edi
@@ -1089,7 +1073,6 @@ void __cdecl L4AddWall()
 	while ( v0 < 40 );
 }
 
-//----- (004131C2) --------------------------------------------------------
 int __fastcall L4HWallOk(int i, int j)
 {
 	int v2; // esi
@@ -1145,7 +1128,6 @@ int __fastcall L4HWallOk(int i, int j)
 	return result;
 }
 
-//----- (00413270) --------------------------------------------------------
 int __fastcall L4VWallOk(int i, int j)
 {
 	int v2; // ecx
@@ -1196,7 +1178,6 @@ int __fastcall L4VWallOk(int i, int j)
 	return result;
 }
 
-//----- (0041330B) --------------------------------------------------------
 void __fastcall L4HorizWall(int i, int j, int dx)
 {
 	int v3; // esi
@@ -1254,7 +1235,6 @@ void __fastcall L4HorizWall(int i, int j, int dx)
 		*v12 = 59;
 }
 
-//----- (004133D6) --------------------------------------------------------
 void __fastcall L4VertWall(int i, int j, int dy)
 {
 	int v3; // edi
@@ -1310,7 +1290,6 @@ void __fastcall L4VertWall(int i, int j, int dy)
 		*(v10 - 41) = 55;
 }
 
-//----- (004134B4) --------------------------------------------------------
 void __cdecl L4tileFix()
 {
 	signed int v0; // edx
@@ -2296,7 +2275,6 @@ void __cdecl L4tileFix()
 	while ( v135 < 40 );
 }
 
-//----- (004142DD) --------------------------------------------------------
 void __cdecl DRLG_L4Subs()
 {
 	signed int v0; // edi
@@ -2361,7 +2339,6 @@ void __cdecl DRLG_L4Subs()
 	while ( v6 < 40 );
 }
 
-//----- (0041439A) --------------------------------------------------------
 void __cdecl L4makeDungeon()
 {
 	signed int v0; // ebx
@@ -2480,7 +2457,6 @@ void __cdecl L4makeDungeon()
 	while ( (signed int)v26 > (signed int)&dung[18][19] );
 }
 
-//----- (004144B1) --------------------------------------------------------
 void __cdecl uShape()
 {
 	int v0; // ecx
@@ -2599,7 +2575,6 @@ void __cdecl uShape()
 	while ( v11 );
 }
 
-//----- (004145E4) --------------------------------------------------------
 int __cdecl GetArea()
 {
 	int result; // eax
@@ -2627,7 +2602,6 @@ int __cdecl GetArea()
 	return result;
 }
 
-//----- (00414606) --------------------------------------------------------
 void __cdecl L4firstRoom()
 {
 	int v0; // esi
@@ -2698,7 +2672,6 @@ LABEL_10:
 // 528A48: using guessed type int SP4y2;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00414738) --------------------------------------------------------
 void __fastcall L4drawRoom(int x, int y, int width, int height)
 {
 	int i; // esi
@@ -2722,7 +2695,6 @@ void __fastcall L4drawRoom(int x, int y, int width, int height)
 	}
 }
 
-//----- (0041476F) --------------------------------------------------------
 void __fastcall L4roomGen(int x, int y, int w, int h, int dir)
 {
 	int v5; // eax
@@ -2836,7 +2808,6 @@ void __fastcall L4roomGen(int x, int y, int w, int h, int dir)
 	}
 }
 
-//----- (00414976) --------------------------------------------------------
 bool __fastcall L4checkRoom(int x, int y, int width, int height)
 {
 	int v4; // esi
@@ -2872,7 +2843,6 @@ LABEL_12:
 	return 0;
 }
 
-//----- (004149E2) --------------------------------------------------------
 bool __fastcall DRLG_L4PlaceMiniSet(unsigned char *miniset, int tmin, int tmax, int cx, int cy, int setview, int ldir)
 {
 	int v7; // ebx
@@ -3065,7 +3035,6 @@ bool __fastcall DRLG_L4PlaceMiniSet(unsigned char *miniset, int tmin, int tmax, 
 // 5CF320: using guessed type int LvlViewY;
 // 5CF324: using guessed type int LvlViewX;
 
-//----- (00414C44) --------------------------------------------------------
 void __cdecl DRLG_L4FloodTVal()
 {
 	int v0; // ebx
@@ -3103,7 +3072,6 @@ void __cdecl DRLG_L4FloodTVal()
 }
 // 5A5590: using guessed type char TransVal;
 
-//----- (00414CB3) --------------------------------------------------------
 void __fastcall DRLG_L4FTVR(int i, int j, int x, int y, int d)
 {
 	int v5; // ebx
@@ -3209,7 +3177,6 @@ void __fastcall DRLG_L4FTVR(int i, int j, int x, int y, int d)
 }
 // 5A5590: using guessed type char TransVal;
 
-//----- (00414EA3) --------------------------------------------------------
 void __cdecl DRLG_L4TransFix() /* check */
 {
 	signed int v0; // edi
@@ -3285,7 +3252,6 @@ void __cdecl DRLG_L4TransFix() /* check */
 	while ( v0 < 40 );
 }
 
-//----- (00414F5B) --------------------------------------------------------
 void __cdecl DRLG_L4Corners()
 {
 	signed int v0; // edx
@@ -3316,7 +3282,6 @@ void __cdecl DRLG_L4Corners()
 	while ( v0 < 39 );
 }
 
-//----- (00414F90) --------------------------------------------------------
 void __cdecl DRLG_L4Pass3()
 {
 	int v0; // eax

--- a/Source/drlg_l4.h
+++ b/Source/drlg_l4.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __DRLG_L4_H__
+#define __DRLG_L4_H__
 
-//drlg_l4
 extern int diabquad1x; // weak
 extern int diabquad1y; // weak
 extern int diabquad3x; // idb
@@ -64,3 +65,5 @@ extern unsigned char L4DSTAIRS[52];
 extern unsigned char L4PENTA[52];
 extern unsigned char L4PENTA2[52];
 extern unsigned char L4BTYPES[140];
+
+#endif /* __DRLG_L4_H__ */

--- a/Source/dthread.cpp
+++ b/Source/dthread.cpp
@@ -14,7 +14,6 @@ int dthread_inf = 0x7F800000; // weak
 /* rdata */
 static HANDLE sghThread = (HANDLE)0xFFFFFFFF; // idb
 
-//----- (0041509D) --------------------------------------------------------
 struct dthread_cpp_init_1
 {
 	dthread_cpp_init_1()
@@ -25,7 +24,6 @@ struct dthread_cpp_init_1
 // 47A460: using guessed type int dthread_inf;
 // 52A4E0: using guessed type int dthread_cpp_init_value;
 
-//----- (004150A8) --------------------------------------------------------
 struct dthread_cpp_init_2
 {
 	dthread_cpp_init_2()
@@ -35,25 +33,21 @@ struct dthread_cpp_init_2
 	}
 } _dthread_cpp_init_2;
 
-//----- (004150B2) --------------------------------------------------------
 void __cdecl dthread_init_mutex()
 {
 	InitializeCriticalSection(&sgMemCrit);
 }
 
-//----- (004150BE) --------------------------------------------------------
 void __cdecl dthread_cleanup_mutex_atexit()
 {
 	atexit(dthread_cleanup_mutex);
 }
 
-//----- (004150CA) --------------------------------------------------------
 void __cdecl dthread_cleanup_mutex()
 {
 	DeleteCriticalSection(&sgMemCrit);
 }
 
-//----- (004150D6) --------------------------------------------------------
 void __fastcall dthread_remove_player(int pnum)
 {
 	int v1; // edi
@@ -69,7 +63,6 @@ void __fastcall dthread_remove_player(int pnum)
 	LeaveCriticalSection(&sgMemCrit);
 }
 
-//----- (00415109) --------------------------------------------------------
 void __fastcall dthread_send_delta(int pnum, int cmd, void *pbSrc, int dwLen)
 {
 	char v4; // bl
@@ -105,7 +98,6 @@ void __fastcall dthread_send_delta(int pnum, int cmd, void *pbSrc, int dwLen)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00415186) --------------------------------------------------------
 void __cdecl dthread_start()
 {
 	char *v0; // eax
@@ -131,7 +123,6 @@ void __cdecl dthread_start()
 // 52A508: using guessed type char byte_52A508;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (004151F3) --------------------------------------------------------
 unsigned int __stdcall dthread_handler(void *a1)
 {
 	char *v1; // eax
@@ -171,7 +162,6 @@ unsigned int __stdcall dthread_handler(void *a1)
 // 52A508: using guessed type char byte_52A508;
 // 679730: using guessed type int gdwDeltaBytesSec;
 
-//----- (004152C0) --------------------------------------------------------
 void __cdecl dthread_cleanup()
 {
 	char *v0; // eax

--- a/Source/dthread.h
+++ b/Source/dthread.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __DTHREAD_H__
+#define __DTHREAD_H__
 
-//dthread
 extern int dthread_cpp_init_value; // weak
 extern unsigned int glpDThreadId; // idb
 extern TMegaPkt *sgpInfoHead; /* may not be right struct */
@@ -20,3 +21,5 @@ void __cdecl dthread_cleanup();
 
 /* data */
 extern int dthread_inf; // weak
+
+#endif /* __DTHREAD_H__ */

--- a/Source/dx.cpp
+++ b/Source/dx.cpp
@@ -17,7 +17,6 @@ HMODULE ghDiabMod; // idb
 
 int dx_inf = 0x7F800000; // weak
 
-//----- (00415367) --------------------------------------------------------
 struct dx_cpp_init_1
 {
 	dx_cpp_init_1()
@@ -28,7 +27,6 @@ struct dx_cpp_init_1
 // 47A464: using guessed type int dx_inf;
 // 52A514: using guessed type int dx_cpp_init_value;
 
-//----- (00415372) --------------------------------------------------------
 struct dx_cpp_init_2
 {
 	dx_cpp_init_2()
@@ -38,25 +36,21 @@ struct dx_cpp_init_2
 	}
 } _dx_cpp_init_2;
 
-//----- (0041537C) --------------------------------------------------------
 void __cdecl dx_init_mutex()
 {
 	InitializeCriticalSection(&sgMemCrit);
 }
 
-//----- (00415388) --------------------------------------------------------
 void __cdecl dx_cleanup_mutex_atexit()
 {
 	atexit(dx_cleanup_mutex);
 }
 
-//----- (00415394) --------------------------------------------------------
 void __cdecl dx_cleanup_mutex()
 {
 	DeleteCriticalSection(&sgMemCrit);
 }
 
-//----- (004153A0) --------------------------------------------------------
 void __fastcall dx_init(HWND hWnd)
 {
 	HWND v1; // esi
@@ -106,7 +100,6 @@ void __fastcall dx_init(HWND hWnd)
 // 484364: using guessed type int fullscreen;
 // 52A549: using guessed type char gbEmulate;
 
-//----- (004154B5) --------------------------------------------------------
 void __cdecl dx_create_back_buffer()
 {
 	int v0; // eax
@@ -149,7 +142,6 @@ void __cdecl dx_create_back_buffer()
 }
 // 52A548: using guessed type char gbBackBuf;
 
-//----- (004155C2) --------------------------------------------------------
 void __cdecl dx_create_primary_surface()
 {
 	int v0; // eax
@@ -164,7 +156,6 @@ void __cdecl dx_create_primary_surface()
 		TermDlg(104, v0, "C:\\Src\\Diablo\\Source\\dx.cpp", 109);
 }
 
-//----- (0041561A) --------------------------------------------------------
 HRESULT __fastcall dx_DirectDrawCreate(GUID *guid, IDirectDraw **DD, void *unknown)
 {
 	IDirectDraw **v3; // ebp
@@ -193,7 +184,6 @@ HRESULT __fastcall dx_DirectDrawCreate(GUID *guid, IDirectDraw **DD, void *unkno
 	return ((int (__stdcall *)(GUID *, IDirectDraw **, void *))v5)(v8, v3, unknown);
 }
 
-//----- (0041569A) --------------------------------------------------------
 void __cdecl dx_lock_mutex()
 {
 	Screen *v0; // eax
@@ -225,7 +215,6 @@ LABEL_9:
 }
 // 69CF0C: using guessed type int screen_buf_end;
 
-//----- (00415725) --------------------------------------------------------
 void __cdecl dx_unlock_mutex()
 {
 	Screen *v0; // eax
@@ -251,7 +240,6 @@ void __cdecl dx_unlock_mutex()
 }
 // 69CF0C: using guessed type int screen_buf_end;
 
-//----- (004157A0) --------------------------------------------------------
 void __cdecl dx_cleanup()
 {
 	void *v0; // ecx
@@ -291,7 +279,6 @@ void __cdecl dx_cleanup()
 	}
 }
 
-//----- (00415848) --------------------------------------------------------
 void __cdecl dx_reinit()
 {
 	int v0; // esi

--- a/Source/dx.h
+++ b/Source/dx.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __DX_H__
+#define __DX_H__
 
-//dx
 extern void *sgpBackBuf;
 extern int dx_cpp_init_value; // weak
 extern IDirectDraw *lpDDInterface;
@@ -33,3 +34,5 @@ void __cdecl j_dx_reinit();
 /* data */
 
 extern int dx_inf; // weak
+
+#endif /* __DX_H__ */

--- a/Source/effects.cpp
+++ b/Source/effects.cpp
@@ -875,7 +875,6 @@ TSFX sgSFX[858] =
   { 1u, "Sfx\\Monsters\\DiabloD.wav", NULL }
 };
 
-//----- (004158AE) --------------------------------------------------------
 struct effects_cpp_init
 {
 	effects_cpp_init()
@@ -886,7 +885,6 @@ struct effects_cpp_init
 // 47A468: using guessed type int effects_inf;
 // 52A550: using guessed type int effects_cpp_init_value;
 
-//----- (004158B9) --------------------------------------------------------
 bool __fastcall effect_is_playing(int nSFX)
 {
 	TSFX *v1; // eax
@@ -901,7 +899,6 @@ bool __fastcall effect_is_playing(int nSFX)
 	return 0;
 }
 
-//----- (004158E2) --------------------------------------------------------
 void __cdecl sfx_stop()
 {
 	if ( sfx_stream )
@@ -913,7 +910,6 @@ void __cdecl sfx_stop()
 	}
 }
 
-//----- (0041590B) --------------------------------------------------------
 void __fastcall InitMonsterSND(int monst)
 {
 	signed int v1; // ebx
@@ -964,7 +960,6 @@ void __fastcall InitMonsterSND(int monst)
 	}
 }
 
-//----- (004159DB) --------------------------------------------------------
 void __cdecl FreeEffects()
 {
 	TSnd **v0; // esi
@@ -1011,7 +1006,6 @@ void __cdecl FreeEffects()
 	}
 }
 
-//----- (00415A45) --------------------------------------------------------
 void __fastcall PlayEffect(int i, int mode)
 {
 	int v2; // edi
@@ -1056,7 +1050,6 @@ void __fastcall PlayEffect(int i, int mode)
 // 4A22D5: using guessed type char gbSoundOn;
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (00415AE1) --------------------------------------------------------
 int __fastcall calc_snd_position(int x, int y, int *plVolume, int *plPan)
 {
 	int v4; // edi
@@ -1082,7 +1075,6 @@ int __fastcall calc_snd_position(int x, int y, int *plVolume, int *plPan)
 	return 1;
 }
 
-//----- (00415B59) --------------------------------------------------------
 void __fastcall PlaySFX(int psfx)
 {
 	int v1; // eax
@@ -1091,7 +1083,6 @@ void __fastcall PlaySFX(int psfx)
 	PlaySFX_priv(&sgSFX[v1], 0, 0, 0);
 }
 
-//----- (00415B71) --------------------------------------------------------
 void __fastcall PlaySFX_priv(TSFX *pSFX, char loc, int x, int y)
 {
 	int v4; // edi
@@ -1141,7 +1132,6 @@ void __fastcall PlaySFX_priv(TSFX *pSFX, char loc, int x, int y)
 // 676194: using guessed type char gbBufferMsgs;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00415C2A) --------------------------------------------------------
 void __fastcall stream_play(TSFX *pSFX, int lVolume, int lPan)
 {
 	int v3; // esi
@@ -1174,7 +1164,6 @@ void __fastcall stream_play(TSFX *pSFX, int lVolume, int lPan)
 	}
 }
 
-//----- (00415C97) --------------------------------------------------------
 int __fastcall RndSFX(int psfx)
 {
 	int v1; // esi
@@ -1209,7 +1198,6 @@ LABEL_19:
 	return psfx;
 }
 
-//----- (00415D01) --------------------------------------------------------
 void __fastcall PlaySfxLoc(int psfx, int x, int y)
 {
 	int v3; // esi
@@ -1227,7 +1215,6 @@ void __fastcall PlaySfxLoc(int psfx, int x, int y)
 	PlaySFX_priv(&sgSFX[v4], 1, v3, y);
 }
 
-//----- (00415D39) --------------------------------------------------------
 void __cdecl FreeMonsterSnd()
 {
 	TSnd **v0; // esi
@@ -1267,7 +1254,6 @@ void __cdecl FreeMonsterSnd()
 	}
 }
 
-//----- (00415D9A) --------------------------------------------------------
 void __cdecl sound_stop()
 {
 	int i; // edi
@@ -1279,7 +1265,6 @@ void __cdecl sound_stop()
 	}
 }
 
-//----- (00415DBA) --------------------------------------------------------
 void __cdecl sound_update()
 {
 	//int v0; // ebp
@@ -1308,7 +1293,6 @@ void __cdecl sound_update()
 }
 // 415DBA: could not find valid save-restore pair for ebp
 
-//----- (00415DFF) --------------------------------------------------------
 void __cdecl effects_cleanup_sfx()
 {
 	unsigned int v0; // edi
@@ -1329,7 +1313,6 @@ void __cdecl effects_cleanup_sfx()
 	while ( v0 < 858 );
 }
 
-//----- (00415E2A) --------------------------------------------------------
 void __cdecl stream_update()
 {
 	char v0; // bl
@@ -1367,7 +1350,6 @@ void __cdecl stream_update()
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00415E77) --------------------------------------------------------
 void __fastcall priv_sound_init(int bLoadMask)
 {
 	unsigned char v1; // bl
@@ -1401,13 +1383,11 @@ void __fastcall priv_sound_init(int bLoadMask)
 	}
 }
 
-//----- (00415ED8) --------------------------------------------------------
 void __cdecl sound_init()
 {
 	priv_sound_init(4);
 }
 
-//----- (00415EDF) --------------------------------------------------------
 void __stdcall effects_play_sound(char *snd_file)
 {
 	int v1; // edi

--- a/Source/effects.h
+++ b/Source/effects.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __EFFECTS_H__
+#define __EFFECTS_H__
 
-//effects
 extern int effects_cpp_init_value; // weak
 extern int sfxdelay; // weak
 extern int sfxdnum;
@@ -36,3 +37,5 @@ extern char monster_action_sounds[]; // idb
 /* rdata */
 
 extern TSFX sgSFX[858];
+
+#endif /* __EFFECTS_H__ */

--- a/Source/encrypt.cpp
+++ b/Source/encrypt.cpp
@@ -4,7 +4,6 @@
 
 int encrypt_table[1280];
 
-//----- (00415F43) --------------------------------------------------------
 void __fastcall encrypt_decrypt_block(void *block, int size, int key) // DecryptMPQBlock
 {
 	unsigned int v3; // edx
@@ -34,7 +33,6 @@ void __fastcall encrypt_decrypt_block(void *block, int size, int key) // Decrypt
 	}
 }
 
-//----- (00415F8F) --------------------------------------------------------
 void __fastcall encrypt_encrypt_block(void *block, int size, int key) // EncryptMPQBlock
 {
 	unsigned int v3; // edx
@@ -64,7 +62,6 @@ void __fastcall encrypt_encrypt_block(void *block, int size, int key) // Encrypt
 	}
 }
 
-//----- (00415FDF) --------------------------------------------------------
 int __fastcall encrypt_hash(char *s, int type) // HashStringSlash
 {
 	int v2; // ebp
@@ -88,7 +85,6 @@ int __fastcall encrypt_hash(char *s, int type) // HashStringSlash
 	return v4;
 }
 
-//----- (0041602E) --------------------------------------------------------
 void __cdecl encrypt_init_lookup_table() // InitScratchSpace
 {
 	unsigned int v0; // eax
@@ -119,7 +115,6 @@ void __cdecl encrypt_init_lookup_table() // InitScratchSpace
 	while ( (signed int)v5 < (signed int)&encrypt_table[256] );
 }
 
-//----- (0041609D) --------------------------------------------------------
 int __fastcall encrypt_compress(void *buf, int size) // MPQCompress_PKWare
 {
 	unsigned char *v2; // ebx
@@ -162,7 +157,6 @@ int __fastcall encrypt_compress(void *buf, int size) // MPQCompress_PKWare
 	return (int)v3;
 }
 
-//----- (00416133) --------------------------------------------------------
 unsigned int __cdecl encrypt_pkware_read(char *buf, unsigned int *size, void *param) // ReadPKWare
 {
 	TDataInfo * pInfo = (TDataInfo *)param;
@@ -178,7 +172,6 @@ unsigned int __cdecl encrypt_pkware_read(char *buf, unsigned int *size, void *pa
 	return v3;
 }
 
-//----- (00416167) --------------------------------------------------------
 void __cdecl encrypt_pkware_write(char *buf, unsigned int *size, void *param) // WritePKWare
 {
 	TDataInfo * pInfo = (TDataInfo *)param;
@@ -187,7 +180,6 @@ void __cdecl encrypt_pkware_write(char *buf, unsigned int *size, void *param) //
 	pInfo->pbOutBuffEnd += *size;
 }
 
-//----- (0041618E) --------------------------------------------------------
 void __fastcall encrypt_decompress(void *param, int recv_size, int dwMaxBytes) // MPQDecompress_PKWare
 {
 	unsigned char *v3; // edi

--- a/Source/encrypt.h
+++ b/Source/encrypt.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __ENCRYPT_H__
+#define __ENCRYPT_H__
 
-//encrypt
 extern int encrypt_table[1280];
 //int encrypt_52B564[257];
 
@@ -12,3 +13,5 @@ int __fastcall encrypt_compress(void *buf, int size);
 unsigned int __cdecl encrypt_pkware_read(char *buf, unsigned int *size, void *param);
 void __cdecl encrypt_pkware_write(char *buf, unsigned int *size, void *param);
 void __fastcall encrypt_decompress(void *param, int recv_size, int dwMaxBytes);
+
+#endif /* __ENCRYPT_H__ */

--- a/Source/engine.cpp
+++ b/Source/engine.cpp
@@ -14,7 +14,6 @@ int dword_52B99C; // bool valid - if x/y are in bounds
 
 int engine_inf = 0x7F800000; // weak
 
-//----- (00416201) --------------------------------------------------------
 struct engine_cpp_init_1
 {
 	engine_cpp_init_1()
@@ -25,7 +24,6 @@ struct engine_cpp_init_1
 // 47A474: using guessed type int engine_inf;
 // 52B968: using guessed type int engine_cpp_init_value;
 
-//----- (0041620C) --------------------------------------------------------
 void __fastcall CelDrawDatOnly(char *pDecodeTo, char *pRLEBytes, int dwRLESize, int dwRLEWdt)
 {
 	char *v4; // esi
@@ -88,7 +86,6 @@ LABEL_14:
 	}
 }
 
-//----- (00416274) --------------------------------------------------------
 void __fastcall CelDecodeOnly(int screen_x, int screen_y, void *pCelBuff, int frame, int frame_width)
 {
 	if ( gpBuffer )
@@ -102,7 +99,6 @@ void __fastcall CelDecodeOnly(int screen_x, int screen_y, void *pCelBuff, int fr
 	}
 }
 
-//----- (004162B8) --------------------------------------------------------
 void __fastcall CelDecDatOnly(char *pBuff, char *pCelBuff, int frame, int frame_width)
 {
 	if ( pCelBuff )
@@ -116,7 +112,6 @@ void __fastcall CelDecDatOnly(char *pBuff, char *pCelBuff, int frame, int frame_
 	}
 }
 
-//----- (004162DE) --------------------------------------------------------
 void __fastcall CelDrawHdrOnly(int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width, int always_0, int direction)
 {
 	int v7; // edx
@@ -151,7 +146,6 @@ void __fastcall CelDrawHdrOnly(int screen_x, int screen_y, char *pCelBuff, int f
 	}
 }
 
-//----- (00416359) --------------------------------------------------------
 void __fastcall CelDecodeHdrOnly(char *pBuff, char *pCelBuff, int frame, int frame_width, int always_0, int direction)
 {
 	int v6; // esi
@@ -180,7 +174,6 @@ void __fastcall CelDecodeHdrOnly(char *pBuff, char *pCelBuff, int frame, int fra
 	}
 }
 
-//----- (004163AC) --------------------------------------------------------
 void __fastcall CelDecDatLightOnly(char *pDecodeTo, char *pRLEBytes, int frame_content_size, int frame_width)
 {
 	char *v4; // esi
@@ -225,7 +218,6 @@ LABEL_9:
 }
 // 69BEF8: using guessed type int light_table_index;
 
-//----- (00416423) --------------------------------------------------------
 void __fastcall CelDecDatLightEntry(int a1, char *a2, char *a3, char *v6)
 {
 	int v4; // ebx
@@ -278,7 +270,6 @@ void __fastcall CelDecDatLightEntry(int a1, char *a2, char *a3, char *v6)
 	}
 }
 
-//----- (00416488) --------------------------------------------------------
 void __fastcall CelDecDatLightTrans(char *pDecodeTo, char *pRLEBytes, int frame_content_size, int frame_width)
 {
 	char *v4; // esi
@@ -424,7 +415,6 @@ LABEL_23:
 }
 // 69BEF8: using guessed type int light_table_index;
 
-//----- (00416565) --------------------------------------------------------
 void __fastcall CelDecodeLightOnly(int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width)
 {
 	int v5; // ebx
@@ -448,7 +438,6 @@ void __fastcall CelDecodeLightOnly(int screen_x, int screen_y, char *pCelBuff, i
 }
 // 69BEF8: using guessed type int light_table_index;
 
-//----- (004165BD) --------------------------------------------------------
 void __fastcall CelDecodeHdrLightOnly(int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width, int always_0, int direction)
 {
 	int v7; // esi
@@ -491,7 +480,6 @@ void __fastcall CelDecodeHdrLightOnly(int screen_x, int screen_y, char *pCelBuff
 }
 // 69BEF8: using guessed type int light_table_index;
 
-//----- (0041664B) --------------------------------------------------------
 void __fastcall CelDecodeHdrLightTrans(char *pBuff, char *pCelBuff, int frame, int frame_width, int always_0, int direction)
 {
 	char *v6; // eax
@@ -537,7 +525,6 @@ void __fastcall CelDecodeHdrLightTrans(char *pBuff, char *pCelBuff, int frame, i
 // 69BEF8: using guessed type int light_table_index;
 // 69CF94: using guessed type int cel_transparency_active;
 
-//----- (004166BF) --------------------------------------------------------
 void __fastcall CelDrawHdrLightRed(int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width, int always_0, int direction, char always_1)
 {
 	char *v8; // esi
@@ -633,7 +620,6 @@ LABEL_20:
 }
 // 525728: using guessed type int light4flag;
 
-//----- (004167DB) --------------------------------------------------------
 void __fastcall Cel2DecDatOnly(char *pDecodeTo, char *pRLEBytes, int frame_content_size, int frame_width)
 {
 	char *v4; // esi
@@ -697,7 +683,6 @@ LABEL_17:
 }
 // 69CF0C: using guessed type int screen_buf_end;
 
-//----- (0041685A) --------------------------------------------------------
 void __fastcall Cel2DrawHdrOnly(int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width, int a6, int direction)
 {
 	int v7; // edx
@@ -732,7 +717,6 @@ void __fastcall Cel2DrawHdrOnly(int screen_x, int screen_y, char *pCelBuff, int 
 	}
 }
 
-//----- (004168D5) --------------------------------------------------------
 void __fastcall Cel2DecodeHdrOnly(char *pBuff, char *pCelBuff, int frame, int frame_width, int a5, int direction)
 {
 	int v6; // edi
@@ -765,7 +749,6 @@ void __fastcall Cel2DecodeHdrOnly(char *pBuff, char *pCelBuff, int frame, int fr
 	}
 }
 
-//----- (0041692A) --------------------------------------------------------
 void __fastcall Cel2DecDatLightOnly(char *pDecodeTo, char *pRLEBytes, int frame_content_size, int frame_width)
 {
 	char *v4; // esi
@@ -819,7 +802,6 @@ LABEL_13:
 // 69BEF8: using guessed type int light_table_index;
 // 69CF0C: using guessed type int screen_buf_end;
 
-//----- (004169BC) --------------------------------------------------------
 void __fastcall Cel2DecDatLightEntry(int a1, int a2)
 {
 	int v2; // ebx
@@ -873,7 +855,6 @@ void __fastcall Cel2DecDatLightEntry(int a1, int a2)
 	}
 }
 
-//----- (00416A21) --------------------------------------------------------
 void __fastcall Cel2DecDatLightTrans(char *pDecodeTo, char *pRLEBytes, int frame_content_size, int frame_width)
 {
 	char *v4; // esi
@@ -1028,7 +1009,6 @@ LABEL_26:
 // 69BEF8: using guessed type int light_table_index;
 // 69CF0C: using guessed type int screen_buf_end;
 
-//----- (00416B19) --------------------------------------------------------
 void __fastcall Cel2DecodeHdrLight(int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width, int a6, int direction)
 {
 	int v7; // esi
@@ -1075,7 +1055,6 @@ void __fastcall Cel2DecodeHdrLight(int screen_x, int screen_y, char *pCelBuff, i
 }
 // 69BEF8: using guessed type int light_table_index;
 
-//----- (00416BA9) --------------------------------------------------------
 void __fastcall Cel2DecodeLightTrans(char *dst_buf, char *pCelBuff, int frame, int frame_width, int a5, int direction)
 {
 	char *v6; // eax
@@ -1122,7 +1101,6 @@ void __fastcall Cel2DecodeLightTrans(char *dst_buf, char *pCelBuff, int frame, i
 // 69BEF8: using guessed type int light_table_index;
 // 69CF94: using guessed type int cel_transparency_active;
 
-//----- (00416C1B) --------------------------------------------------------
 void __fastcall Cel2DrawHdrLightRed(int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width, int always_0, int direction, char always_1)
 {
 	char *v8; // esi
@@ -1225,7 +1203,6 @@ LABEL_21:
 // 525728: using guessed type int light4flag;
 // 69CF0C: using guessed type int screen_buf_end;
 
-//----- (00416D3C) --------------------------------------------------------
 void __fastcall CelDecodeRect(char *pBuff, int always_0, int dst_height, int dst_width, char *pCelBuff, int frame, int frame_width)
 {
 	char *v7; // ebx
@@ -1292,7 +1269,6 @@ LABEL_14:
 	}
 }
 
-//----- (00416DC6) --------------------------------------------------------
 void __fastcall CelDecodeClr(char colour, int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width, int a7, int direction)
 {
 	char *v8; // ebx
@@ -1371,7 +1347,6 @@ LABEL_20:
 	}
 }
 
-//----- (00416EC0) --------------------------------------------------------
 void __fastcall CelDrawHdrClrHL(char colour, int screen_x, int screen_y, char *pCelBuff, int frame, int frame_width, int a7, int direction)
 {
 	char *v8; // ebx
@@ -1481,7 +1456,6 @@ LABEL_28:
 }
 // 69CF0C: using guessed type int screen_buf_end;
 
-//----- (00416FEF) --------------------------------------------------------
 void __fastcall ENG_set_pixel(int screen_x, int screen_y, char pixel)
 {
 	char *v3; // edi
@@ -1495,7 +1469,6 @@ void __fastcall ENG_set_pixel(int screen_x, int screen_y, char pixel)
 }
 // 69CF0C: using guessed type int screen_buf_end;
 
-//----- (00417034) --------------------------------------------------------
 void __fastcall engine_draw_pixel(int x, int y)
 {
 	_BYTE *v2; // eax
@@ -1522,7 +1495,6 @@ LABEL_14:
 // 52B99C: using guessed type int dword_52B99C;
 // 69CF0C: using guessed type int screen_buf_end;
 
-//----- (004170BD) --------------------------------------------------------
 void __fastcall engine_draw_automap_pixels(int x1, int y1, int x2, int y2, char a5)
 {
 	int v5; // edi
@@ -1821,7 +1793,6 @@ LABEL_65:
 // 52B970: using guessed type int dword_52B970;
 // 52B99C: using guessed type int dword_52B99C;
 
-//----- (004174B3) --------------------------------------------------------
 int __fastcall GetDirection(int x1, int y1, int x2, int y2)
 {
 	int v4; // esi
@@ -1875,7 +1846,6 @@ int __fastcall GetDirection(int x1, int y1, int x2, int y2)
 	return result;
 }
 
-//----- (00417518) --------------------------------------------------------
 void __fastcall SetRndSeed(int s)
 {
 	SeedCount = 0;
@@ -1886,7 +1856,6 @@ void __fastcall SetRndSeed(int s)
 // 52B97C: using guessed type int sglGameSeed;
 // 52B998: using guessed type int SeedCount;
 
-//----- (0041752C) --------------------------------------------------------
 int __cdecl GetRndSeed()
 {
 	++SeedCount;
@@ -1896,7 +1865,6 @@ int __cdecl GetRndSeed()
 // 52B97C: using guessed type int sglGameSeed;
 // 52B998: using guessed type int SeedCount;
 
-//----- (0041754B) --------------------------------------------------------
 int __fastcall random(int idx, int v)
 {
 	int v2; // esi
@@ -1911,7 +1879,6 @@ int __fastcall random(int idx, int v)
 	return v4 % v2;
 }
 
-//----- (0041756D) --------------------------------------------------------
 struct engine_cpp_init_2
 {
 	engine_cpp_init_2()
@@ -1921,25 +1888,21 @@ struct engine_cpp_init_2
 	}
 } _engine_cpp_init_2;
 
-//----- (00417577) --------------------------------------------------------
 void __cdecl mem_init_mutex()
 {
 	InitializeCriticalSection(&sgMemCrit);
 }
 
-//----- (00417583) --------------------------------------------------------
 void __cdecl mem_atexit_mutex()
 {
 	atexit(mem_free_mutex);
 }
 
-//----- (0041758F) --------------------------------------------------------
 void __cdecl mem_free_mutex()
 {
 	DeleteCriticalSection(&sgMemCrit);
 }
 
-//----- (0041759B) --------------------------------------------------------
 void *__fastcall DiabloAllocPtr(int dwBytes)
 {
 	int v1; // ebx
@@ -1958,7 +1921,6 @@ void *__fastcall DiabloAllocPtr(int dwBytes)
 	return v2;
 }
 
-//----- (004175E8) --------------------------------------------------------
 void __fastcall mem_free_dbg(void *ptr)
 {
 	void *v1; // edi
@@ -1972,7 +1934,6 @@ void __fastcall mem_free_dbg(void *ptr)
 	}
 }
 
-//----- (00417618) --------------------------------------------------------
 unsigned char *__fastcall LoadFileInMem(char *pszName, int *pdwFileLen)
 {
 	int *v2; // edi
@@ -1997,7 +1958,6 @@ unsigned char *__fastcall LoadFileInMem(char *pszName, int *pdwFileLen)
 	return (unsigned char *)v6;
 }
 
-//----- (00417673) --------------------------------------------------------
 void __fastcall LoadFileWithMem(char *pszName, void *buf)
 {
 	char *v2; // ebx
@@ -2017,7 +1977,6 @@ void __fastcall LoadFileWithMem(char *pszName, void *buf)
 	WCloseFile(a1);
 }
 
-//----- (004176D2) --------------------------------------------------------
 void __fastcall Cl2ApplyTrans(char *p, char *ttbl, int last_frame)
 {
 	int v3; // eax
@@ -2069,7 +2028,6 @@ void __fastcall Cl2ApplyTrans(char *p, char *ttbl, int last_frame)
 	}
 }
 
-//----- (00417745) --------------------------------------------------------
 void __fastcall Cl2DecodeFrm1(int x, int y, char *pCelBuff, int nCel, int width, int dir1, int dir2)
 {
 	char *v8; // edx
@@ -2103,7 +2061,6 @@ void __fastcall Cl2DecodeFrm1(int x, int y, char *pCelBuff, int nCel, int width,
 	}
 }
 
-//----- (004177BF) --------------------------------------------------------
 void __fastcall Cl2DecDatFrm1(char *buffer, char *frame_content, int a3, int width) /* fix */
 {
 	char *v4; // esi
@@ -2189,7 +2146,6 @@ void __fastcall Cl2DecDatFrm1(char *buffer, char *frame_content, int a3, int wid
 	while ( v8 );
 }
 
-//----- (00417847) --------------------------------------------------------
 void __fastcall Cl2DecodeFrm2(char colour, int screen_x, int screen_y, char *pCelBuff, int nCel, int frame_width, int a7, int a8)
 {
 	int v8; // ebx
@@ -2222,7 +2178,6 @@ void __fastcall Cl2DecodeFrm2(char colour, int screen_x, int screen_y, char *pCe
 	}
 }
 
-//----- (004178C5) --------------------------------------------------------
 void __fastcall Cl2DecDatFrm2(char *buffer, char *frame_content, int a3, int frame_width, char colour)
 {
 	char *v5; // esi
@@ -2320,7 +2275,6 @@ LABEL_12:
 	while ( v9 );
 }
 
-//----- (00417981) --------------------------------------------------------
 void __fastcall Cl2DecodeFrm3(int screen_x, int screen_y, char *pCelBuff, int nCel, int frame_width, int a6, int a7, char a8)
 {
 	char *v8; // edi
@@ -2371,7 +2325,6 @@ void __fastcall Cl2DecodeFrm3(int screen_x, int screen_y, char *pCelBuff, int nC
 }
 // 525728: using guessed type int light4flag;
 
-//----- (00417A44) --------------------------------------------------------
 void __fastcall Cl2DecDatLightTbl1(char *a1, char *a2, int a3, int a4, char *unused_lindex) /* check 5th arg */
 {
 	char *v5; // esi
@@ -2460,7 +2413,6 @@ void __fastcall Cl2DecDatLightTbl1(char *a1, char *a2, int a3, int a4, char *unu
 }
 // 52B978: using guessed type int sgnWidth;
 
-//----- (00417AE9) --------------------------------------------------------
 void __fastcall Cl2DecodeLightTbl(int screen_x, int screen_y, char *pCelBuff, int nCel, int frame_width, int a6, int a7)
 {
 	int v7; // esi
@@ -2509,7 +2461,6 @@ void __fastcall Cl2DecodeLightTbl(int screen_x, int screen_y, char *pCelBuff, in
 }
 // 69BEF8: using guessed type int light_table_index;
 
-//----- (00417B83) --------------------------------------------------------
 void __fastcall Cl2DecodeFrm4(int screen_x, int screen_y, char *pCelBuff, int nCel, int frame_width, int a6, int a7)
 {
 	int v7; // ebx
@@ -2547,7 +2498,6 @@ void __fastcall Cl2DecodeFrm4(int screen_x, int screen_y, char *pCelBuff, int nC
 	}
 }
 
-//----- (00417BFD) --------------------------------------------------------
 void __fastcall Cl2DecDatFrm4(char *buffer, char *a2, int a3, int frame_width)
 {
 	char *v4; // esi
@@ -2641,7 +2591,6 @@ LABEL_12:
 }
 // 69CF0C: using guessed type int screen_buf_end;
 
-//----- (00417C99) --------------------------------------------------------
 void __fastcall Cl2DecodeClrHL(char colour, int screen_x, int screen_y, char *pCelBuff, int nCel, int frame_width, int a7, int a8)
 {
 	int v8; // ebx
@@ -2681,7 +2630,6 @@ void __fastcall Cl2DecodeClrHL(char colour, int screen_x, int screen_y, char *pC
 }
 // 69CF0C: using guessed type int screen_buf_end;
 
-//----- (00417D28) --------------------------------------------------------
 void __fastcall Cl2DecDatClrHL(char *dst_buf, char *frame_content, int a3, int frame_width, char colour)
 {
 	char *v5; // esi
@@ -2787,7 +2735,6 @@ LABEL_15:
 }
 // 69CF0C: using guessed type int screen_buf_end;
 
-//----- (00417DF8) --------------------------------------------------------
 void __fastcall Cl2DecodeFrm5(int screen_x, int screen_y, char *pCelBuff, int nCel, int frame_width, int a6, int a7, char a8)
 {
 	char *v8; // edi
@@ -2838,7 +2785,6 @@ void __fastcall Cl2DecodeFrm5(int screen_x, int screen_y, char *pCelBuff, int nC
 }
 // 525728: using guessed type int light4flag;
 
-//----- (00417EBB) --------------------------------------------------------
 void __fastcall Cl2DecDatLightTbl2(char *dst_buf, char *a2, int a3, int frame_width, char *a5) /* check 5th arg */
 {
 	char *v5; // esi
@@ -2935,7 +2881,6 @@ LABEL_12:
 // 52B978: using guessed type int sgnWidth;
 // 69CF0C: using guessed type int screen_buf_end;
 
-//----- (00417F78) --------------------------------------------------------
 void __fastcall Cl2DecodeFrm6(int screen_x, int screen_y, char *pCelBuff, int nCel, int frame_width, int a6, int a7)
 {
 	int v7; // esi
@@ -2979,7 +2924,6 @@ void __fastcall Cl2DecodeFrm6(int screen_x, int screen_y, char *pCelBuff, int nC
 }
 // 69BEF8: using guessed type int light_table_index;
 
-//----- (00418012) --------------------------------------------------------
 void __fastcall PlayInGameMovie(char *pszMovie)
 {
 	char *v1; // esi

--- a/Source/engine.h
+++ b/Source/engine.h
@@ -1,9 +1,10 @@
 //HEADER_GOES_HERE
+#ifndef __ENGINE_H__
+#define __ENGINE_H__
 
 //offset 0
 //pCelBuff->pFrameTable[0]
 
-//engine
 extern int engine_cpp_init_value; // weak
 extern char byte_52B96C; // automap pixel color 8-bit (palette entry)
 extern int dword_52B970; // bool flip - if y < x
@@ -73,3 +74,5 @@ void __fastcall PlayInGameMovie(char *pszMovie);
 /* data */
 
 extern int engine_inf; // weak
+
+#endif /* __ENGINE_H__ */

--- a/Source/error.cpp
+++ b/Source/error.cpp
@@ -55,7 +55,6 @@ char *MsgStrings[44] =
   "Arcane knowledge gained!"
 };
 
-//----- (0041804E) --------------------------------------------------------
 void __fastcall InitDiabloMsg(char e)
 {
 	int i; // edx
@@ -87,7 +86,6 @@ LABEL_4:
 // 52B9F1: using guessed type char msgflag;
 // 52B9F2: using guessed type char msgcnt;
 
-//----- (0041808F) --------------------------------------------------------
 void __cdecl ClrDiabloMsg()
 {
 	msgflag = 0;
@@ -97,7 +95,6 @@ void __cdecl ClrDiabloMsg()
 // 52B9F1: using guessed type char msgflag;
 // 52B9F2: using guessed type char msgcnt;
 
-//----- (004180AA) --------------------------------------------------------
 void __cdecl DrawDiabloMsg()
 {
 	int v0; // esi

--- a/Source/error.h
+++ b/Source/error.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __ERROR_H__
+#define __ERROR_H__
 
-//error
 extern char msgtable[80];
 extern char msgdelay; // weak
 extern char msgflag; // weak
@@ -12,3 +13,5 @@ void __cdecl DrawDiabloMsg();
 
 /* data */
 extern char *MsgStrings[44];
+
+#endif /* __ERROR_H__ */

--- a/Source/fault.cpp
+++ b/Source/fault.cpp
@@ -4,7 +4,6 @@
 
 LPTOP_LEVEL_EXCEPTION_FILTER lpTopLevelExceptionFilter; // idb
 
-//----- (004182AD) --------------------------------------------------------
 struct exception_cpp_init
 {
 	exception_cpp_init()
@@ -14,25 +13,21 @@ struct exception_cpp_init
 	}
 } _exception_cpp_init;
 
-//----- (004182B7) --------------------------------------------------------
 void __cdecl exception_install_filter()
 {
 	exception_set_filter();
 }
 
-//----- (004182C1) --------------------------------------------------------
 void __cdecl j_exception_init_filter()
 {
 	atexit(exception_init_filter);
 }
 
-//----- (004182CD) --------------------------------------------------------
 void __cdecl exception_init_filter()
 {
 	exception_set_filter_ptr();
 }
 
-//----- (004182D7) --------------------------------------------------------
 LONG __stdcall TopLevelExceptionFilter(struct _EXCEPTION_POINTERS *ExceptionInfo)
 {
 	PEXCEPTION_RECORD v1; // esi
@@ -78,7 +73,6 @@ LONG __stdcall TopLevelExceptionFilter(struct _EXCEPTION_POINTERS *ExceptionInfo
 	return result;
 }
 
-//----- (00418455) --------------------------------------------------------
 void __fastcall exception_hex_format(char *a1, char a2)
 {
 	unsigned int v2; // ebp
@@ -138,7 +132,6 @@ void __fastcall exception_hex_format(char *a1, char a2)
 	log_printf("\r\n");
 }
 
-//----- (00418518) --------------------------------------------------------
 void __fastcall exception_unknown_module(LPCVOID lpAddress, LPSTR lpString1, int iMaxLength, int a4, int a5)
 {
 	int v6; // eax
@@ -208,7 +201,6 @@ void __fastcall exception_unknown_module(LPCVOID lpAddress, LPSTR lpString1, int
 	}
 }
 
-//----- (004185FF) --------------------------------------------------------
 void __fastcall exception_call_stack(void *a1, LPVOID lp)
 {
 	_DWORD *v2; // ebx
@@ -237,7 +229,6 @@ void __fastcall exception_call_stack(void *a1, LPVOID lp)
 	log_printf("\r\n");
 }
 
-//----- (00418688) --------------------------------------------------------
 char *__fastcall exception_get_error_type(DWORD dwMessageId, LPSTR lpString1, DWORD nSize)
 {
 	CHAR *v3; // esi
@@ -356,19 +347,16 @@ LABEL_42:
 	return v3;
 }
 
-//----- (0041883C) --------------------------------------------------------
 void __fastcall exception_set_filter()
 {
 	lpTopLevelExceptionFilter = SetUnhandledExceptionFilter((LPTOP_LEVEL_EXCEPTION_FILTER)TopLevelExceptionFilter);
 }
 
-//----- (00418853) --------------------------------------------------------
 LPTOP_LEVEL_EXCEPTION_FILTER __cdecl exception_set_filter_ptr()
 {
 	return SetUnhandledExceptionFilter(lpTopLevelExceptionFilter);
 }
 
-//----- (00418860) --------------------------------------------------------
 LPTOP_LEVEL_EXCEPTION_FILTER __cdecl exception_get_filter()
 {
 	return lpTopLevelExceptionFilter;

--- a/Source/fault.h
+++ b/Source/fault.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __FAULT_H__
+#define __FAULT_H__
 
-//fault
 //int dword_52B9F4;
 extern LPTOP_LEVEL_EXCEPTION_FILTER lpTopLevelExceptionFilter; // idb
 
@@ -16,3 +17,5 @@ char *__fastcall exception_get_error_type(DWORD dwMessageId, LPSTR lpString1, DW
 void __fastcall exception_set_filter();
 LPTOP_LEVEL_EXCEPTION_FILTER __cdecl exception_set_filter_ptr();
 LPTOP_LEVEL_EXCEPTION_FILTER __cdecl exception_get_filter();
+
+#endif /* __FAULT_H__ */

--- a/Source/gamemenu.cpp
+++ b/Source/gamemenu.cpp
@@ -32,7 +32,6 @@ char *music_toggle_names[] = { "Music", "Music Disabled" };
 char *sound_toggle_names[] = { "Sound", "Sound Disabled" };
 char *color_cycling_toggle_names[] = { "Color Cycling Off", "Color Cycling On" };
 
-//----- (00418866) --------------------------------------------------------
 void __cdecl gamemenu_previous()
 {
 	void (__cdecl *v0)(); // edx
@@ -53,7 +52,6 @@ void __cdecl gamemenu_previous()
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0041888F) --------------------------------------------------------
 void __cdecl gamemenu_enable_single()
 {
 	bool v0; // dl
@@ -65,19 +63,16 @@ void __cdecl gamemenu_enable_single()
 	gmenu_enable(sgSingleMenu, v0);
 }
 
-//----- (004188C8) --------------------------------------------------------
 void __cdecl gamemenu_enable_multi()
 {
 	gmenu_enable(&sgMultiMenu[2], deathflag);
 }
 
-//----- (004188D8) --------------------------------------------------------
 void __cdecl gamemenu_off()
 {
 	gmenu_call_proc(0, 0);
 }
 
-//----- (004188E1) --------------------------------------------------------
 void __cdecl gamemenu_handle_previous()
 {
 	if ( gmenu_exception() )
@@ -86,7 +81,6 @@ void __cdecl gamemenu_handle_previous()
 		gamemenu_previous();
 }
 
-//----- (004188F9) --------------------------------------------------------
 void __cdecl gamemenu_new_game()
 {
 	int i; // eax
@@ -106,7 +100,6 @@ void __cdecl gamemenu_new_game()
 // 525650: using guessed type int gbRunGame;
 // 52571C: using guessed type int drawpanflag;
 
-//----- (0041893B) --------------------------------------------------------
 void __cdecl gamemenu_quit_game()
 {
 	gamemenu_new_game();
@@ -114,7 +107,6 @@ void __cdecl gamemenu_quit_game()
 }
 // 525698: using guessed type int gbRunGameResult;
 
-//----- (00418948) --------------------------------------------------------
 void __cdecl gamemenu_load_game()
 {
 	LRESULT (__stdcall *saveProc)(HWND, UINT, WPARAM, LPARAM); // edi
@@ -138,7 +130,6 @@ void __cdecl gamemenu_load_game()
 }
 // 52571C: using guessed type int drawpanflag;
 
-//----- (004189BE) --------------------------------------------------------
 void __cdecl gamemenu_save_game()
 {
 	LRESULT (__stdcall *saveProc)(HWND, UINT, WPARAM, LPARAM); // edi
@@ -168,13 +159,11 @@ void __cdecl gamemenu_save_game()
 }
 // 52571C: using guessed type int drawpanflag;
 
-//----- (00418A42) --------------------------------------------------------
 void __cdecl gamemenu_restart_town()
 {
 	NetSendCmd(1u, CMD_RETOWN);
 }
 
-//----- (00418A4C) --------------------------------------------------------
 void __cdecl gamemenu_options()
 {
 	gamemenu_get_music();
@@ -184,13 +173,11 @@ void __cdecl gamemenu_options()
 	gmenu_call_proc(sgOptionMenu, 0);
 }
 
-//----- (00418A6C) --------------------------------------------------------
 void __cdecl gamemenu_get_music()
 {
 	gamemenu_sound_music_toggle(music_toggle_names, sgOptionMenu, sound_get_or_set_music_volume(1));
 }
 
-//----- (00418A85) --------------------------------------------------------
 void __fastcall gamemenu_sound_music_toggle(char **names, TMenuItem *menu_item, int gamma)
 {
 	if ( gbSndInited )
@@ -207,26 +194,22 @@ void __fastcall gamemenu_sound_music_toggle(char **names, TMenuItem *menu_item, 
 	}
 }
 
-//----- (00418AC6) --------------------------------------------------------
 void __cdecl gamemenu_get_sound()
 {
 	gamemenu_sound_music_toggle(sound_toggle_names, &sgOptionMenu[1], sound_get_or_set_sound_volume(1));
 }
 
-//----- (00418ADF) --------------------------------------------------------
 void __cdecl gamemenu_get_color_cycling()
 {
 	sgOptionMenu[3].pszStr = color_cycling_toggle_names[palette_get_colour_cycling()];
 }
 
-//----- (00418AF4) --------------------------------------------------------
 void __cdecl gamemenu_get_gamma()
 {
 	gmenu_slider_3(&sgOptionMenu[2], 15);
 	gmenu_slider_1(&sgOptionMenu[2], 30, 100, palette_update_gamma(0));
 }
 
-//----- (00418B1A) --------------------------------------------------------
 void __fastcall gamemenu_music_volume(int a1)
 {
 	int v1; // esi
@@ -266,13 +249,11 @@ LABEL_11:
 // 4A22D4: using guessed type char gbMusicOn;
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (00418BA3) --------------------------------------------------------
 int __fastcall gamemenu_slider_music_sound(TMenuItem *menu_item)
 {
 	return gmenu_slider_get(menu_item, -1600, 0);
 }
 
-//----- (00418BB0) --------------------------------------------------------
 void __fastcall gamemenu_sound_volume(int a1)
 {
 	int v1; // ecx
@@ -315,7 +296,6 @@ void __fastcall gamemenu_sound_volume(int a1)
 }
 // 4A22D5: using guessed type char gbSoundOn;
 
-//----- (00418C30) --------------------------------------------------------
 void __fastcall gamemenu_gamma(int a1)
 {
 	int v1; // eax
@@ -335,13 +315,11 @@ void __fastcall gamemenu_gamma(int a1)
 	gamemenu_get_gamma();
 }
 
-//----- (00418C5A) --------------------------------------------------------
 int __cdecl gamemenu_slider_gamma()
 {
 	return gmenu_slider_get(&sgOptionMenu[2], 30, 100);
 }
 
-//----- (00418C6A) --------------------------------------------------------
 void __cdecl gamemenu_color_cycling()
 {
 	palette_set_color_cycling(palette_get_colour_cycling() == 0);

--- a/Source/gamemenu.h
+++ b/Source/gamemenu.h
@@ -1,4 +1,6 @@
 //HEADER_GOES_HERE
+#ifndef __GAMEMENU_H__
+#define __GAMEMENU_H__
 
 void __cdecl gamemenu_previous();
 void __cdecl gamemenu_enable_single();
@@ -30,3 +32,5 @@ extern TMenuItem sgOptionMenu[6];
 extern char *music_toggle_names[];
 extern char *sound_toggle_names[];
 extern char *color_cycling_toggle_names[];
+
+#endif /* __GAMEMENU_H__ */

--- a/Source/gendung.cpp
+++ b/Source/gendung.cpp
@@ -69,7 +69,6 @@ int dminx; // weak
 int dminy; // weak
 short dpiece_defs_map_2[16][112][112];
 
-//----- (00418C8B) --------------------------------------------------------
 void __cdecl FillSolidBlockTbls()
 {
 	unsigned char *v0; // eax
@@ -137,7 +136,6 @@ LABEL_13:
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (00418D91) --------------------------------------------------------
 void __cdecl gendung_418D91()
 {
 	signed int v0; // edx
@@ -496,7 +494,6 @@ LABEL_66:
 // 53CD4C: using guessed type int nlevel_frames;
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (004191BF) --------------------------------------------------------
 void __fastcall gendung_4191BF(int frames)
 {
 	int v1; // edi
@@ -520,7 +517,6 @@ void __fastcall gendung_4191BF(int frames)
 	}
 }
 
-//----- (004191FB) --------------------------------------------------------
 void __fastcall gendung_4191FB(int a1, int a2)
 {
 	int v2; // esi
@@ -554,7 +550,6 @@ void __fastcall gendung_4191FB(int a1, int a2)
 	*(int *)((char *)level_frame_sizes + v2) = v10;
 }
 
-//----- (0041927A) --------------------------------------------------------
 int __fastcall gendung_get_dpiece_num_from_coord(int x, int y)
 {
 	__int64 v3; // rax
@@ -565,7 +560,6 @@ int __fastcall gendung_get_dpiece_num_from_coord(int x, int y)
 	return 12543 - (((signed int)v3 - HIDWORD(v3)) >> 1);
 }
 
-//----- (004192C2) --------------------------------------------------------
 void __cdecl gendung_4192C2()
 {
 	short (*v0)[112][112]; // ebx
@@ -592,7 +586,6 @@ void __cdecl gendung_4192C2()
 	while ( (signed int)v0 < (signed int)&dpiece_defs_map_2[16][0][0] );
 }
 
-//----- (0041930B) --------------------------------------------------------
 void __cdecl SetDungeonMicros()
 {
 	signed int v0; // esi
@@ -679,7 +672,6 @@ void __cdecl SetDungeonMicros()
 // 5C3000: using guessed type int scr_pix_width;
 // 5C3004: using guessed type int scr_pix_height;
 
-//----- (0041944A) --------------------------------------------------------
 void __cdecl DRLG_InitTrans()
 {
 	memset(dung_map, 0, 0x3100u);
@@ -688,7 +680,6 @@ void __cdecl DRLG_InitTrans()
 }
 // 5A5590: using guessed type char TransVal;
 
-//----- (00419477) --------------------------------------------------------
 void __fastcall DRLG_MRectTrans(int x1, int y1, int x2, int y2)
 {
 	int v4; // esi
@@ -720,7 +711,6 @@ void __fastcall DRLG_MRectTrans(int x1, int y1, int x2, int y2)
 }
 // 5A5590: using guessed type char TransVal;
 
-//----- (004194D0) --------------------------------------------------------
 void __fastcall DRLG_RectTrans(int x1, int y1, int x2, int y2)
 {
 	int i; // esi
@@ -746,13 +736,11 @@ void __fastcall DRLG_RectTrans(int x1, int y1, int x2, int y2)
 }
 // 5A5590: using guessed type char TransVal;
 
-//----- (00419515) --------------------------------------------------------
 void __fastcall DRLG_CopyTrans(int sx, int sy, int dx, int dy)
 {
 	dung_map[dx][dy] = dung_map[sx][sy];
 }
 
-//----- (00419534) --------------------------------------------------------
 void __fastcall DRLG_ListTrans(int num, unsigned char *List)
 {
 	unsigned char *v2; // esi
@@ -782,7 +770,6 @@ void __fastcall DRLG_ListTrans(int num, unsigned char *List)
 	}
 }
 
-//----- (00419565) --------------------------------------------------------
 void __fastcall DRLG_AreaTrans(int num, unsigned char *List)
 {
 	unsigned char *v2; // esi
@@ -815,7 +802,6 @@ void __fastcall DRLG_AreaTrans(int num, unsigned char *List)
 }
 // 5A5590: using guessed type char TransVal;
 
-//----- (004195A2) --------------------------------------------------------
 void __cdecl DRLG_InitSetPC()
 {
 	setpc_x = 0;
@@ -826,7 +812,6 @@ void __cdecl DRLG_InitSetPC()
 // 5CF330: using guessed type int setpc_h;
 // 5CF334: using guessed type int setpc_w;
 
-//----- (004195B9) --------------------------------------------------------
 void __cdecl DRLG_SetPC()
 {
 	int v0; // ebx
@@ -860,7 +845,6 @@ void __cdecl DRLG_SetPC()
 // 5CF330: using guessed type int setpc_h;
 // 5CF334: using guessed type int setpc_w;
 
-//----- (0041960C) --------------------------------------------------------
 void __fastcall Make_SetPC(int x, int y, int w, int h)
 {
 	int v4; // eax
@@ -892,7 +876,6 @@ void __fastcall Make_SetPC(int x, int y, int w, int h)
 	}
 }
 
-//----- (0041965B) --------------------------------------------------------
 bool __fastcall DRLG_WillThemeRoomFit(int floor, int x, int y, int minSize, int maxSize, int *width, int *height)
 {
 	int v7; // esi
@@ -1038,7 +1021,6 @@ LABEL_32:
 // 41965B: using guessed type int var_6C[20];
 // 41965B: using guessed type int var_BC[20];
 
-//----- (004197F4) --------------------------------------------------------
 void __fastcall DRLG_CreateThemeRoom(int themeIndex)
 {
 	int v1; // esi
@@ -1273,7 +1255,6 @@ LABEL_53:
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (00419C10) --------------------------------------------------------
 void __fastcall DRLG_PlaceThemeRooms(int minSize, int maxSize, int floor, int freq, int rndSize)
 {
 	int v5; // ebx
@@ -1374,7 +1355,6 @@ void __fastcall DRLG_PlaceThemeRooms(int minSize, int maxSize, int floor, int fr
 // 5A5590: using guessed type char TransVal;
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (00419D92) --------------------------------------------------------
 void __cdecl DRLG_HoldThemeRooms()
 {
 	int *v0; // esi
@@ -1431,7 +1411,6 @@ void __cdecl DRLG_HoldThemeRooms()
 	}
 }
 
-//----- (00419E1F) --------------------------------------------------------
 bool __fastcall SkipThemeRoom(int x, int y)
 {
 	int i; // ebx
@@ -1458,7 +1437,6 @@ bool __fastcall SkipThemeRoom(int x, int y)
 	return 0;
 }
 
-//----- (00419E71) --------------------------------------------------------
 void __cdecl InitLevels()
 {
 	if ( !leveldebug )

--- a/Source/gendung.h
+++ b/Source/gendung.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __GENDUNG_H__
+#define __GENDUNG_H__
 
-//gendung
 extern short level_frame_types[2048];
 extern int themeCount;
 extern char nTransTable[2049];
@@ -90,3 +91,5 @@ void __fastcall DRLG_PlaceThemeRooms(int minSize, int maxSize, int floor, int fr
 void __cdecl DRLG_HoldThemeRooms();
 bool __fastcall SkipThemeRoom(int x, int y);
 void __cdecl InitLevels();
+
+#endif /* __GENDUNG_H__ */

--- a/Source/gmenu.cpp
+++ b/Source/gmenu.cpp
@@ -41,7 +41,6 @@ unsigned char lfontkern[56] =
    11,  10,  12,  11,  21,  23
 };
 
-//----- (00419E8B) --------------------------------------------------------
 void __cdecl gmenu_draw_pause()
 {
 	if ( currlevel )
@@ -54,7 +53,6 @@ void __cdecl gmenu_draw_pause()
 }
 // 69BEF8: using guessed type int light_table_index;
 
-//----- (00419EBE) --------------------------------------------------------
 void __fastcall gmenu_print_text(int x, int y, char *pszStr)
 {
 	char *v3; // edi
@@ -76,7 +74,6 @@ void __fastcall gmenu_print_text(int x, int y, char *pszStr)
 	}
 }
 
-//----- (00419F17) --------------------------------------------------------
 void __cdecl FreeGMenu()
 {
 	void *v0; // ecx
@@ -102,7 +99,6 @@ void __cdecl FreeGMenu()
 	mem_free_dbg(v4);
 }
 
-//----- (00419F70) --------------------------------------------------------
 void __cdecl gmenu_init_menu()
 {
 	byte_634478 = 1;
@@ -121,13 +117,11 @@ void __cdecl gmenu_init_menu()
 // 634478: using guessed type char byte_634478;
 // 63448C: using guessed type int dword_63448C;
 
-//----- (00419FE8) --------------------------------------------------------
 bool __cdecl gmenu_exception()
 {
 	return dword_634480 != 0;
 }
 
-//----- (00419FF4) --------------------------------------------------------
 void __fastcall gmenu_call_proc(TMenuItem *pItem, void (__cdecl *gmFunc)())
 {
 	TMenuItem *v2; // eax
@@ -163,7 +157,6 @@ void __fastcall gmenu_call_proc(TMenuItem *pItem, void (__cdecl *gmFunc)())
 // 634464: using guessed type char byte_634464;
 // 63448C: using guessed type int dword_63448C;
 
-//----- (0041A04E) --------------------------------------------------------
 void __fastcall gmenu_up_down(int a1)
 {
 	TMenuItem *v1; // eax
@@ -205,7 +198,6 @@ LABEL_10:
 // 634464: using guessed type char byte_634464;
 // 63448C: using guessed type int dword_63448C;
 
-//----- (0041A0B6) --------------------------------------------------------
 void __cdecl gmenu_draw()
 {
 	int v0; // edi
@@ -235,7 +227,6 @@ void __cdecl gmenu_draw()
 // 634474: using guessed type int dword_634474;
 // 634478: using guessed type char byte_634478;
 
-//----- (0041A145) --------------------------------------------------------
 void __fastcall gmenu_draw_menu_item(TMenuItem *pItem, int a2)
 {
 	int v2; // edi
@@ -286,7 +277,6 @@ void __fastcall gmenu_draw_menu_item(TMenuItem *pItem, int a2)
 // 634478: using guessed type char byte_634478;
 // 69BEF8: using guessed type int light_table_index;
 
-//----- (0041A239) --------------------------------------------------------
 void __fastcall gmenu_clear_buffer(int x, int y, int width, int height)
 {
 	int v4; // edi
@@ -300,7 +290,6 @@ void __fastcall gmenu_clear_buffer(int x, int y, int width, int height)
 	}
 }
 
-//----- (0041A272) --------------------------------------------------------
 int __fastcall gmenu_get_lfont(TMenuItem *pItem)
 {
 	char *v2; // eax
@@ -320,7 +309,6 @@ int __fastcall gmenu_get_lfont(TMenuItem *pItem)
 	return i - 2;
 }
 
-//----- (0041A2AE) --------------------------------------------------------
 int __fastcall gmenu_presskeys(int a1)
 {
 	int v1; // ecx
@@ -363,7 +351,6 @@ LABEL_10:
 	return 1;
 }
 
-//----- (0041A32A) --------------------------------------------------------
 void __fastcall gmenu_left_right(int a1)
 {
 	signed int v1; // edx
@@ -393,7 +380,6 @@ void __fastcall gmenu_left_right(int a1)
 	}
 }
 
-//----- (0041A37A) --------------------------------------------------------
 int __fastcall gmenu_on_mouse_move(LPARAM lParam)
 {
 	int v2; // edx
@@ -413,7 +399,6 @@ int __fastcall gmenu_on_mouse_move(LPARAM lParam)
 // 41A37A: could not find valid save-restore pair for esi
 // 634464: using guessed type char byte_634464;
 
-//----- (0041A3D2) --------------------------------------------------------
 bool __fastcall gmenu_valid_mouse_pos(int *plOffset)
 {
 	*plOffset = 282;
@@ -431,7 +416,6 @@ bool __fastcall gmenu_valid_mouse_pos(int *plOffset)
 	return 1;
 }
 
-//----- (0041A401) --------------------------------------------------------
 int __fastcall gmenu_left_mouse(int a1)
 {
 	int result; // eax
@@ -486,7 +470,6 @@ int __fastcall gmenu_left_mouse(int a1)
 // 634464: using guessed type char byte_634464;
 // 63448C: using guessed type int dword_63448C;
 
-//----- (0041A4B8) --------------------------------------------------------
 void __fastcall gmenu_enable(TMenuItem *pMenuItem, bool enable)
 {
 	if ( enable )
@@ -495,7 +478,6 @@ void __fastcall gmenu_enable(TMenuItem *pMenuItem, bool enable)
 		pMenuItem->dwFlags &= 0x7F000000;
 }
 
-//----- (0041A4C6) --------------------------------------------------------
 void __fastcall gmenu_slider_1(TMenuItem *pItem, int min, int max, int gamma)
 {
 	unsigned int v4; // esi
@@ -509,7 +491,6 @@ void __fastcall gmenu_slider_1(TMenuItem *pItem, int min, int max, int gamma)
 	pItem->dwFlags = v4 | (v5 * (gamma - min) + (max - min - 1) / 2) / (max - min);
 }
 
-//----- (0041A508) --------------------------------------------------------
 int __fastcall gmenu_slider_get(TMenuItem *pItem, int min, int max)
 {
 	int v3; // eax
@@ -522,7 +503,6 @@ int __fastcall gmenu_slider_get(TMenuItem *pItem, int min, int max)
 	return min + (v4 * (max - min) + (v3 - 1) / 2) / v3;
 }
 
-//----- (0041A545) --------------------------------------------------------
 void __fastcall gmenu_slider_3(TMenuItem *pItem, int dwTicks)
 {
 	pItem->dwFlags ^= (pItem->dwFlags ^ (dwTicks << 12)) & 0xFFF000;

--- a/Source/gmenu.h
+++ b/Source/gmenu.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __GMENU_H__
+#define __GMENU_H__
 
-//gmenu
 extern void *optbar_cel;
 extern bool byte_634464; // weak
 extern void *PentSpin_cel;
@@ -39,3 +40,5 @@ void __fastcall gmenu_slider_3(TMenuItem *pItem, int dwTicks);
 
 extern unsigned char lfontframe[127];
 extern unsigned char lfontkern[56];
+
+#endif /* __GMENU_H__ */

--- a/Source/help.cpp
+++ b/Source/help.cpp
@@ -78,7 +78,6 @@ char gszHelpText[] =
 	"&"
 };
 
-//----- (0041A553) --------------------------------------------------------
 void __cdecl InitHelp()
 {
 	helpflag = 0;
@@ -87,7 +86,6 @@ void __cdecl InitHelp()
 }
 // 634494: using guessed type int dword_634494;
 
-//----- (0041A565) --------------------------------------------------------
 void __cdecl DrawHelp()
 {
 	int v0; // edi
@@ -222,7 +220,6 @@ LABEL_48:
 // 634490: using guessed type int help_select_line;
 // 634960: using guessed type int HelpTop;
 
-//----- (0041A6FA) --------------------------------------------------------
 void __fastcall DrawHelpLine(int always_0, int help_line_nr, char *text, text_color color)
 {
 	signed int v4; // ebx
@@ -248,7 +245,6 @@ void __fastcall DrawHelpLine(int always_0, int help_line_nr, char *text, text_co
 	}
 }
 
-//----- (0041A773) --------------------------------------------------------
 void __cdecl DisplayHelp()
 {
 	help_select_line = 0;
@@ -258,7 +254,6 @@ void __cdecl DisplayHelp()
 // 634490: using guessed type int help_select_line;
 // 634960: using guessed type int HelpTop;
 
-//----- (0041A78F) --------------------------------------------------------
 void __cdecl HelpScrollUp()
 {
 	if ( help_select_line > 0 )
@@ -266,7 +261,6 @@ void __cdecl HelpScrollUp()
 }
 // 634490: using guessed type int help_select_line;
 
-//----- (0041A79F) --------------------------------------------------------
 void __cdecl HelpScrollDown()
 {
 	if ( help_select_line < HelpTop )

--- a/Source/help.h
+++ b/Source/help.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __HELP_H__
+#define __HELP_H__
 
-//help
 extern int help_select_line; // weak
 extern int dword_634494; // weak
 extern int helpflag;
@@ -16,3 +17,5 @@ void __cdecl HelpScrollDown();
 
 /* data */
 extern char gszHelpText[];
+
+#endif /* __HELP_H__ */

--- a/Source/init.cpp
+++ b/Source/init.cpp
@@ -22,7 +22,6 @@ int init_inf = 0x7F800000; // weak
 char gszVersionNumber[260] = "internal version unknown";
 char gszProductName[260] = "Diablo v1.09";
 
-//----- (0041A7B8) --------------------------------------------------------
 struct init_cpp_init
 {
 	init_cpp_init()
@@ -33,7 +32,6 @@ struct init_cpp_init
 // 47AE20: using guessed type int init_inf;
 // 63497C: using guessed type int init_cpp_init_value;
 
-//----- (0041A7C3) --------------------------------------------------------
 void __fastcall init_cleanup(bool show_cursor)
 {
 	int v1; // edi
@@ -68,7 +66,6 @@ void __fastcall init_cleanup(bool show_cursor)
 		ShowCursor(1);
 }
 
-//----- (0041A84C) --------------------------------------------------------
 void __cdecl init_run_office_from_start_menu()
 {
 	HWND v0; // eax
@@ -93,7 +90,6 @@ void __cdecl init_run_office_from_start_menu()
 }
 // 634CA0: using guessed type int killed_mom_parent;
 
-//----- (0041A8B9) --------------------------------------------------------
 void __fastcall init_run_office(char *dir)
 {
 	char *v1; // esi
@@ -142,7 +138,6 @@ void __fastcall init_run_office(char *dir)
 	}
 }
 
-//----- (0041AA2C) --------------------------------------------------------
 void __fastcall init_disable_screensaver(bool disable)
 {
 	bool v1; // al
@@ -173,7 +168,6 @@ void __fastcall init_disable_screensaver(bool disable)
 	}
 }
 
-//----- (0041AAC5) --------------------------------------------------------
 void __cdecl init_create_window()
 {
 	int nHeight; // eax
@@ -217,7 +211,6 @@ void __cdecl init_create_window()
 	init_disable_screensaver(1);
 }
 
-//----- (0041AC00) --------------------------------------------------------
 void __cdecl init_kill_mom_parent()
 {
 	HWND v0; // eax
@@ -231,7 +224,6 @@ void __cdecl init_kill_mom_parent()
 }
 // 634CA0: using guessed type int killed_mom_parent;
 
-//----- (0041AC21) --------------------------------------------------------
 HWND __cdecl init_find_mom_parent()
 {
 	HWND i; // eax
@@ -250,7 +242,6 @@ HWND __cdecl init_find_mom_parent()
 	return v1;
 }
 
-//----- (0041AC71) --------------------------------------------------------
 void __cdecl init_await_mom_parent_exit()
 {
 	DWORD v0; // edi
@@ -265,7 +256,6 @@ void __cdecl init_await_mom_parent_exit()
 	while ( GetTickCount() - v0 <= 4000 );
 }
 
-//----- (0041ACA1) --------------------------------------------------------
 void __cdecl init_archives()
 {
 	void *a1; // [esp+8h] [ebp-8h]
@@ -298,7 +288,6 @@ void __cdecl init_archives()
 	patch_rt_mpq = init_test_access(patch_rt_mpq_path, "\\patch_rt.mpq", "DiabloInstall", 2000, 0);
 }
 
-//----- (0041AD72) --------------------------------------------------------
 void *__fastcall init_test_access(char *mpq_path, char *mpq_name, char *reg_loc, int flags, bool on_cd)
 {
 	char *v5; // esi
@@ -365,7 +354,6 @@ void *__fastcall init_test_access(char *mpq_path, char *mpq_name, char *reg_loc,
 	return 0;
 }
 
-//----- (0041AF22) --------------------------------------------------------
 char *__fastcall init_strip_trailing_slash(char *path)
 {
 	char *result; // eax
@@ -379,7 +367,6 @@ char *__fastcall init_strip_trailing_slash(char *path)
 	return result;
 }
 
-//----- (0041AF3A) --------------------------------------------------------
 int __fastcall init_read_test_file(char *mpq_path, char *mpq_name, int flags, void **archive)
 {
 	char *v4; // edi
@@ -416,7 +403,6 @@ int __fastcall init_read_test_file(char *mpq_path, char *mpq_name, int flags, vo
 	return 1;
 }
 
-//----- (0041AFCE) --------------------------------------------------------
 void __cdecl init_get_file_info()
 {
 	int v0; // eax
@@ -449,7 +435,6 @@ void __cdecl init_get_file_info()
 	}
 }
 
-//----- (0041B06C) --------------------------------------------------------
 LRESULT __stdcall init_palette(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 {
 	if ( Msg > WM_ERASEBKGND )
@@ -494,7 +479,6 @@ LRESULT __stdcall init_palette(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 }
 // 52571C: using guessed type int drawpanflag;
 
-//----- (0041B105) --------------------------------------------------------
 void __fastcall init_activate_window(HWND hWnd, bool activated)
 {
 	LONG dwNewLong; // eax
@@ -520,7 +504,6 @@ void __fastcall init_activate_window(HWND hWnd, bool activated)
 // 52571C: using guessed type int drawpanflag;
 // 634980: using guessed type int window_activated;
 
-//----- (0041B15F) --------------------------------------------------------
 LRESULT __stdcall init_redraw_window(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 {
 	LRESULT result; // eax
@@ -532,7 +515,6 @@ LRESULT __stdcall init_redraw_window(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM 
 	return result;
 }
 
-//----- (0041B184) --------------------------------------------------------
 LRESULT (__stdcall *SetWindowProc(void *func))(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
 	LRESULT (__stdcall *result)(HWND, UINT, WPARAM, LPARAM); // eax

--- a/Source/init.h
+++ b/Source/init.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __INIT_H__
+#define __INIT_H__
 
-//init
 extern _SNETVERSIONDATA fileinfo;
 extern int init_cpp_init_value; // weak
 extern int window_activated; // weak
@@ -40,3 +41,5 @@ extern int init_inf; // weak
 
 extern char gszVersionNumber[260];
 extern char gszProductName[260];
+
+#endif /* __INIT_H__ */

--- a/Source/interfac.cpp
+++ b/Source/interfac.cpp
@@ -11,7 +11,6 @@ int interfac_inf = 0x7F800000; // weak
 unsigned char progress_bar_colours[3] = { 138u, 43u, 254u };
 POINT32 progress_bar_screen_pos[3] = { { 53, 37 }, { 53, 421 }, { 53, 37 } };
 
-//----- (0041B195) --------------------------------------------------------
 struct interfac_cpp_init
 {
 	interfac_cpp_init()
@@ -21,7 +20,6 @@ struct interfac_cpp_init
 } _interfac_cpp_init;
 // 47AE40: using guessed type int interfac_inf;
 
-//----- (0041B1A0) --------------------------------------------------------
 void __cdecl interface_msg_pump()
 {
 	MSG Msg; // [esp+8h] [ebp-1Ch]
@@ -36,7 +34,6 @@ void __cdecl interface_msg_pump()
 	}
 }
 
-//----- (0041B1DF) --------------------------------------------------------
 bool __cdecl IncProgress()
 {
 	interface_msg_pump();
@@ -48,7 +45,6 @@ bool __cdecl IncProgress()
 	return (unsigned int)sgdwProgress >= 0x216;
 }
 
-//----- (0041B218) --------------------------------------------------------
 void __cdecl DrawCutscene()
 {
 	unsigned int v0; // esi
@@ -71,7 +67,6 @@ void __cdecl DrawCutscene()
 }
 // 52571C: using guessed type int drawpanflag;
 
-//----- (0041B28D) --------------------------------------------------------
 void __fastcall DrawProgress(int screen_x, int screen_y, int progress_id)
 {
 	_BYTE *v3; // eax
@@ -88,7 +83,6 @@ void __fastcall DrawProgress(int screen_x, int screen_y, int progress_id)
 	while ( v4 );
 }
 
-//----- (0041B2B6) --------------------------------------------------------
 void __fastcall ShowProgress(int uMsg)
 {
 	LRESULT (__stdcall *saveProc)(HWND, UINT, WPARAM, LPARAM); // edi
@@ -245,7 +239,6 @@ LABEL_41:
 // 6761B8: using guessed type char gbSomebodyWonGameKludge;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0041B5F5) --------------------------------------------------------
 void __cdecl FreeInterface()
 {
 	void *v0; // ecx
@@ -255,7 +248,6 @@ void __cdecl FreeInterface()
 	mem_free_dbg(v0);
 }
 
-//----- (0041B607) --------------------------------------------------------
 void __fastcall InitCutscene(int interface_mode)
 {
 	int v1; // eax

--- a/Source/interfac.h
+++ b/Source/interfac.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __INTERFAC_H__
+#define __INTERFAC_H__
 
-//interfac
 extern void *sgpBackCel;
 extern float interfac_cpp_init_value;
 extern int sgdwProgress;
@@ -20,3 +21,5 @@ void __fastcall InitCutscene(int interface_mode);
 extern int interfac_inf; // weak
 extern unsigned char progress_bar_colours[3];
 extern POINT32 progress_bar_screen_pos[3];
+
+#endif /* __INTERFAC_H__ */

--- a/Source/inv.cpp
+++ b/Source/inv.cpp
@@ -88,7 +88,6 @@ InvXY InvRect[73] =
 
 int AP2x2Tbl[10] = { 8, 28, 6, 26, 4, 24, 2, 22, 0, 20 }; // weak
 
-//----- (0041B814) --------------------------------------------------------
 void __cdecl FreeInvGFX()
 {
 	void *v0; // ecx
@@ -98,7 +97,6 @@ void __cdecl FreeInvGFX()
 	mem_free_dbg(v0);
 }
 
-//----- (0041B826) --------------------------------------------------------
 void __cdecl InitInv()
 {
 	char v0; // al
@@ -123,7 +121,6 @@ LABEL_7:
 	drawsbarflag = 0;
 }
 
-//----- (0041B871) --------------------------------------------------------
 void __fastcall InvDrawSlotBack(int X, int Y, int W, int H)
 {
 	unsigned char *v4; // edi
@@ -164,7 +161,6 @@ LABEL_9:
 	while ( v5 );
 }
 
-//----- (0041B8C4) --------------------------------------------------------
 void __cdecl DrawInv()
 {
 	int v0; // ecx
@@ -454,7 +450,6 @@ void __cdecl DrawInv()
 // 69CF94: using guessed type int cel_transparency_active;
 // 41B8C4: using guessed type int var_A0[40];
 
-//----- (0041C060) --------------------------------------------------------
 void __cdecl DrawInvBelt()
 {
 	int v0; // ebx
@@ -539,7 +534,6 @@ void __cdecl DrawInvBelt()
 // 4B8960: using guessed type int talkflag;
 // 4B8CB8: using guessed type char pcursinvitem;
 
-//----- (0041C23F) --------------------------------------------------------
 int __fastcall AutoPlace(int pnum, int ii, int sx, int sy, int saveflag)
 {
 	__int64 v5; // rax
@@ -637,7 +631,6 @@ LABEL_16:
 	return v6;
 }
 
-//----- (0041C373) --------------------------------------------------------
 int __fastcall SpecialAutoPlace(int pnum, int ii, int sx, int sy, int saveflag)
 {
 	__int64 v5; // rax
@@ -750,7 +743,6 @@ LABEL_24:
 	return v6;
 }
 
-//----- (0041C4E0) --------------------------------------------------------
 int __fastcall GoldAutoPlace(int pnum)
 {
 	int v1; // ebp
@@ -885,7 +877,6 @@ LABEL_28:
 	return v3;
 }
 
-//----- (0041C6A9) --------------------------------------------------------
 int __fastcall WeaponAutoPlace(int pnum)
 {
 	int v1; // edi
@@ -927,7 +918,6 @@ LABEL_13:
 	return 0;
 }
 
-//----- (0041C746) --------------------------------------------------------
 int __fastcall SwapItem(ItemStruct *a, ItemStruct *b)
 {
 	int v2; // eax
@@ -940,7 +930,6 @@ int __fastcall SwapItem(ItemStruct *a, ItemStruct *b)
 	return v2 + 12;
 }
 
-//----- (0041C783) --------------------------------------------------------
 void __fastcall CheckInvPaste(int pnum, int mx, int my)
 {
 	int v3; // ebx
@@ -1598,7 +1587,6 @@ LABEL_89:
 // 4B8CBC: using guessed type int icursW;
 // 52571C: using guessed type int drawpanflag;
 
-//----- (0041D2CF) --------------------------------------------------------
 void __fastcall CheckInvSwap(int pnum, int bLoc, int idx, int wCI, int seed, int bId)
 {
 	unsigned char v6; // bl
@@ -1628,7 +1616,6 @@ void __fastcall CheckInvSwap(int pnum, int bLoc, int idx, int wCI, int seed, int
 	CalcPlrInv(p, 1u);
 }
 
-//----- (0041D378) --------------------------------------------------------
 void __fastcall CheckInvCut(int pnum, int mx, int my)
 {
 	int v3; // ebp
@@ -1805,7 +1792,6 @@ LABEL_60:
 // 4B84DC: using guessed type int dropGoldFlag;
 // 4B8C9C: using guessed type int cursH;
 
-//----- (0041D6EB) --------------------------------------------------------
 void __fastcall inv_update_rem_item(int pnum, int iv)
 {
 	unsigned char v2; // dl
@@ -1818,7 +1804,6 @@ void __fastcall inv_update_rem_item(int pnum, int iv)
 	CalcPlrInv(pnum, v2);
 }
 
-//----- (0041D722) --------------------------------------------------------
 void __fastcall RemoveInvItem(int pnum, int iv)
 {
 	int v2; // edx
@@ -1877,7 +1862,6 @@ void __fastcall RemoveInvItem(int pnum, int iv)
 }
 // 52571C: using guessed type int drawpanflag;
 
-//----- (0041D810) --------------------------------------------------------
 void __fastcall RemoveSpdBarItem(int pnum, int iv)
 {
 	int v2; // esi
@@ -1896,7 +1880,6 @@ void __fastcall RemoveSpdBarItem(int pnum, int iv)
 }
 // 52571C: using guessed type int drawpanflag;
 
-//----- (0041D86C) --------------------------------------------------------
 void __cdecl CheckInvItem()
 {
 	if ( pcurs < CURSOR_FIRSTITEM )
@@ -1905,14 +1888,12 @@ void __cdecl CheckInvItem()
 		CheckInvPaste(myplr, MouseX, MouseY);
 }
 
-//----- (0041D893) --------------------------------------------------------
 void __cdecl CheckInvScrn()
 {
 	if ( MouseX > 190 && MouseX < 437 && MouseY > 352 && MouseY < 385 )
 		CheckInvItem();
 }
 
-//----- (0041D8BF) --------------------------------------------------------
 void __fastcall CheckItemStats(int pnum)
 {
 	PlayerStruct *v1; // eax
@@ -1929,7 +1910,6 @@ void __fastcall CheckItemStats(int pnum)
 	}
 }
 
-//----- (0041D90B) --------------------------------------------------------
 void __fastcall CheckBookLevel(int pnum)
 {
 	int v1; // ecx
@@ -1962,7 +1942,6 @@ void __fastcall CheckBookLevel(int pnum)
 	}
 }
 
-//----- (0041D97F) --------------------------------------------------------
 void __fastcall CheckQuestItem(int pnum)
 {
 	int v1; // ecx
@@ -2098,7 +2077,6 @@ void __fastcall CheckQuestItem(int pnum)
 }
 // 52A554: using guessed type int sfxdelay;
 
-//----- (0041DB65) --------------------------------------------------------
 void __fastcall InvGetItem(int pnum, int ii)
 {
 	int v2; // ebp
@@ -2148,7 +2126,6 @@ void __fastcall InvGetItem(int pnum, int ii)
 // 4B84DC: using guessed type int dropGoldFlag;
 // 4B8CC0: using guessed type char pcursitem;
 
-//----- (0041DC79) --------------------------------------------------------
 void __fastcall AutoGetItem(int pnum, int ii)
 {
 	int v2; // ebx
@@ -2437,7 +2414,6 @@ LABEL_84:
 // 48E9A8: using guessed type int AP2x2Tbl[10];
 // 4B84DC: using guessed type int dropGoldFlag;
 
-//----- (0041E103) --------------------------------------------------------
 int __fastcall FindGetItem(int indx, unsigned short ci, int iseed)
 {
 	int i; // ebx
@@ -2457,7 +2433,6 @@ int __fastcall FindGetItem(int indx, unsigned short ci, int iseed)
 	return ii;
 }
 
-//----- (0041E158) --------------------------------------------------------
 void __fastcall SyncGetItem(int x, int y, int idx, unsigned short ci, int iseed)
 {
 	char v5; // cl
@@ -2502,7 +2477,6 @@ void __fastcall SyncGetItem(int x, int y, int idx, unsigned short ci, int iseed)
 	}
 }
 
-//----- (0041E222) --------------------------------------------------------
 int __fastcall CanPut(int i, int j)
 {
 	int v2; // ecx
@@ -2549,7 +2523,6 @@ int __fastcall CanPut(int i, int j)
 	return 1;
 }
 
-//----- (0041E2F9) --------------------------------------------------------
 int __cdecl TryInvPut()
 {
 	int result; // eax
@@ -2578,7 +2551,6 @@ int __cdecl TryInvPut()
 	return result;
 }
 
-//----- (0041E3BC) --------------------------------------------------------
 void __fastcall DrawInvMsg(char *msg)
 {
 	char *v1; // esi
@@ -2593,7 +2565,6 @@ void __fastcall DrawInvMsg(char *msg)
 	}
 }
 
-//----- (0041E3E4) --------------------------------------------------------
 int __fastcall InvPutItem(int pnum, int x, int y)
 {
 	int v3; // edi
@@ -2713,7 +2684,6 @@ int __fastcall InvPutItem(int pnum, int x, int y)
 	return yc;
 }
 
-//----- (0041E639) --------------------------------------------------------
 int __fastcall SyncPutItem(int pnum, int x, int y, int idx, int icreateinfo, int iseed, int Id, int dur, int mdur, int ch, int mch, int ivalue, unsigned int ibuff)
 {
 	int v13; // ebx
@@ -2847,7 +2817,6 @@ int __fastcall SyncPutItem(int pnum, int x, int y, int idx, int icreateinfo, int
 	return ic;
 }
 
-//----- (0041E8DD) --------------------------------------------------------
 int __cdecl CheckInvHLight()
 {
 	signed int v0; // ebx
@@ -2996,7 +2965,6 @@ LABEL_36:
 }
 // 4B883C: using guessed type int infoclr;
 
-//----- (0041EAEA) --------------------------------------------------------
 void __fastcall RemoveScroll(int pnum)
 {
 	int v1; // eax
@@ -3040,7 +3008,6 @@ LABEL_8:
 	CalcPlrScrolls(p);
 }
 
-//----- (0041EB8B) --------------------------------------------------------
 bool __cdecl UseScroll()
 {
 	int v0; // eax
@@ -3083,7 +3050,6 @@ LABEL_11:
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0041EC42) --------------------------------------------------------
 void __fastcall UseStaffCharge(int pnum)
 {
 	int v1; // eax
@@ -3103,7 +3069,6 @@ void __fastcall UseStaffCharge(int pnum)
 	}
 }
 
-//----- (0041EC7F) --------------------------------------------------------
 bool __cdecl UseStaff()
 {
 	int v0; // eax
@@ -3124,7 +3089,6 @@ bool __cdecl UseStaff()
 	return result;
 }
 
-//----- (0041ECC3) --------------------------------------------------------
 void __cdecl StartGoldDrop()
 {
 	int v0; // eax
@@ -3144,7 +3108,6 @@ void __cdecl StartGoldDrop()
 // 4B8960: using guessed type int talkflag;
 // 4B8CB8: using guessed type char pcursinvitem;
 
-//----- (0041ED29) --------------------------------------------------------
 int __fastcall UseInvItem(int pnum, int cii)
 {
 	int v2; // esi
@@ -3300,7 +3263,6 @@ LABEL_39:
 // 52A554: using guessed type int sfxdelay;
 // 6AA705: using guessed type char stextflag;
 
-//----- (0041EFA1) --------------------------------------------------------
 void __cdecl DoTelekinesis()
 {
 	if ( pcursobj != -1 )
@@ -3314,7 +3276,6 @@ void __cdecl DoTelekinesis()
 // 4B8CC0: using guessed type char pcursitem;
 // 4B8CC1: using guessed type char pcursobj;
 
-//----- (0041F013) --------------------------------------------------------
 int __fastcall CalculateGold(int pnum)
 {
 	int result; // eax
@@ -3356,7 +3317,6 @@ int __fastcall CalculateGold(int pnum)
 }
 // 52571C: using guessed type int drawpanflag;
 
-//----- (0041F068) --------------------------------------------------------
 int __cdecl DropItemBeforeTrig()
 {
 	if ( !TryInvPut() )

--- a/Source/inv.h
+++ b/Source/inv.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __INV_H__
+#define __INV_H__
 
-//inv
 extern int invflag;
 extern void *pInvCels;
 extern int drawsbarflag; // idb
@@ -54,3 +55,5 @@ extern InvXY InvRect[73];
 /* rdata */
 
 extern int AP2x2Tbl[10]; // weak
+
+#endif /* __INV_H__ */

--- a/Source/items.cpp
+++ b/Source/items.cpp
@@ -635,7 +635,6 @@ int ItemInvSnds[35] =
 int idoppely = 16; // weak
 int premiumlvladd[6] = { -1, -1, 0, 0, 1, 2 };
 
-//----- (0041F096) --------------------------------------------------------
 void __cdecl InitItemGFX()
 {
 	signed int v0; // esi
@@ -652,7 +651,6 @@ void __cdecl InitItemGFX()
 	memset(UniqueItemFlag, 0, 0x200u);
 }
 
-//----- (0041F0E8) --------------------------------------------------------
 bool __fastcall ItemPlace(int x, int y)
 {
 	int v2; // ecx
@@ -668,7 +666,6 @@ bool __fastcall ItemPlace(int x, int y)
 	return result;
 }
 
-//----- (0041F13A) --------------------------------------------------------
 void __cdecl AddInitItems()
 {
 	int i; // eax
@@ -714,7 +711,6 @@ void __cdecl AddInitItems()
 	}
 }
 
-//----- (0041F24E) --------------------------------------------------------
 void __cdecl InitItems()
 {
 	int *v0; // eax
@@ -759,7 +755,6 @@ void __cdecl InitItems()
 }
 // 5CF31D: using guessed type char setlevel;
 
-//----- (0041F320) --------------------------------------------------------
 void __fastcall CalcPlrItemVals(int p, bool Loadgfx)
 {
 	int v2; // eax
@@ -1109,7 +1104,6 @@ LABEL_86:
 }
 // 52571C: using guessed type int drawpanflag;
 
-//----- (0041F953) --------------------------------------------------------
 void __fastcall CalcPlrScrolls(int p)
 {
 	int v1; // esi
@@ -1170,7 +1164,6 @@ void __fastcall CalcPlrScrolls(int p)
 }
 // 52571C: using guessed type int drawpanflag;
 
-//----- (0041FA4A) --------------------------------------------------------
 void __fastcall CalcPlrStaff(int pnum)
 {
 	int v1; // esi
@@ -1189,7 +1182,6 @@ void __fastcall CalcPlrStaff(int pnum)
 	}
 }
 
-//----- (0041FA97) --------------------------------------------------------
 void __fastcall CalcSelfItems(int pnum)
 {
 	PlayerStruct *v1; // ecx
@@ -1266,7 +1258,6 @@ void __fastcall CalcSelfItems(int pnum)
 	while ( v9 );
 }
 
-//----- (0041FB91) --------------------------------------------------------
 void __fastcall CalcPlrItemMin(int pnum)
 {
 	PlayerStruct *v1; // ecx
@@ -1304,7 +1295,6 @@ void __fastcall CalcPlrItemMin(int pnum)
 	while ( v7 );
 }
 
-//----- (0041FBF6) --------------------------------------------------------
 bool __fastcall ItemMinStats(PlayerStruct *p, ItemStruct *x)
 {
 	if ( p->_pStrength < x->_iMinStr || p->_pMagic < x->_iMinMag || p->_pDexterity < x->_iMinDex )
@@ -1313,7 +1303,6 @@ bool __fastcall ItemMinStats(PlayerStruct *p, ItemStruct *x)
 		return 1;
 }
 
-//----- (0041FC2C) --------------------------------------------------------
 void __fastcall CalcPlrBookVals(int p)
 {
 	int v1; // esi
@@ -1385,7 +1374,6 @@ void __fastcall CalcPlrBookVals(int p)
 	}
 }
 
-//----- (0041FD3E) --------------------------------------------------------
 void __fastcall CalcPlrInv(int p, bool Loadgfx)
 {
 	CalcPlrItemMin(p);
@@ -1402,7 +1390,6 @@ void __fastcall CalcPlrInv(int p, bool Loadgfx)
 	}
 }
 
-//----- (0041FD98) --------------------------------------------------------
 void __fastcall SetPlrHandItem(ItemStruct *h, int idata)
 {
 	ItemDataStruct *pAllItem; // edi
@@ -1438,13 +1425,11 @@ void __fastcall SetPlrHandItem(ItemStruct *h, int idata)
 	h->IDidx = idata;
 }
 
-//----- (0041FE98) --------------------------------------------------------
 void __fastcall GetPlrHandSeed(ItemStruct *h)
 {
 	h->_iSeed = GetRndSeed();
 }
 
-//----- (0041FEA4) --------------------------------------------------------
 void __fastcall GetGoldSeed(int pnum, ItemStruct *h)
 {
 	int v3; // edi
@@ -1485,13 +1470,11 @@ void __fastcall GetGoldSeed(int pnum, ItemStruct *h)
 	h->_iSeed = v5;
 }
 
-//----- (0041FF16) --------------------------------------------------------
 void __fastcall SetPlrHandSeed(ItemStruct *h, int iseed)
 {
 	h->_iSeed = iseed;
 }
 
-//----- (0041FF19) --------------------------------------------------------
 void __fastcall SetPlrHandGoldCurs(ItemStruct *h)
 {
 	int v1; // eax
@@ -1510,7 +1493,6 @@ void __fastcall SetPlrHandGoldCurs(ItemStruct *h)
 	}
 }
 
-//----- (0041FF4E) --------------------------------------------------------
 void __fastcall CreatePlrItems(int p)
 {
 	int v1; // ebx
@@ -1592,7 +1574,6 @@ LABEL_14:
 	CalcPlrItemVals(player_numa, 0);
 }
 
-//----- (004200F8) --------------------------------------------------------
 bool __fastcall ItemSpaceOk(int i, int j)
 {
 	int v2; // eax
@@ -1643,7 +1624,6 @@ bool __fastcall ItemSpaceOk(int i, int j)
 	return 0;
 }
 
-//----- (004201F2) --------------------------------------------------------
 bool __fastcall GetItemSpace(int x, int y, char inum)
 {
 	int v3; // eax
@@ -1740,7 +1720,6 @@ bool __fastcall GetItemSpace(int x, int y, char inum)
 	return 1;
 }
 
-//----- (004202E8) --------------------------------------------------------
 void __fastcall GetSuperItemSpace(int x, int y, char inum)
 {
 	signed int v4; // edi
@@ -1795,7 +1774,6 @@ void __fastcall GetSuperItemSpace(int x, int y, char inum)
 	}
 }
 
-//----- (00420376) --------------------------------------------------------
 void __fastcall GetSuperItemLoc(int x, int y, int *xx, int *yy)
 {
 	signed int v4; // edi
@@ -1840,7 +1818,6 @@ LABEL_3:
 	}
 }
 
-//----- (004203E0) --------------------------------------------------------
 void __fastcall CalcItemValue(int i)
 {
 	int v1; // ecx
@@ -1864,7 +1841,6 @@ void __fastcall CalcItemValue(int i)
 	item[v1]._iIvalue = v4;
 }
 
-//----- (0042042C) --------------------------------------------------------
 void __fastcall GetBookSpell(int i, int lvl)
 {
 	int v2; // edi
@@ -1924,7 +1900,6 @@ LABEL_13:
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00420514) --------------------------------------------------------
 void __fastcall GetStaffPower(int i, int lvl, int bs, unsigned char onlygood)
 {
 	int v4; // esi
@@ -2004,7 +1979,6 @@ void __fastcall GetStaffPower(int i, int lvl, int bs, unsigned char onlygood)
 }
 // 420514: using guessed type int var_484[256];
 
-//----- (004206E5) --------------------------------------------------------
 void __fastcall GetStaffSpell(int i, int lvl, unsigned char onlygood)
 {
 	int l; // esi
@@ -2066,7 +2040,6 @@ LABEL_15:
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0042084A) --------------------------------------------------------
 void __fastcall GetItemAttrs(int i, int idata, int lvl)
 {
 	int rndv; // eax
@@ -2153,13 +2126,11 @@ void __fastcall GetItemAttrs(int i, int idata, int lvl)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (00420B17) --------------------------------------------------------
 int __fastcall RndPL(int param1, int param2)
 {
 	return param1 + random(22, param2 - param1 + 1);
 }
 
-//----- (00420B28) --------------------------------------------------------
 int __fastcall PLVal(int pv, int p1, int p2, int minv, int maxv)
 {
 	if ( p1 == p2 )
@@ -2169,7 +2140,6 @@ int __fastcall PLVal(int pv, int p1, int p2, int minv, int maxv)
 	return minv + (maxv - minv) * (100 * (pv - p1) / (p2 - p1)) / 100;
 }
 
-//----- (00420B68) --------------------------------------------------------
 void __fastcall SaveItemPower(int i, int power, int param1, int param2, int minval, int maxval, int multval)
 {
 	int v7; // edi
@@ -2562,7 +2532,6 @@ LABEL_62:
 	}
 }
 
-//----- (004215EF) --------------------------------------------------------
 void __fastcall GetItemPower(int i, int minlvl, int maxlvl, int flgs, int onlygood)
 {
 	//int v6; // ecx
@@ -2686,7 +2655,6 @@ void __fastcall GetItemPower(int i, int minlvl, int maxlvl, int flgs, int onlygo
 }
 // 4215EF: using guessed type int var_494[256];
 
-//----- (0042191C) --------------------------------------------------------
 void __fastcall GetItemBonus(int i, int idata, int minlvl, int maxlvl, int onlygood)
 {
 	if ( item[i]._iClass != ICLASS_GOLD )
@@ -2726,7 +2694,6 @@ void __fastcall GetItemBonus(int i, int idata, int minlvl, int maxlvl, int onlyg
 	}
 }
 
-//----- (004219C1) --------------------------------------------------------
 void __fastcall SetupItem(int i)
 {
 	int it; // eax
@@ -2756,7 +2723,6 @@ void __fastcall SetupItem(int i)
 	item[i]._iAnimFrame = il;
 }
 
-//----- (00421A4B) --------------------------------------------------------
 int __fastcall RndItem(int m)
 {
 	int ri; // esi
@@ -2797,7 +2763,6 @@ int __fastcall RndItem(int m)
 // 679660: using guessed type char gbMaxPlayers;
 // 421A4B: using guessed type int var_800[512];
 
-//----- (00421B32) --------------------------------------------------------
 int __fastcall RndUItem(int m)
 {
 	int ri; // edx
@@ -2853,7 +2818,6 @@ int __fastcall RndUItem(int m)
 // 679660: using guessed type char gbMaxPlayers;
 // 421B32: using guessed type int var_800[512];
 
-//----- (00421C2A) --------------------------------------------------------
 int __cdecl RndAllItems()
 {
 	int ri; // esi
@@ -2884,7 +2848,6 @@ int __cdecl RndAllItems()
 // 679660: using guessed type char gbMaxPlayers;
 // 421C2A: using guessed type int var_800[512];
 
-//----- (00421CB7) --------------------------------------------------------
 int __fastcall RndTypeItems(int itype, int imid)
 {
 	int i; // edi
@@ -2919,7 +2882,6 @@ int __fastcall RndTypeItems(int itype, int imid)
 }
 // 421CB7: using guessed type int var_80C[512];
 
-//----- (00421D41) --------------------------------------------------------
 int __fastcall CheckUnique(int i, int lvl, int uper, bool recreate)
 {
 	int numu; // ebx
@@ -2969,7 +2931,6 @@ int __fastcall CheckUnique(int i, int lvl, int uper, bool recreate)
 // 679660: using guessed type char gbMaxPlayers;
 // 421D41: using guessed type char var_84[128];
 
-//----- (00421E11) --------------------------------------------------------
 void __fastcall GetUniqueItem(int i, int uid)
 {
 	UniqueItemFlag[uid] = 1;
@@ -2997,7 +2958,6 @@ void __fastcall GetUniqueItem(int i, int uid)
 	item[i]._iMagical = 2;
 }
 
-//----- (00421F5C) --------------------------------------------------------
 void __fastcall SpawnUnique(int uid, int x, int y)
 {
 	int ii; // esi
@@ -3027,14 +2987,12 @@ void __fastcall SpawnUnique(int uid, int x, int y)
 }
 // 421F5C: could not find valid save-restore pair for esi
 
-//----- (00421FE6) --------------------------------------------------------
 void __fastcall ItemRndDur(int ii)
 {
 	if ( item[ii]._iDurability && item[ii]._iDurability != 255 )
 		item[ii]._iDurability = random(0, item[ii]._iMaxDur >> 1) + (item[ii]._iMaxDur >> 2) + 1;
 }
 
-//----- (00422024) --------------------------------------------------------
 void __fastcall SetupAllItems(int ii, int idx, int iseed, int lvl, int uper, int onlygood, int recreate, int pregen)
 {
 	int iblvl; // edi
@@ -3098,7 +3056,6 @@ void __fastcall SetupAllItems(int ii, int idx, int iseed, int lvl, int uper, int
 	SetupItem(ii);
 }
 
-//----- (0042217A) --------------------------------------------------------
 void __fastcall SpawnItem(int m, int x, int y, unsigned char sendmsg)
 {
 	int ii; // edi
@@ -3150,7 +3107,6 @@ LABEL_13:
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00422290) --------------------------------------------------------
 void __fastcall CreateItem(int uid, int x, int y)
 {
 	int ii; // esi
@@ -3181,7 +3137,6 @@ void __fastcall CreateItem(int uid, int x, int y)
 }
 // 422290: could not find valid save-restore pair for esi
 
-//----- (0042232B) --------------------------------------------------------
 void __fastcall CreateRndItem(int x, int y, unsigned char onlygood, unsigned char sendmsg, int delta)
 {
 	int idx; // edi
@@ -3209,7 +3164,6 @@ void __fastcall CreateRndItem(int x, int y, unsigned char onlygood, unsigned cha
 	}
 }
 
-//----- (004223D0) --------------------------------------------------------
 void __fastcall SetupAllUseful(int ii, int iseed, int lvl)
 {
 	int idx; // esi
@@ -3229,7 +3183,6 @@ void __fastcall SetupAllUseful(int ii, int iseed, int lvl)
 	SetupItem(ii);
 }
 
-//----- (0042243D) --------------------------------------------------------
 void __fastcall CreateRndUseful(int pnum, int x, int y, unsigned char sendmsg)
 {
 	int ii; // esi
@@ -3249,7 +3202,6 @@ void __fastcall CreateRndUseful(int pnum, int x, int y, unsigned char sendmsg)
 	}
 }
 
-//----- (004224A6) --------------------------------------------------------
 void __fastcall CreateTypeItem(int x, int y, unsigned char onlygood, int itype, int imisc, int sendmsg, int delta)
 {
 	int idx; // edi
@@ -3277,7 +3229,6 @@ void __fastcall CreateTypeItem(int x, int y, unsigned char onlygood, int itype, 
 	}
 }
 
-//----- (0042254A) --------------------------------------------------------
 void __fastcall RecreateItem(int ii, int idx, unsigned short ic, int iseed, int ivalue)
 {
 	int uper; // esi
@@ -3342,7 +3293,6 @@ void __fastcall RecreateItem(int ii, int idx, unsigned short ic, int iseed, int 
 	}
 }
 
-//----- (0042265C) --------------------------------------------------------
 void __fastcall RecreateEar(int ii, unsigned short ic, int iseed, unsigned char Id, int dur, int mdur, int ch, int mch, int ivalue, int ibuff)
 {
 	SetPlrHandItem(&item[ii], IDI_EAR);
@@ -3370,7 +3320,6 @@ void __fastcall RecreateEar(int ii, unsigned short ic, int iseed, unsigned char 
 	item[ii]._iSeed = iseed;
 }
 
-//----- (00422795) --------------------------------------------------------
 void __fastcall SpawnQuestItem(int itemid, int x, int y, int randarea, int selflag)
 {
 	int i; // ebx
@@ -3437,7 +3386,6 @@ LABEL_13:
 	}
 }
 
-//----- (004228B1) --------------------------------------------------------
 void __cdecl SpawnRock()
 {
 	BOOL v0; // edx
@@ -3491,7 +3439,6 @@ void __cdecl SpawnRock()
 	}
 }
 
-//----- (00422989) --------------------------------------------------------
 void __fastcall RespawnItem(int i, bool FlipFlag)
 {
 	int it; // ecx
@@ -3531,7 +3478,6 @@ void __fastcall RespawnItem(int i, bool FlipFlag)
 		item[i]._iSelFlag = 1;
 }
 
-//----- (00422A50) --------------------------------------------------------
 void __fastcall DeleteItem(int ii, int i)
 {
 	int v2; // eax
@@ -3547,7 +3493,6 @@ void __fastcall DeleteItem(int ii, int i)
 		itemactive[i] = itemactive[v2];
 }
 
-//----- (00422A84) --------------------------------------------------------
 void __cdecl ItemDoppel()
 {
 	int idoppelx; // esi
@@ -3572,7 +3517,6 @@ void __cdecl ItemDoppel()
 // 492EAC: using guessed type int idoppely;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00422ADE) --------------------------------------------------------
 void __cdecl ProcessItems()
 {
 	int i; // edi
@@ -3608,7 +3552,6 @@ void __cdecl ProcessItems()
 	ItemDoppel();
 }
 
-//----- (00422BB2) --------------------------------------------------------
 void __cdecl FreeItemGFX()
 {
 	int i; // esi
@@ -3622,13 +3565,11 @@ void __cdecl FreeItemGFX()
 	}
 }
 
-//----- (00422BCF) --------------------------------------------------------
 void __fastcall GetItemFrm(int i)
 {
 	item[i]._iAnimData = Item2Frm[ItemCAnimTbl[item[i]._iCurs]];
 }
 
-//----- (00422BF0) --------------------------------------------------------
 void __fastcall GetItemStr(int i)
 {
 	int nGold; // esi
@@ -3653,7 +3594,6 @@ void __fastcall GetItemStr(int i)
 }
 // 4B883C: using guessed type int infoclr;
 
-//----- (00422C63) --------------------------------------------------------
 void __fastcall CheckIdentify(int pnum, int cii)
 {
 	ItemStruct *pi; // esi
@@ -3667,7 +3607,6 @@ void __fastcall CheckIdentify(int pnum, int cii)
 		SetCursor(CURSOR_HAND);
 }
 
-//----- (00422C9C) --------------------------------------------------------
 void __fastcall DoRepair(int pnum, int cii)
 {
 	PlayerStruct *p; // eax
@@ -3684,7 +3623,6 @@ void __fastcall DoRepair(int pnum, int cii)
 		SetCursor(CURSOR_HAND);
 }
 
-//----- (00422CF6) --------------------------------------------------------
 void __fastcall RepairItem(ItemStruct *i, int lvl)
 {
 	int rep; // edi
@@ -3720,7 +3658,6 @@ void __fastcall RepairItem(ItemStruct *i, int lvl)
 	}
 }
 
-//----- (00422D6C) --------------------------------------------------------
 void __fastcall DoRecharge(int pnum, int cii)
 {
 	PlayerStruct *p; // eax
@@ -3739,7 +3676,6 @@ void __fastcall DoRecharge(int pnum, int cii)
 		SetCursor(CURSOR_HAND);
 }
 
-//----- (00422DDD) --------------------------------------------------------
 void __fastcall RechargeItem(ItemStruct *i, int r)
 {
 	if ( i->_iCharges != i->_iMaxCharges )
@@ -3761,7 +3697,6 @@ void __fastcall RechargeItem(ItemStruct *i, int r)
 	}
 }
 
-//----- (00422E14) --------------------------------------------------------
 void __fastcall PrintItemOil(char IDidx)
 {
 	switch ( IDidx )
@@ -3819,7 +3754,6 @@ void __fastcall PrintItemOil(char IDidx)
 	AddPanelString(tempstr, 1);
 }
 
-//----- (00422EF4) --------------------------------------------------------
 void __fastcall PrintItemPower(char plidx, ItemStruct *x)
 {
 	ItemStruct *v2; // esi
@@ -4097,7 +4031,6 @@ LABEL_104:
 	}
 }
 
-//----- (00423530) --------------------------------------------------------
 void __cdecl DrawUBack()
 {
 	char *v0; // edi
@@ -4147,7 +4080,6 @@ void __cdecl DrawUBack()
 	*v0 = 0;
 }
 
-//----- (0042358C) --------------------------------------------------------
 void __fastcall PrintUString(int x, int y, int cjustflag, char *str, int col)
 {
 	char *v5; // edi
@@ -4208,7 +4140,6 @@ LABEL_16:
 	}
 }
 
-//----- (0042365B) --------------------------------------------------------
 void __fastcall DrawULine(int y)
 {
 	char *v1; // esi
@@ -4231,7 +4162,6 @@ void __fastcall DrawULine(int y)
 	while ( v3 );
 }
 
-//----- (004236A6) --------------------------------------------------------
 void __cdecl DrawUniqueInfo()
 {
 	int v0; // esi
@@ -4277,7 +4207,6 @@ void __cdecl DrawUniqueInfo()
 }
 // 69BD04: using guessed type int questlog;
 
-//----- (004237DC) --------------------------------------------------------
 void __fastcall PrintItemMisc(ItemStruct *x)
 {
 	if ( x->_iMiscId == IMISC_SCROLL )
@@ -4315,7 +4244,6 @@ void __fastcall PrintItemMisc(ItemStruct *x)
 	}
 }
 
-//----- (004238D4) --------------------------------------------------------
 void __fastcall PrintItemDetails(ItemStruct *x)
 {
 	ItemStruct *v1; // ebp
@@ -4385,7 +4313,6 @@ void __fastcall PrintItemDetails(ItemStruct *x)
 }
 // 4B8824: using guessed type int pinfoflag;
 
-//----- (00423AE1) --------------------------------------------------------
 void __fastcall PrintItemDur(ItemStruct *x)
 {
 	ItemStruct *v1; // esi
@@ -4447,7 +4374,6 @@ void __fastcall PrintItemDur(ItemStruct *x)
 }
 // 4B8824: using guessed type int pinfoflag;
 
-//----- (00423CE0) --------------------------------------------------------
 void __fastcall UseItem(int p, int Mid, int spl)
 {
 	int v3; // esi
@@ -4785,7 +4711,6 @@ LABEL_71:
 	}
 }
 
-//----- (004241D7) --------------------------------------------------------
 bool __fastcall StoreStatOk(ItemStruct *h)
 {
 	bool sf; // al
@@ -4798,7 +4723,6 @@ bool __fastcall StoreStatOk(ItemStruct *h)
 	return sf;
 }
 
-//----- (0042421C) --------------------------------------------------------
 bool __fastcall SmithItemOk(int i)
 {
 	unsigned char v1; // cl
@@ -4811,7 +4735,6 @@ bool __fastcall SmithItemOk(int i)
 	return rv;
 }
 
-//----- (00424252) --------------------------------------------------------
 int __fastcall RndSmithItem(int lvl)
 {
 	int ri; // edx
@@ -4838,7 +4761,6 @@ int __fastcall RndSmithItem(int lvl)
 }
 // 424252: using guessed type int var_804[512];
 
-//----- (004242C1) --------------------------------------------------------
 void __fastcall BubbleSwapItem(ItemStruct *a, ItemStruct *b)
 {
 	ItemStruct h; // [esp+8h] [ebp-170h]
@@ -4848,7 +4770,6 @@ void __fastcall BubbleSwapItem(ItemStruct *a, ItemStruct *b)
 	qmemcpy(b, &h, sizeof(ItemStruct));
 }
 
-//----- (004242F5) --------------------------------------------------------
 void __cdecl SortSmith()
 {
 	int v0; // esi
@@ -4894,7 +4815,6 @@ void __cdecl SortSmith()
 	}
 }
 
-//----- (00424351) --------------------------------------------------------
 void __fastcall SpawnSmith(int lvl)
 {
 	int v3; // ebp
@@ -4936,7 +4856,6 @@ void __fastcall SpawnSmith(int lvl)
 	SortSmith();
 }
 
-//----- (00424420) --------------------------------------------------------
 bool __fastcall PremiumItemOk(int i)
 {
 	unsigned char v1; // cl
@@ -4954,7 +4873,6 @@ bool __fastcall PremiumItemOk(int i)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0042445F) --------------------------------------------------------
 int __fastcall RndPremiumItem(int minlvl, int maxlvl)
 {
 	int ri; // edx
@@ -4983,7 +4901,6 @@ int __fastcall RndPremiumItem(int minlvl, int maxlvl)
 }
 // 42445F: using guessed type int ril[512];
 
-//----- (004244C6) --------------------------------------------------------
 void __fastcall SpawnOnePremium(int i, int plvl)
 {
 	int itype; // esi
@@ -5010,7 +4927,6 @@ void __fastcall SpawnOnePremium(int i, int plvl)
 	qmemcpy(item, &holditem, sizeof(ItemStruct));
 }
 
-//----- (004245A0) --------------------------------------------------------
 void __fastcall SpawnPremium(int lvl)
 {
 	int i; // eax
@@ -5037,7 +4953,6 @@ void __fastcall SpawnPremium(int lvl)
 }
 // 69FB38: using guessed type int talker;
 
-//----- (0042466C) --------------------------------------------------------
 bool __fastcall WitchItemOk(int i)
 {
 	bool rv; // eax
@@ -5071,7 +4986,6 @@ bool __fastcall WitchItemOk(int i)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (004246D2) --------------------------------------------------------
 int __fastcall RndWitchItem(int lvl)
 {
 	int ri; // ebx
@@ -5094,7 +5008,6 @@ int __fastcall RndWitchItem(int lvl)
 }
 // 4246D2: using guessed type int var_804[512];
 
-//----- (00424735) --------------------------------------------------------
 void __cdecl SortWitch()
 {
 	signed int v0; // esi
@@ -5140,7 +5053,6 @@ void __cdecl SortWitch()
 	}
 }
 
-//----- (00424795) --------------------------------------------------------
 void __fastcall WitchBookLevel(int ii)
 {
 	int slvl; // edi
@@ -5166,7 +5078,6 @@ void __fastcall WitchBookLevel(int ii)
 	}
 }
 
-//----- (00424815) --------------------------------------------------------
 void __fastcall SpawnWitch(int lvl)
 {
 	int v2; // ebp
@@ -5233,7 +5144,6 @@ void __fastcall SpawnWitch(int lvl)
 	SortWitch();
 }
 
-//----- (004249A4) --------------------------------------------------------
 int __fastcall RndBoyItem(int lvl)
 {
 	int ri; // edx
@@ -5256,7 +5166,6 @@ int __fastcall RndBoyItem(int lvl)
 }
 // 4249A4: using guessed type int var_800[512];
 
-//----- (00424A03) --------------------------------------------------------
 void __fastcall SpawnBoy(int lvl)
 {
 	int itype; // esi
@@ -5281,7 +5190,6 @@ void __fastcall SpawnBoy(int lvl)
 }
 // 6A8A3C: using guessed type int boylevel;
 
-//----- (00424A9B) --------------------------------------------------------
 bool __fastcall HealerItemOk(int i)
 {
 	int v1; // ecx
@@ -5339,7 +5247,6 @@ LABEL_21:
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00424B49) --------------------------------------------------------
 int __fastcall RndHealerItem(int lvl)
 {
 	int ri; // ebx
@@ -5362,7 +5269,6 @@ int __fastcall RndHealerItem(int lvl)
 }
 // 424B49: using guessed type int var_804[512];
 
-//----- (00424BAC) --------------------------------------------------------
 void __cdecl SortHealer()
 {
 	signed int v0; // esi
@@ -5408,7 +5314,6 @@ void __cdecl SortHealer()
 	}
 }
 
-//----- (00424C0C) --------------------------------------------------------
 void __fastcall SpawnHealer(int lvl)
 {
 	int v3; // eax
@@ -5468,7 +5373,6 @@ void __fastcall SpawnHealer(int lvl)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00424D57) --------------------------------------------------------
 void __cdecl SpawnStoreGold()
 {
 	GetItemAttrs(0, IDI_GOLD, 1);
@@ -5476,7 +5380,6 @@ void __cdecl SpawnStoreGold()
 	golditem._iStatFlag = 1;
 }
 
-//----- (00424D80) --------------------------------------------------------
 void __fastcall RecreateSmithItem(int ii, int idx, int plvl, int iseed)
 {
 	SetRndSeed(iseed);
@@ -5486,7 +5389,6 @@ void __fastcall RecreateSmithItem(int ii, int idx, int plvl, int iseed)
 	item[ii]._iIdentified = 1;
 }
 
-//----- (00424DD1) --------------------------------------------------------
 void __fastcall RecreatePremiumItem(int ii, int idx, int lvl, int iseed)
 {
 	int itype; // edi
@@ -5500,7 +5402,6 @@ void __fastcall RecreatePremiumItem(int ii, int idx, int lvl, int iseed)
 	item[ii]._iIdentified = 1;
 }
 
-//----- (00424E3C) --------------------------------------------------------
 void __fastcall RecreateBoyItem(int ii, int idx, int lvl, int iseed)
 {
 	int itype; // edi
@@ -5514,7 +5415,6 @@ void __fastcall RecreateBoyItem(int ii, int idx, int lvl, int iseed)
 	item[ii]._iIdentified = 1;
 }
 
-//----- (00424EA1) --------------------------------------------------------
 void __fastcall RecreateWitchItem(int ii, int idx, int lvl, int iseed)
 {
 	int itype; // edi
@@ -5540,7 +5440,6 @@ void __fastcall RecreateWitchItem(int ii, int idx, int lvl, int iseed)
 	item[ii]._iIdentified = 1;
 }
 
-//----- (00424F52) --------------------------------------------------------
 void __fastcall RecreateHealerItem(int ii, int idx, int lvl, int iseed)
 {
 	if ( idx != IDI_HEAL && idx != IDI_FULLHEAL && idx != IDI_RESURRECT )
@@ -5554,7 +5453,6 @@ void __fastcall RecreateHealerItem(int ii, int idx, int lvl, int iseed)
 	item[ii]._iIdentified = 1;
 }
 
-//----- (00424FB8) --------------------------------------------------------
 void __fastcall RecreateTownItem(int ii, int idx, unsigned short icreateinfo, int iseed, int ivalue)
 {
 	if ( icreateinfo & 0x400 )
@@ -5569,7 +5467,6 @@ void __fastcall RecreateTownItem(int ii, int idx, unsigned short icreateinfo, in
 		RecreateHealerItem(ii, idx, icreateinfo & 0x3F, iseed);
 }
 
-//----- (0042501F) --------------------------------------------------------
 void __cdecl RecalcStoreStats()
 {
 	int i;
@@ -5595,7 +5492,6 @@ void __cdecl RecalcStoreStats()
 // 6A6BB8: using guessed type int stextscrl;
 // 6AA700: using guessed type int stextdown;
 
-//----- (004250C0) --------------------------------------------------------
 int __cdecl ItemNoFlippy()
 {
 	int r; // ecx
@@ -5608,7 +5504,6 @@ int __cdecl ItemNoFlippy()
 	return r;
 }
 
-//----- (004250EF) --------------------------------------------------------
 void __fastcall CreateSpellBook(int x, int y, int ispell, bool sendmsg, int delta)
 {
 	int ii; // edi
@@ -5638,7 +5533,6 @@ void __fastcall CreateSpellBook(int x, int y, int ispell, bool sendmsg, int delt
 	}
 }
 
-//----- (004251B8) --------------------------------------------------------
 void __fastcall CreateMagicItem(int x, int y, int imisc, int icurs, int sendmsg, int delta)
 {
 	int ii; // esi
@@ -5668,7 +5562,6 @@ void __fastcall CreateMagicItem(int x, int y, int imisc, int icurs, int sendmsg,
 	}
 }
 
-//----- (0042526E) --------------------------------------------------------
 bool __fastcall GetItemRecord(int dwSeed, int CI, int indx)
 {
 	int v3; // edi
@@ -5712,7 +5605,6 @@ LABEL_8:
 	return 0;
 }
 
-//----- (00425311) --------------------------------------------------------
 void __fastcall NextItemRecord(int i)
 {
 	int v1; // eax
@@ -5727,7 +5619,6 @@ void __fastcall NextItemRecord(int i)
 	}
 }
 
-//----- (00425357) --------------------------------------------------------
 void __fastcall SetItemRecord(int dwSeed, int CI, int indx)
 {
 	int i; // ecx
@@ -5742,7 +5633,6 @@ void __fastcall SetItemRecord(int dwSeed, int CI, int indx)
 	}
 }
 
-//----- (0042539E) --------------------------------------------------------
 void __fastcall PutItemRecord(int seed, int ci, int index)
 {
 	int v3; // edi

--- a/Source/items.h
+++ b/Source/items.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __ITEMS_H__
+#define __ITEMS_H__
 
-//items
 extern int itemactive[127];
 extern int uitemflag;
 extern int itemavail[127];
@@ -142,3 +143,5 @@ extern int ItemDropSnds[35];
 extern int ItemInvSnds[35];
 extern int idoppely; // weak
 extern int premiumlvladd[6];
+
+#endif /* __ITEMS_H__ */

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -479,7 +479,6 @@ unsigned char byte_49463C[18][18] = /* unused */
 
 unsigned char RadiusAdj[23] = { 0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 3, 4, 3, 2, 2, 2, 1, 1, 1, 0, 0, 0, 0 };
 
-//----- (00425443) --------------------------------------------------------
 void __fastcall SetLightFX(int *x, int *y, short *s_r, short *s_g, int *s_b, int *d_r, int *d_g, int *d_b)
 {
 	short *v8; // eax
@@ -511,7 +510,6 @@ void __fastcall SetLightFX(int *x, int *y, short *s_r, short *s_g, int *s_b, int
 	}
 }
 
-//----- (004254BA) --------------------------------------------------------
 void __fastcall DoLighting(int nXPos, int nYPos, int nRadius, int Lnum)
 {
 	int v4; // edi
@@ -794,7 +792,6 @@ void __fastcall DoLighting(int nXPos, int nYPos, int nRadius, int Lnum)
 	}
 }
 
-//----- (004258B0) --------------------------------------------------------
 void __fastcall DoUnLight(int nXPos, int nYPos, int nRadius)
 {
 	int max_y; // ebx
@@ -835,7 +832,6 @@ void __fastcall DoUnLight(int nXPos, int nYPos, int nRadius)
 	}
 }
 
-//----- (00425930) --------------------------------------------------------
 void __fastcall DoUnVision(int nXPos, int nYPos, int nRadius)
 {
 	int y2; // edi
@@ -873,7 +869,6 @@ void __fastcall DoUnVision(int nXPos, int nYPos, int nRadius)
 	}
 }
 
-//----- (0042598A) --------------------------------------------------------
 void __fastcall DoVision(int nXPos, int nYPos, int nRadius, unsigned char doautomap, int visible)
 {
 	char *v5; // esi
@@ -1037,7 +1032,6 @@ void __fastcall DoVision(int nXPos, int nYPos, int nRadius, unsigned char doauto
 	while ( v27 < 4 );
 }
 
-//----- (00425C13) --------------------------------------------------------
 void __cdecl FreeLightTable()
 {
 	char *v0; // ecx
@@ -1047,13 +1041,11 @@ void __cdecl FreeLightTable()
 	mem_free_dbg(v0);
 }
 
-//----- (00425C25) --------------------------------------------------------
 void __cdecl InitLightTable()
 {
 	pLightTbl = (char *)DiabloAllocPtr(6912);
 }
 
-//----- (00425C35) --------------------------------------------------------
 void __cdecl MakeLightTable()
 {
 	char *v0; // ebx
@@ -1399,7 +1391,6 @@ void __cdecl MakeLightTable()
 // 525728: using guessed type int light4flag;
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (00425FB8) --------------------------------------------------------
 void __cdecl InitLightMax()
 {
 	lightmax = light4flag == 0 ? 15 : 3;
@@ -1407,7 +1398,6 @@ void __cdecl InitLightMax()
 // 525728: using guessed type int light4flag;
 // 642A14: using guessed type char lightmax;
 
-//----- (00425FCE) --------------------------------------------------------
 void __cdecl InitLighting()
 {
 	signed int v0; // eax
@@ -1426,7 +1416,6 @@ void __cdecl InitLighting()
 // 642A18: using guessed type int dolighting;
 // 646A28: using guessed type int lightflag;
 
-//----- (00425FEC) --------------------------------------------------------
 int __fastcall AddLight(int x, int y, int r)
 {
 	int lid; // eax
@@ -1449,7 +1438,6 @@ int __fastcall AddLight(int x, int y, int r)
 // 642A18: using guessed type int dolighting;
 // 646A28: using guessed type int lightflag;
 
-//----- (00426056) --------------------------------------------------------
 void __fastcall AddUnLight(int i)
 {
 	if ( !lightflag && i != -1 )
@@ -1461,7 +1449,6 @@ void __fastcall AddUnLight(int i)
 // 642A18: using guessed type int dolighting;
 // 646A28: using guessed type int lightflag;
 
-//----- (00426076) --------------------------------------------------------
 void __fastcall ChangeLightRadius(int i, int r)
 {
 	if ( !lightflag && i != -1 )
@@ -1477,7 +1464,6 @@ void __fastcall ChangeLightRadius(int i, int r)
 // 642A18: using guessed type int dolighting;
 // 646A28: using guessed type int lightflag;
 
-//----- (004260C5) --------------------------------------------------------
 void __fastcall ChangeLightXY(int i, int x, int y)
 {
 	if ( !lightflag && i != -1 )
@@ -1494,7 +1480,6 @@ void __fastcall ChangeLightXY(int i, int x, int y)
 // 642A18: using guessed type int dolighting;
 // 646A28: using guessed type int lightflag;
 
-//----- (00426120) --------------------------------------------------------
 void __fastcall ChangeLightOff(int i, int x, int y)
 {
 	if ( !lightflag && i != -1 )
@@ -1511,7 +1496,6 @@ void __fastcall ChangeLightOff(int i, int x, int y)
 // 642A18: using guessed type int dolighting;
 // 646A28: using guessed type int lightflag;
 
-//----- (0042617B) --------------------------------------------------------
 void __fastcall ChangeLight(int i, int x, int y, int r)
 {
 	if ( !lightflag && i != -1 )
@@ -1529,7 +1513,6 @@ void __fastcall ChangeLight(int i, int x, int y, int r)
 // 642A18: using guessed type int dolighting;
 // 646A28: using guessed type int lightflag;
 
-//----- (004261E7) --------------------------------------------------------
 void __cdecl ProcessLightList()
 {
 	int v0; // ebp
@@ -1600,13 +1583,11 @@ void __cdecl ProcessLightList()
 // 642A18: using guessed type int dolighting;
 // 646A28: using guessed type int lightflag;
 
-//----- (004262E0) --------------------------------------------------------
 void __cdecl SavePreLighting()
 {
 	memcpy(dTransVal2, dTransVal, 0x3100u);
 }
 
-//----- (004262F8) --------------------------------------------------------
 void __cdecl InitVision()
 {
 	numvision = 0;
@@ -1618,7 +1599,6 @@ void __cdecl InitVision()
 // 5A5590: using guessed type char TransVal;
 // 642A0C: using guessed type int dovision;
 
-//----- (00426333) --------------------------------------------------------
 int __fastcall AddVision(int x, int y, int r, bool mine)
 {
 	int vid; // eax
@@ -1643,7 +1623,6 @@ int __fastcall AddVision(int x, int y, int r, bool mine)
 }
 // 642A0C: using guessed type int dovision;
 
-//----- (004263A0) --------------------------------------------------------
 void __fastcall ChangeVisionRadius(int id, int r)
 {
 	int i; // esi
@@ -1666,7 +1645,6 @@ void __fastcall ChangeVisionRadius(int id, int r)
 }
 // 642A0C: using guessed type int dovision;
 
-//----- (004263E1) --------------------------------------------------------
 void __fastcall ChangeVisionXY(int id, int x, int y)
 {
 	int i; // esi
@@ -1690,7 +1668,6 @@ void __fastcall ChangeVisionXY(int id, int x, int y)
 }
 // 642A0C: using guessed type int dovision;
 
-//----- (0042642B) --------------------------------------------------------
 void __cdecl ProcessVisionList()
 {
 	bool delflag; // ecx
@@ -1742,7 +1719,6 @@ void __cdecl ProcessVisionList()
 // 5A5590: using guessed type char TransVal;
 // 642A0C: using guessed type int dovision;
 
-//----- (0042651F) --------------------------------------------------------
 void __cdecl lighting_color_cycling()
 {
 	char *v0; // eax

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __LIGHTING_H__
+#define __LIGHTING_H__
 
-//lighting
 extern LightListStruct VisionList[32];
 extern char lightactive[32];
 extern LightListStruct LightList[32];
@@ -47,3 +48,5 @@ extern void *pCrawlTable[19];
 extern unsigned char vCrawlTable[23][30];
 extern unsigned char byte_49463C[18][18];
 extern unsigned char RadiusAdj[23];
+
+#endif /* __LIGHTING_H__ */

--- a/Source/loadsave.cpp
+++ b/Source/loadsave.cpp
@@ -4,7 +4,6 @@
 
 void *tbuff;
 
-//----- (00426564) --------------------------------------------------------
 void __fastcall LoadGame(bool firstflag)
 {
 	int v1; // esi
@@ -390,7 +389,6 @@ void __fastcall LoadGame(bool firstflag)
 // 5CCB10: using guessed type char setlvlnum;
 // 5CF31D: using guessed type char setlevel;
 
-//----- (00426AE2) --------------------------------------------------------
 char __cdecl BLoad()
 {
 	char result; // al
@@ -400,7 +398,6 @@ char __cdecl BLoad()
 	return result;
 }
 
-//----- (00426AF0) --------------------------------------------------------
 int __cdecl ILoad()
 {
 	int v0; // eax
@@ -420,7 +417,6 @@ int __cdecl ILoad()
 	return result;
 }
 
-//----- (00426B2C) --------------------------------------------------------
 int __cdecl ILoad_2()
 {
 	int v0; // eax
@@ -440,7 +436,6 @@ int __cdecl ILoad_2()
 	return result;
 }
 
-//----- (00426B68) --------------------------------------------------------
 bool __cdecl OLoad()
 {
 	char v0; // cl
@@ -454,14 +449,12 @@ bool __cdecl OLoad()
 	return result;
 }
 
-//----- (00426B7F) --------------------------------------------------------
 void __fastcall LoadPlayer(int i)
 {
 	memcpy(&plr[i], tbuff, 0x54B0u);
 	tbuff = (char *)tbuff + 21680;
 }
 
-//----- (00426BA9) --------------------------------------------------------
 void __fastcall LoadMonster(int i)
 {
 	int v1; // edi
@@ -472,21 +465,18 @@ void __fastcall LoadMonster(int i)
 	SyncMonsterAnim(v1);
 }
 
-//----- (00426BDE) --------------------------------------------------------
 void __fastcall LoadMissile(int i)
 {
 	memcpy(&missile[i], tbuff, 0xB0u);
 	tbuff = (char *)tbuff + 176;
 }
 
-//----- (00426C08) --------------------------------------------------------
 void __fastcall LoadObject(int i)
 {
 	memcpy(&object[i], tbuff, 0x78u);
 	tbuff = (char *)tbuff + 120;
 }
 
-//----- (00426C2A) --------------------------------------------------------
 void __fastcall LoadItem(int i)
 {
 	int v1; // edi
@@ -497,14 +487,12 @@ void __fastcall LoadItem(int i)
 	GetItemFrm(v1);
 }
 
-//----- (00426C5F) --------------------------------------------------------
 void __fastcall LoadPremium(int i)
 {
 	memcpy(&premiumitem[i], tbuff, 0x170u);
 	tbuff = (char *)tbuff + 368;
 }
 
-//----- (00426C89) --------------------------------------------------------
 void __fastcall LoadQuest(int i)
 {
 	memcpy(&quests[i], tbuff, 0x18u);
@@ -516,28 +504,24 @@ void __fastcall LoadQuest(int i)
 	DoomQuestState = ILoad();
 }
 
-//----- (00426CDE) --------------------------------------------------------
 void __fastcall LoadLighting(int i)
 {
 	memcpy(&LightList[i], tbuff, 0x34u);
 	tbuff = (char *)tbuff + 52;
 }
 
-//----- (00426D00) --------------------------------------------------------
 void __fastcall LoadVision(int i)
 {
 	memcpy(&VisionList[i], tbuff, 0x34u);
 	tbuff = (char *)tbuff + 52;
 }
 
-//----- (00426D22) --------------------------------------------------------
 void __fastcall LoadPortal(int i)
 {
 	memcpy(&portal[i], tbuff, 0x18u);
 	tbuff = (char *)tbuff + 24;
 }
 
-//----- (00426D45) --------------------------------------------------------
 void __cdecl SaveGame()
 {
 	int v0; // eax
@@ -896,14 +880,12 @@ void __cdecl SaveGame()
 // 5CCB10: using guessed type char setlvlnum;
 // 5CF31D: using guessed type char setlevel;
 
-//----- (00427203) --------------------------------------------------------
 void __fastcall BSave(char v)
 {
 	*(_BYTE *)tbuff = v;
 	tbuff = (char *)tbuff + 1;
 }
 
-//----- (00427211) --------------------------------------------------------
 void __fastcall ISave(int v)
 {
 	*(_BYTE *)tbuff = _HIBYTE(v);
@@ -916,7 +898,6 @@ void __fastcall ISave(int v)
 	tbuff = (char *)tbuff + 1;
 }
 
-//----- (00427258) --------------------------------------------------------
 void __fastcall ISave_2(int v)
 {
 	*(_BYTE *)tbuff = _HIBYTE(v);
@@ -929,7 +910,6 @@ void __fastcall ISave_2(int v)
 	tbuff = (char *)tbuff + 1;
 }
 
-//----- (0042729F) --------------------------------------------------------
 void __fastcall OSave(unsigned char v)
 {
 	if ( v )
@@ -939,49 +919,42 @@ void __fastcall OSave(unsigned char v)
 	tbuff = (char *)tbuff + 1;
 }
 
-//----- (004272B7) --------------------------------------------------------
 void __fastcall SavePlayer(int i)
 {
 	memcpy(tbuff, &plr[i], 0x54B0u);
 	tbuff = (char *)tbuff + 21680;
 }
 
-//----- (004272E1) --------------------------------------------------------
 void __fastcall SaveMonster(int i)
 {
 	memcpy(tbuff, &monster[i], 0xD8u);
 	tbuff = (char *)tbuff + 216;
 }
 
-//----- (0042730B) --------------------------------------------------------
 void __fastcall SaveMissile(int i)
 {
 	memcpy(tbuff, &missile[i], 0xB0u);
 	tbuff = (char *)tbuff + 176;
 }
 
-//----- (00427335) --------------------------------------------------------
 void __fastcall SaveObject(int i)
 {
 	memcpy(tbuff, &object[i], 0x78u);
 	tbuff = (char *)tbuff + 120;
 }
 
-//----- (00427357) --------------------------------------------------------
 void __fastcall SaveItem(int i)
 {
 	memcpy(tbuff, &item[i], 0x170u);
 	tbuff = (char *)tbuff + 368;
 }
 
-//----- (00427381) --------------------------------------------------------
 void __fastcall SavePremium(int i)
 {
 	memcpy(tbuff, &premiumitem[i], 0x170u);
 	tbuff = (char *)tbuff + 368;
 }
 
-//----- (004273AB) --------------------------------------------------------
 void __fastcall SaveQuest(int i)
 {
 	memcpy(tbuff, &quests[i], 0x18u);
@@ -993,28 +966,24 @@ void __fastcall SaveQuest(int i)
 	ISave(DoomQuestState);
 }
 
-//----- (00427404) --------------------------------------------------------
 void __fastcall SaveLighting(int i)
 {
 	memcpy(tbuff, &LightList[i], 0x34u);
 	tbuff = (char *)tbuff + 52;
 }
 
-//----- (00427426) --------------------------------------------------------
 void __fastcall SaveVision(int i)
 {
 	memcpy(tbuff, &VisionList[i], 0x34u);
 	tbuff = (char *)tbuff + 52;
 }
 
-//----- (00427448) --------------------------------------------------------
 void __fastcall SavePortal(int i)
 {
 	memcpy(tbuff, &portal[i], 0x18u);
 	tbuff = (char *)tbuff + 24;
 }
 
-//----- (0042746B) --------------------------------------------------------
 void __cdecl SaveLevel()
 {
 	int v0; // eax
@@ -1153,7 +1122,6 @@ void __cdecl SaveLevel()
 // 5CCB10: using guessed type char setlvlnum;
 // 5CF31D: using guessed type char setlevel;
 
-//----- (0042772F) --------------------------------------------------------
 void __cdecl LoadLevel()
 {
 	int i; // esi

--- a/Source/loadsave.h
+++ b/Source/loadsave.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __LOADSAVE_H__
+#define __LOADSAVE_H__
 
-//loadsave
 extern void *tbuff;
 
 void __fastcall LoadGame(bool firstflag);
@@ -35,3 +36,5 @@ void __fastcall SaveVision(int i);
 void __fastcall SavePortal(int i);
 void __cdecl SaveLevel();
 void __cdecl LoadLevel();
+
+#endif /* __LOADSAVE_H__ */

--- a/Source/logging.cpp
+++ b/Source/logging.cpp
@@ -16,7 +16,6 @@ int log_inf = 0x7F800000; // weak
 int log_not_created = 1; // weak
 HANDLE log_file = (HANDLE)0xFFFFFFFF; // idb
 
-//----- (004279F7) --------------------------------------------------------
 struct log_cpp_init_1
 {
 	log_cpp_init_1()
@@ -27,7 +26,6 @@ struct log_cpp_init_1
 // 47F070: using guessed type int log_inf;
 // 646A30: using guessed type int log_cpp_init_value;
 
-//----- (00427A02) --------------------------------------------------------
 struct log_cpp_init_2
 {
 	log_cpp_init_2()
@@ -37,25 +35,21 @@ struct log_cpp_init_2
 	}
 } _log_cpp_init_2;
 
-//----- (00427A0C) --------------------------------------------------------
 void __cdecl log_init_mutex()
 {
 	InitializeCriticalSection(&sgMemCrit);
 }
 
-//----- (00427A18) --------------------------------------------------------
 void __cdecl j_log_cleanup_mutex()
 {
 	atexit(log_cleanup_mutex);
 }
 
-//----- (00427A24) --------------------------------------------------------
 void __cdecl log_cleanup_mutex()
 {
 	DeleteCriticalSection(&sgMemCrit);
 }
 
-//----- (00427A30) --------------------------------------------------------
 void __cdecl log_flush(bool force_close)
 {
 	void *v1; // eax
@@ -86,7 +80,6 @@ void __cdecl log_flush(bool force_close)
 	LeaveCriticalSection(&sgMemCrit);
 }
 
-//----- (00427AC2) --------------------------------------------------------
 void *__cdecl log_create()
 {
 	char *v0; // eax
@@ -142,7 +135,6 @@ void *__cdecl log_create()
 }
 // 4947D4: using guessed type int log_not_created;
 
-//----- (00427C18) --------------------------------------------------------
 void __fastcall log_get_version(VS_FIXEDFILEINFO *file_info)
 {
 	DWORD v1; // eax
@@ -176,7 +168,6 @@ void __fastcall log_get_version(VS_FIXEDFILEINFO *file_info)
 	}
 }
 
-//----- (00427CC9) --------------------------------------------------------
 void log_printf(char *pszFmt, ...)
 {
 	size_t v1; // edi
@@ -203,7 +194,6 @@ void log_printf(char *pszFmt, ...)
 	LeaveCriticalSection(&sgMemCrit);
 }
 
-//----- (00427D75) --------------------------------------------------------
 void __cdecl log_dump_computer_info()
 {
 	char Buffer[64]; // [esp+0h] [ebp-88h]

--- a/Source/logging.h
+++ b/Source/logging.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __LOGGING_H__
+#define __LOGGING_H__
 
-//logging
 extern int log_cpp_init_value; // weak
 extern CHAR FileName[260]; // idb
 extern char log_buffer[388];
@@ -26,3 +27,5 @@ extern int log_inf; // weak
 
 extern int log_not_created; // weak
 extern HANDLE log_file; // idb
+
+#endif /* __LOGGING_H__ */

--- a/Source/mainmenu.cpp
+++ b/Source/mainmenu.cpp
@@ -11,7 +11,6 @@ int mainmenu_inf = 0x7F800000; // weak
 
 int menu_music_track_id = 5; // idb
 
-//----- (00427E13) --------------------------------------------------------
 struct mainmenu_cpp_init
 {
 	mainmenu_cpp_init()
@@ -22,7 +21,6 @@ struct mainmenu_cpp_init
 // 47F074: using guessed type int mainmenu_inf;
 // 646CE0: using guessed type int mainmenu_cpp_init_value;
 
-//----- (00427E1E) --------------------------------------------------------
 void __cdecl mainmenu_refresh_music()
 {
 	int v0; // eax
@@ -38,7 +36,6 @@ void __cdecl mainmenu_refresh_music()
 	menu_music_track_id = v0;
 }
 
-//----- (00427E45) --------------------------------------------------------
 void __stdcall mainmenu_create_hero(char *a1, char *a2)
 {
 	// char *v2; // [esp-14h] [ebp-14h]
@@ -47,7 +44,6 @@ void __stdcall mainmenu_create_hero(char *a1, char *a2)
 		pfile_create_save_file(a1, a2);
 }
 
-//----- (00427E62) --------------------------------------------------------
 int __stdcall mainmenu_select_hero_dialog(int u1, int u2, int u3, int u4, int mode, char *cname, int clen, char *cdesc, int cdlen, int *multi) /* fix args */
 {
 	int v10; // eax
@@ -110,7 +106,6 @@ LABEL_6:
 // 5256E8: using guessed type int dword_5256E8;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00427F76) --------------------------------------------------------
 void __fastcall mainmenu_action(int option)
 {
 	int v1; // eax
@@ -156,7 +151,6 @@ LABEL_16:
 }
 // 634980: using guessed type int window_activated;
 
-//----- (00427FEC) --------------------------------------------------------
 int __cdecl mainmenu_single_player()
 {
 	gbMaxPlayers = 1;
@@ -164,7 +158,6 @@ int __cdecl mainmenu_single_player()
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00427FFA) --------------------------------------------------------
 int __fastcall mainmenu_init_menu(int a1)
 {
 	int v1; // esi
@@ -180,7 +173,6 @@ int __fastcall mainmenu_init_menu(int a1)
 	return v3;
 }
 
-//----- (00428030) --------------------------------------------------------
 int __cdecl mainmenu_multi_player()
 {
 	gbMaxPlayers = 4;
@@ -188,7 +180,6 @@ int __cdecl mainmenu_multi_player()
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0042803F) --------------------------------------------------------
 void __cdecl mainmenu_play_intro()
 {
 	music_stop();

--- a/Source/mainmenu.h
+++ b/Source/mainmenu.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __MAINMENU_H__
+#define __MAINMENU_H__
 
-//mainmenu
 extern int mainmenu_cpp_init_value; // weak
 extern char chr_name_str[16];
 
@@ -21,3 +22,5 @@ extern int mainmenu_inf; // weak
 /* rdata */
 
 extern int menu_music_track_id; // idb
+
+#endif /* __MAINMENU_H__ */

--- a/Source/minitext.cpp
+++ b/Source/minitext.cpp
@@ -41,7 +41,6 @@ unsigned char mfontkern[56] =
 
 int qscroll_spd_tbl[9] = { 2, 4, 6, 8, 0, -1, -2, -3, -4 };
 
-//----- (00428056) --------------------------------------------------------
 void __cdecl FreeQuestText()
 {
 	void *v0; // ecx
@@ -55,7 +54,6 @@ void __cdecl FreeQuestText()
 	mem_free_dbg(v1);
 }
 
-//----- (0042807A) --------------------------------------------------------
 void __cdecl InitQuestText()
 {
 	unsigned char *v0; // eax
@@ -67,7 +65,6 @@ void __cdecl InitQuestText()
 }
 // 646D00: using guessed type char qtextflag;
 
-//----- (004280A4) --------------------------------------------------------
 void __fastcall InitQTextMsg(int m)
 {
 	if ( alltext[m].scrlltxt )
@@ -89,7 +86,6 @@ void __fastcall InitQTextMsg(int m)
 // 646D08: using guessed type int sgLastScroll;
 // 69BD04: using guessed type int questlog;
 
-//----- (00428104) --------------------------------------------------------
 void __cdecl DrawQTextBack()
 {
 	char *v0; // edi
@@ -139,7 +135,6 @@ void __cdecl DrawQTextBack()
 	*v0 = 0;
 }
 
-//----- (00428160) --------------------------------------------------------
 void __fastcall PrintQTextChr(int screen_x, int screen_y, char *cel_buf, int frame)
 {
 	char *v4; // ebx
@@ -205,7 +200,6 @@ LABEL_15:
 	while ( (char *)v7 != v5 );
 }
 
-//----- (00428202) --------------------------------------------------------
 void __cdecl DrawQText()
 {
 	char *v0; // edi

--- a/Source/minitext.h
+++ b/Source/minitext.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __MINITEXT_H__
+#define __MINITEXT_H__
 
-//minitext
 extern int qtexty; // weak
 extern char *qtextptr;
 extern int qtextSpd; // weak
@@ -25,3 +26,5 @@ extern unsigned char mfontkern[56];
 /* rdata */
 
 extern int qscroll_spd_tbl[9];
+
+#endif /* __MINITEXT_H__ */

--- a/Source/missiles.cpp
+++ b/Source/missiles.cpp
@@ -464,7 +464,6 @@ MisFileData misfiledata[47] =
 int XDirAdd[8] = { 1, 0, -1, -1, -1, 0, 1, 1 };
 int YDirAdd[8] = { 1, 1, 1, 0, -1, -1, -1, 0 };
 
-//----- (004283C0) --------------------------------------------------------
 void __fastcall GetDamageAmt(int i, int *mind, int *maxd)
 {
 	int v3; // eax
@@ -779,7 +778,6 @@ LABEL_74:
 	}
 }
 
-//----- (00428921) --------------------------------------------------------
 int __fastcall CheckBlock(int fx, int fy, int tx, int ty)
 {
 	int v4; // edi
@@ -801,7 +799,6 @@ int __fastcall CheckBlock(int fx, int fy, int tx, int ty)
 	return v6;
 }
 
-//----- (0042897A) --------------------------------------------------------
 int __fastcall FindClosest(int sx, int sy, int rad)
 {
 	int v3; // eax
@@ -871,7 +868,6 @@ LABEL_13:
 	}
 }
 
-//----- (00428A99) --------------------------------------------------------
 int __fastcall GetSpellLevel(int id, int sn)
 {
 	int result; // eax
@@ -885,7 +881,6 @@ int __fastcall GetSpellLevel(int id, int sn)
 	return result;
 }
 
-//----- (00428AC4) --------------------------------------------------------
 int __fastcall GetDirection8(int x1, int y1, int x2, int y2)
 {
 	int v4; // edi
@@ -973,7 +968,6 @@ int __fastcall GetDirection8(int x1, int y1, int x2, int y2)
 	return result;
 }
 
-//----- (004290EE) --------------------------------------------------------
 int __fastcall GetDirection16(int x1, int y1, int x2, int y2)
 {
 	int v4; // edi
@@ -1069,7 +1063,6 @@ int __fastcall GetDirection16(int x1, int y1, int x2, int y2)
 	return result;
 }
 
-//----- (0042977E) --------------------------------------------------------
 void __fastcall DeleteMissile(int mi, int i)
 {
 	int v2; // edi
@@ -1097,7 +1090,6 @@ void __fastcall DeleteMissile(int mi, int i)
 		missileactive[v3] = missileactive[v5];
 }
 
-//----- (004297EE) --------------------------------------------------------
 void __fastcall GetMissileVel(int i, int sx, int sy, int dx, int dy, int v)
 {
 	int v6; // eax
@@ -1123,7 +1115,6 @@ void __fastcall GetMissileVel(int i, int sx, int sy, int dx, int dy, int v)
 	}
 }
 
-//----- (004298AD) --------------------------------------------------------
 void __fastcall PutMissile(int i)
 {
 	int v1; // eax
@@ -1152,7 +1143,6 @@ void __fastcall PutMissile(int i)
 }
 // 64CCD4: using guessed type int MissilePreFlag;
 
-//----- (00429918) --------------------------------------------------------
 void __fastcall GetMissilePos(int i)
 {
 	int v1; // ecx
@@ -1203,7 +1193,6 @@ void __fastcall GetMissilePos(int i)
 	ChangeLightOff(missile[v1]._mlid, v12 - 8 * v8, v10 - 8 * v11);
 }
 
-//----- (004299EA) --------------------------------------------------------
 void __fastcall MoveMissilePos(int i)
 {
 	int v1; // esi
@@ -1248,7 +1237,6 @@ LABEL_7:
 	}
 }
 
-//----- (00429A99) --------------------------------------------------------
 bool __fastcall MonsterTrapHit(int m, int mindam, int maxdam, int dist, int t, int shift)
 {
 	int v6; // esi
@@ -1344,7 +1332,6 @@ bool __fastcall MonsterTrapHit(int m, int mindam, int maxdam, int dist, int t, i
 	return 1;
 }
 
-//----- (00429C3B) --------------------------------------------------------
 bool __fastcall MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, int t, int shift)
 {
 	int v7; // edi
@@ -1515,7 +1502,6 @@ bool __fastcall MonsterMHit(int pnum, int m, int mindam, int maxdam, int dist, i
 	return 1;
 }
 
-//----- (00429F4E) --------------------------------------------------------
 bool __fastcall PlayerMHit(int pnum, int m, int dist, int mind, int maxd, int mtype, int shift, int earflag)
 {
 	int v8; // ebx
@@ -1756,7 +1742,6 @@ LABEL_78:
 	return 0;
 }
 
-//----- (0042A307) --------------------------------------------------------
 bool __fastcall Plr2PlrMHit(int pnum, int p, int mindam, int maxdam, int dist, int mtype, int shift)
 {
 	int v7; // edi
@@ -1922,7 +1907,6 @@ LABEL_14:
 	return 0;
 }
 
-//----- (0042A5DB) --------------------------------------------------------
 void __fastcall CheckMissileCol(int i, int mindam, int maxdam, bool shift, int mx, int my, int nodel)
 {
 	int v7; // ebx
@@ -2107,7 +2091,6 @@ LABEL_39:
 	}
 }
 
-//----- (0042A8D5) --------------------------------------------------------
 void __fastcall SetMissAnim(int mi, int animtype)
 {
 	int v2; // ecx
@@ -2142,14 +2125,12 @@ void __fastcall SetMissAnim(int mi, int animtype)
 	missile[v2]._miAnimFrame = 1;
 }
 
-//----- (0042A959) --------------------------------------------------------
 void __fastcall SetMissDir(int mi, int dir)
 {
 	missile[mi]._mimfnum = dir;
 	SetMissAnim(mi, _LOBYTE(missile[mi]._miAnimType));
 }
 
-//----- (0042A973) --------------------------------------------------------
 void __fastcall LoadMissileGFX(int mi)
 {
 	MisFileData *v1; // esi
@@ -2211,7 +2192,6 @@ void __fastcall LoadMissileGFX(int mi)
 	}
 }
 
-//----- (0042AA5C) --------------------------------------------------------
 void __cdecl InitMissileGFX()
 {
 	char v0; // bl
@@ -2232,7 +2212,6 @@ void __cdecl InitMissileGFX()
 	}
 }
 
-//----- (0042AA89) --------------------------------------------------------
 void __fastcall FreeMissileGFX(int mi)
 {
 	int v1; // esi
@@ -2273,7 +2252,6 @@ void __fastcall FreeMissileGFX(int mi)
 	}
 }
 
-//----- (0042AAF2) --------------------------------------------------------
 void __cdecl FreeMissiles()
 {
 	int v0; // edi
@@ -2294,7 +2272,6 @@ void __cdecl FreeMissiles()
 	}
 }
 
-//----- (0042AB20) --------------------------------------------------------
 void __cdecl FreeMissiles2()
 {
 	int v0; // edi
@@ -2315,7 +2292,6 @@ void __cdecl FreeMissiles2()
 	}
 }
 
-//----- (0042AB4E) --------------------------------------------------------
 void __cdecl InitMissiles()
 {
 	int v0; // eax
@@ -2380,7 +2356,6 @@ void __cdecl InitMissiles()
 }
 // 64CCD8: using guessed type int END_unkmis_126;
 
-//----- (0042AC0C) --------------------------------------------------------
 void __fastcall AddLArrow(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -2430,7 +2405,6 @@ LABEL_12:
 	missile[v15]._mlid = AddLight(v10, sy, 5);
 }
 
-//----- (0042ACD9) --------------------------------------------------------
 void __fastcall AddArrow(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // ebx
@@ -2479,7 +2453,6 @@ void __fastcall AddArrow(int mi, int sx, int sy, int dx, int dy, int midir, int 
 	missile[v14]._miAnimFrame = v15 + 1;
 }
 
-//----- (0042ADAA) --------------------------------------------------------
 void __fastcall GetVileMissPos(int mi, int dx, int dy)
 {
 	signed int v3; // edi
@@ -2534,7 +2507,6 @@ void __fastcall GetVileMissPos(int mi, int dx, int dy)
 	missile[v6]._miy = dy;
 }
 
-//----- (0042AE48) --------------------------------------------------------
 void __fastcall AddRndTeleport(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // eax
@@ -2603,7 +2575,6 @@ LABEL_12:
 // 5CCB10: using guessed type char setlvlnum;
 // 5CF31D: using guessed type char setlevel;
 
-//----- (0042AF8B) --------------------------------------------------------
 void __fastcall AddFirebolt(int mi, int sx, int sy, int dx, int dy, int midir, int micaster, int id, int dam)
 {
 	int v9; // ebx
@@ -2661,7 +2632,6 @@ LABEL_17:
 	missile[v15]._mlid = AddLight(v11, sy, 8);
 }
 
-//----- (0042B09A) --------------------------------------------------------
 void __fastcall AddMagmaball(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -2682,7 +2652,6 @@ void __fastcall AddMagmaball(int mi, int sx, int sy, int dx, int dy, int midir, 
 	*(int *)((char *)&missile[0]._mlid + v9) = AddLight(v10, sy, 8);
 }
 
-//----- (0042B113) --------------------------------------------------------
 void __fastcall miss_null_33(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -2699,7 +2668,6 @@ void __fastcall miss_null_33(int mi, int sx, int sy, int dx, int dy, int midir, 
 	PutMissile(v10);
 }
 
-//----- (0042B159) --------------------------------------------------------
 void __fastcall AddTeleport(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -2774,7 +2742,6 @@ LABEL_13:
 	}
 }
 
-//----- (0042B284) --------------------------------------------------------
 void __fastcall AddLightball(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // edi
@@ -2806,7 +2773,6 @@ void __fastcall AddLightball(int mi, int sx, int sy, int dx, int dy, int midir, 
 	}
 }
 
-//----- (0042B303) --------------------------------------------------------
 void __fastcall AddFirewall(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // ST20_4
@@ -2837,7 +2803,6 @@ void __fastcall AddFirewall(int mi, int sx, int sy, int dx, int dy, int midir, i
 	missile[v11]._miVar1 = v16;
 }
 
-//----- (0042B3C0) --------------------------------------------------------
 void __fastcall AddFireball(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // edi
@@ -2904,7 +2869,6 @@ void __fastcall AddFireball(int mi, int sx, int sy, int dx, int dy, int midir, i
 	missile[v16]._mlid = AddLight(v9, sy, 8);
 }
 
-//----- (0042B4E7) --------------------------------------------------------
 void __fastcall AddLightctrl(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // edi
@@ -2927,7 +2891,6 @@ void __fastcall AddLightctrl(int mi, int sx, int sy, int dx, int dy, int midir, 
 	missile[v11]._miAnimFrame = v13 + 1;
 }
 
-//----- (0042B553) --------------------------------------------------------
 void __fastcall AddLightning(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -2965,7 +2928,6 @@ LABEL_10:
 	missile[v9]._mlid = AddLight(missile[v9]._mix, missile[v9]._miy, 4);
 }
 
-//----- (0042B620) --------------------------------------------------------
 void __fastcall AddMisexp(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // edi
@@ -3002,7 +2964,6 @@ void __fastcall AddMisexp(int mi, int sx, int sy, int dx, int dy, int midir, int
 	missile[v11]._mirange = missile[v9]._miAnimLen;
 }
 
-//----- (0042B711) --------------------------------------------------------
 void __fastcall AddWeapexp(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -3024,7 +2985,6 @@ void __fastcall AddWeapexp(int mi, int sx, int sy, int dx, int dy, int midir, in
 	missile[v9]._mirange = missile[v9]._miAnimLen - 1;
 }
 
-//----- (0042B77C) --------------------------------------------------------
 bool __fastcall CheckIfTrig(int x, int y)
 {
 	int v2; // edi
@@ -3054,7 +3014,6 @@ bool __fastcall CheckIfTrig(int x, int y)
 	return 1;
 }
 
-//----- (0042B7DF) --------------------------------------------------------
 void __fastcall AddTown(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // ebx
@@ -3177,7 +3136,6 @@ LABEL_14:
 // 5CCB10: using guessed type char setlvlnum;
 // 5CF31D: using guessed type char setlevel;
 
-//----- (0042B9FC) --------------------------------------------------------
 void __fastcall AddFlash(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -3230,7 +3188,6 @@ LABEL_13:
 	missile[v9]._mirange = 19;
 }
 
-//----- (0042BAC1) --------------------------------------------------------
 void __fastcall AddFlash2(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -3278,7 +3235,6 @@ void __fastcall AddFlash2(int mi, int sx, int sy, int dx, int dy, int midir, int
 	missile[v14]._mirange = 19;
 }
 
-//----- (0042BB83) --------------------------------------------------------
 void __fastcall AddManashield(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // eax
@@ -3295,7 +3251,6 @@ void __fastcall AddManashield(int mi, int sx, int sy, int dx, int dy, int midir,
 	plr[id].pManaShield = 1;
 }
 
-//----- (0042BBFA) --------------------------------------------------------
 void __fastcall AddFiremove(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // edi
@@ -3317,7 +3272,6 @@ void __fastcall AddFiremove(int mi, int sx, int sy, int dx, int dy, int midir, i
 	*(int *)((char *)&missile[0]._mirange + v11) = 255;
 }
 
-//----- (0042BC76) --------------------------------------------------------
 void __fastcall AddGuardian(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // edi
@@ -3445,7 +3399,6 @@ LABEL_18:
 	}
 }
 
-//----- (0042BE98) --------------------------------------------------------
 void __fastcall AddChain(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // ecx
@@ -3456,7 +3409,6 @@ void __fastcall AddChain(int mi, int sx, int sy, int dx, int dy, int midir, int 
 	missile[v9]._mirange = 1;
 }
 
-//----- (0042BECB) --------------------------------------------------------
 void __fastcall miss_null_11(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -3470,7 +3422,6 @@ void __fastcall miss_null_11(int mi, int sx, int sy, int dx, int dy, int midir, 
 	missile[v10]._mirange = 250;
 }
 
-//----- (0042BEFE) --------------------------------------------------------
 void __fastcall miss_null_12(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	signed int v9; // edx
@@ -3488,7 +3439,6 @@ void __fastcall miss_null_12(int mi, int sx, int sy, int dx, int dy, int midir, 
 	missile[v11]._mirange = 250;
 }
 
-//----- (0042BF3B) --------------------------------------------------------
 void __fastcall miss_null_13(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	signed int v9; // edx
@@ -3508,7 +3458,6 @@ void __fastcall miss_null_13(int mi, int sx, int sy, int dx, int dy, int midir, 
 	missile[v11]._mirange = v12;
 }
 
-//----- (0042BF7A) --------------------------------------------------------
 void __fastcall AddRhino(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -3561,7 +3510,6 @@ void __fastcall AddRhino(int mi, int sx, int sy, int dx, int dy, int midir, int 
 	PutMissile(i);
 }
 
-//----- (0042C08B) --------------------------------------------------------
 void __fastcall miss_null_32(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -3598,7 +3546,6 @@ void __fastcall miss_null_32(int mi, int sx, int sy, int dx, int dy, int midir, 
 	PutMissile(v10);
 }
 
-//----- (0042C167) --------------------------------------------------------
 void __fastcall AddFlare(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // edi
@@ -3653,7 +3600,6 @@ void __fastcall AddFlare(int mi, int sx, int sy, int dx, int dy, int midir, int 
 	}
 }
 
-//----- (0042C276) --------------------------------------------------------
 void __fastcall AddAcid(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -3676,7 +3622,6 @@ void __fastcall AddAcid(int mi, int sx, int sy, int dx, int dy, int midir, int m
 	PutMissile(v10);
 }
 
-//----- (0042C2EE) --------------------------------------------------------
 void __fastcall miss_null_1D(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // ecx
@@ -3692,7 +3637,6 @@ void __fastcall miss_null_1D(int mi, int sx, int sy, int dx, int dy, int midir, 
 	missile[v9]._miVar2 = 0;
 }
 
-//----- (0042C32A) --------------------------------------------------------
 void __fastcall AddAcidpud(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -3712,7 +3656,6 @@ void __fastcall AddAcidpud(int mi, int sx, int sy, int dx, int dy, int midir, in
 	missile[v9]._mirange = v11 + 40 * ((unsigned char)monster[v10]._mint + 1);
 }
 
-//----- (0042C38E) --------------------------------------------------------
 void __fastcall AddStone(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // eax
@@ -3806,7 +3749,6 @@ LABEL_19:
 	}
 }
 
-//----- (0042C518) --------------------------------------------------------
 void __fastcall AddGolem(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // eax
@@ -3858,7 +3800,6 @@ LABEL_6:
 	}
 }
 
-//----- (0042C5DA) --------------------------------------------------------
 void __fastcall AddEtherealize(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // edx
@@ -3892,13 +3833,11 @@ void __fastcall AddEtherealize(int mi, int sx, int sy, int dx, int dy, int midir
 		UseMana(id, 25);
 }
 
-//----- (0042C664) --------------------------------------------------------
 void __fastcall miss_null_1F(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	missile[mi]._miDelFlag = 1;
 }
 
-//----- (0042C677) --------------------------------------------------------
 void __fastcall miss_null_23(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -3921,7 +3860,6 @@ void __fastcall miss_null_23(int mi, int sx, int sy, int dx, int dy, int midir, 
 	missile[v9]._mirange = v11;
 }
 
-//----- (0042C6D9) --------------------------------------------------------
 void __fastcall AddBoom(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // ecx
@@ -3940,7 +3878,6 @@ void __fastcall AddBoom(int mi, int sx, int sy, int dx, int dy, int midir, int m
 	missile[v9]._miVar1 = 0;
 }
 
-//----- (0042C72C) --------------------------------------------------------
 void __fastcall AddHeal(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -3996,7 +3933,6 @@ void __fastcall AddHeal(int mi, int sx, int sy, int dx, int dy, int midir, int m
 	drawhpflag = 1;
 }
 
-//----- (0042C80C) --------------------------------------------------------
 void __fastcall AddHealOther(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	missile[mi]._miDelFlag = 1;
@@ -4005,7 +3941,6 @@ void __fastcall AddHealOther(int mi, int sx, int sy, int dx, int dy, int midir, 
 		SetCursor(CURSOR_HEALOTHER);
 }
 
-//----- (0042C83F) --------------------------------------------------------
 void __fastcall AddElement(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // ebx
@@ -4058,7 +3993,6 @@ void __fastcall AddElement(int mi, int sx, int sy, int dx, int dy, int midir, in
 	missile[v14]._mlid = AddLight(x, sy, 8);
 }
 
-//----- (0042C942) --------------------------------------------------------
 void __fastcall AddIdentify(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	missile[mi]._miDelFlag = 1;
@@ -4074,7 +4008,6 @@ void __fastcall AddIdentify(int mi, int sx, int sy, int dx, int dy, int midir, i
 }
 // 4B8968: using guessed type int sbookflag;
 
-//----- (0042C993) --------------------------------------------------------
 void __fastcall AddFirewallC(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -4154,7 +4087,6 @@ LABEL_16:
 	}
 }
 
-//----- (0042CAF5) --------------------------------------------------------
 void __fastcall AddInfra(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // ecx
@@ -4180,7 +4112,6 @@ void __fastcall AddInfra(int mi, int sx, int sy, int dx, int dy, int midir, int 
 		UseMana(id, 9);
 }
 
-//----- (0042CB5C) --------------------------------------------------------
 void __fastcall AddWave(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // ecx
@@ -4194,7 +4125,6 @@ void __fastcall AddWave(int mi, int sx, int sy, int dx, int dy, int midir, int m
 	missile[v9]._miAnimFrame = 4;
 }
 
-//----- (0042CBA7) --------------------------------------------------------
 void __fastcall AddNova(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -4266,7 +4196,6 @@ void __fastcall AddNova(int mi, int sx, int sy, int dx, int dy, int midir, int m
 	missile[v9]._mirange = 1;
 }
 
-//----- (0042CC98) --------------------------------------------------------
 void __fastcall AddRepair(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	missile[mi]._miDelFlag = 1;
@@ -4282,7 +4211,6 @@ void __fastcall AddRepair(int mi, int sx, int sy, int dx, int dy, int midir, int
 }
 // 4B8968: using guessed type int sbookflag;
 
-//----- (0042CCE9) --------------------------------------------------------
 void __fastcall AddRecharge(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	missile[mi]._miDelFlag = 1;
@@ -4298,7 +4226,6 @@ void __fastcall AddRecharge(int mi, int sx, int sy, int dx, int dy, int midir, i
 }
 // 4B8968: using guessed type int sbookflag;
 
-//----- (0042CD3A) --------------------------------------------------------
 void __fastcall AddDisarm(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	missile[mi]._miDelFlag = 1;
@@ -4307,7 +4234,6 @@ void __fastcall AddDisarm(int mi, int sx, int sy, int dx, int dy, int midir, int
 		SetCursor(CURSOR_DISARM);
 }
 
-//----- (0042CD6D) --------------------------------------------------------
 void __fastcall AddApoca(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -4351,7 +4277,6 @@ void __fastcall AddApoca(int mi, int sx, int sy, int dx, int dy, int midir, int 
 	missile[v9]._mirange = 255;
 }
 
-//----- (0042CE32) --------------------------------------------------------
 void __fastcall AddFlame(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -4392,7 +4317,6 @@ void __fastcall AddFlame(int mi, int sx, int sy, int dx, int dy, int midir, int 
 	}
 }
 
-//----- (0042CF35) --------------------------------------------------------
 void __fastcall AddFlamec(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -4420,7 +4344,6 @@ void __fastcall AddFlamec(int mi, int sx, int sy, int dx, int dy, int midir, int
 	missile[v13]._mirange = 256;
 }
 
-//----- (0042CFAD) --------------------------------------------------------
 void __fastcall AddCbolt(int mi, int sx, int sy, int dx, int dy, int midir, int micaster, int id, int dam)
 {
 	int v9; // esi
@@ -4467,7 +4390,6 @@ void __fastcall AddCbolt(int mi, int sx, int sy, int dx, int dy, int midir, int 
 	missile[v9]._mirange = 256;
 }
 
-//----- (0042D098) --------------------------------------------------------
 void __fastcall AddHbolt(int mi, int sx, int sy, int dx, int dy, int midir, int micaster, int id, int dam)
 {
 	int v9; // esi
@@ -4516,7 +4438,6 @@ LABEL_8:
 	missile[v14]._midam = random(v16, 10) + plr[id]._pLevel + 9;
 }
 
-//----- (0042D178) --------------------------------------------------------
 void __fastcall AddResurrect(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // esi
@@ -4528,7 +4449,6 @@ void __fastcall AddResurrect(int mi, int sx, int sy, int dx, int dy, int midir, 
 	missile[v9]._miDelFlag = 1;
 }
 
-//----- (0042D1AF) --------------------------------------------------------
 void __fastcall AddResurrectBeam(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // ecx
@@ -4545,7 +4465,6 @@ void __fastcall AddResurrectBeam(int mi, int sx, int sy, int dx, int dy, int mid
 	missile[v9]._mirange = v10;
 }
 
-//----- (0042D1F3) --------------------------------------------------------
 void __fastcall AddTelekinesis(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	missile[mi]._miDelFlag = 1;
@@ -4554,7 +4473,6 @@ void __fastcall AddTelekinesis(int mi, int sx, int sy, int dx, int dy, int midir
 		SetCursor(CURSOR_TELEKINESIS);
 }
 
-//----- (0042D226) --------------------------------------------------------
 void __fastcall AddBoneSpirit(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // ebx
@@ -4598,7 +4516,6 @@ void __fastcall AddBoneSpirit(int mi, int sx, int sy, int dx, int dy, int midir,
 	}
 }
 
-//----- (0042D311) --------------------------------------------------------
 void __fastcall AddRportal(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	int v9; // eax
@@ -4616,7 +4533,6 @@ void __fastcall AddRportal(int mi, int sx, int sy, int dx, int dy, int midir, in
 	PutMissile(mi);
 }
 
-//----- (0042D35B) --------------------------------------------------------
 void __fastcall AddDiabApoca(int mi, int sx, int sy, int dx, int dy, int midir, int mienemy, int id, int dam)
 {
 	signed int v9; // edi
@@ -4649,7 +4565,6 @@ void __fastcall AddDiabApoca(int mi, int sx, int sy, int dx, int dy, int midir, 
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0042D3DA) --------------------------------------------------------
 int __fastcall AddMissile(int sx, int sy, int v1, int v2, int midir, int mitype, int micaster, int id, int v3, int spllvl)
 {
 	int v10; // esi
@@ -4736,7 +4651,6 @@ LABEL_9:
 	return v13;
 }
 
-//----- (0042D5A3) --------------------------------------------------------
 int __fastcall Sentfire(int i, int sx, int sy)
 {
 	int v3; // esi
@@ -4782,7 +4696,6 @@ void __fastcall MI_Dummy(int i)
 	return;
 }
 
-//----- (0042D680) --------------------------------------------------------
 void __fastcall MI_Golem(int i)
 {
 	int v1; // esi
@@ -4864,13 +4777,11 @@ LABEL_17:
 	missile[v1]._miDelFlag = 1;
 }
 
-//----- (0042D7C7) --------------------------------------------------------
 void __fastcall MI_SetManashield(int i)
 {
 	ManashieldFlag = 1;
 }
 
-//----- (0042D7D2) --------------------------------------------------------
 void __fastcall MI_LArrow(int i)
 {
 	int v1; // esi
@@ -5028,7 +4939,6 @@ void __fastcall MI_LArrow(int i)
 	PutMissile(ia);
 }
 
-//----- (0042DAD0) --------------------------------------------------------
 void __fastcall MI_Arrow(int i)
 {
 	int v1; // esi
@@ -5077,7 +4987,6 @@ void __fastcall MI_Arrow(int i)
 	PutMissile(ia);
 }
 
-//----- (0042DBA1) --------------------------------------------------------
 void __fastcall MI_Firebolt(int i)
 {
 	int v1; // edi
@@ -5253,7 +5162,6 @@ LABEL_39:
 	PutMissile(v1);
 }
 
-//----- (0042DE5A) --------------------------------------------------------
 void __fastcall MI_Lightball(int i)
 {
 	int v1; // esi
@@ -5292,7 +5200,6 @@ void __fastcall MI_Lightball(int i)
 	PutMissile(ia);
 }
 
-//----- (0042DF42) --------------------------------------------------------
 void __fastcall mi_null_33(int i)
 {
 	int v1; // edi
@@ -5312,7 +5219,6 @@ void __fastcall mi_null_33(int i)
 	PutMissile(v1);
 }
 
-//----- (0042DFAB) --------------------------------------------------------
 void __fastcall MI_Acidpud(int i)
 {
 	int v1; // ebx
@@ -5344,7 +5250,6 @@ void __fastcall MI_Acidpud(int i)
 	PutMissile(v1);
 }
 
-//----- (0042E01E) --------------------------------------------------------
 void __fastcall MI_Firewall(int i)
 {
 	int v1; // esi
@@ -5410,7 +5315,6 @@ void __fastcall MI_Firewall(int i)
 	PutMissile(ia);
 }
 
-//----- (0042E18F) --------------------------------------------------------
 void __fastcall MI_Fireball(int i)
 {
 	int v1; // esi
@@ -5545,7 +5449,6 @@ void __fastcall MI_Fireball(int i)
 	PutMissile(ia);
 }
 
-//----- (0042E5A7) --------------------------------------------------------
 void __fastcall MI_Lightctrl(int i)
 {
 	int v1; // esi
@@ -5641,7 +5544,6 @@ LABEL_27:
 		missile[v1]._miDelFlag = 1;
 }
 
-//----- (0042E79B) --------------------------------------------------------
 void __fastcall MI_Lightning(int i)
 {
 	int v1; // edi
@@ -5668,7 +5570,6 @@ void __fastcall MI_Lightning(int i)
 	PutMissile(v1);
 }
 
-//----- (0042E820) --------------------------------------------------------
 void __fastcall MI_Town(int i)
 {
 	int v1; // esi
@@ -5743,7 +5644,6 @@ void __fastcall MI_Town(int i)
 	PutMissile(ia);
 }
 
-//----- (0042E9CB) --------------------------------------------------------
 void __fastcall MI_Flash(int i)
 {
 	int v1; // edi
@@ -5783,7 +5683,6 @@ void __fastcall MI_Flash(int i)
 	PutMissile(v1);
 }
 
-//----- (0042EAF1) --------------------------------------------------------
 void __fastcall MI_Flash2(int i)
 {
 	int v1; // edi
@@ -5820,7 +5719,6 @@ void __fastcall MI_Flash2(int i)
 	PutMissile(v1);
 }
 
-//----- (0042EBBF) --------------------------------------------------------
 void __fastcall MI_Manashield(int i)
 {
 	int v1; // edi
@@ -5940,7 +5838,6 @@ LABEL_33:
 	PutMissile(ia);
 }
 
-//----- (0042EE19) --------------------------------------------------------
 void __fastcall MI_Etherealize(int i)
 {
 	int v1; // ebx
@@ -5996,7 +5893,6 @@ void __fastcall MI_Etherealize(int i)
 	PutMissile(v1);
 }
 
-//----- (0042EEFD) --------------------------------------------------------
 void __fastcall MI_Firemove(int i)
 {
 	int v1; // esi
@@ -6078,7 +5974,6 @@ void __fastcall MI_Firemove(int i)
 	PutMissile(v10);
 }
 
-//----- (0042F0C8) --------------------------------------------------------
 void __fastcall MI_Guardian(int i)
 {
 	int v1; // esi
@@ -6182,7 +6077,6 @@ void __fastcall MI_Guardian(int i)
 	PutMissile(ia);
 }
 
-//----- (0042F2C2) --------------------------------------------------------
 void __fastcall MI_Chain(int i)
 {
 	int v1; // esi
@@ -6274,7 +6168,6 @@ void __fastcall MI_Chain(int i)
 		missile[v1]._miDelFlag = 1;
 }
 
-//----- (0042F475) --------------------------------------------------------
 void __fastcall mi_null_11(int i)
 {
 	int v1; // eax
@@ -6290,7 +6183,6 @@ void __fastcall mi_null_11(int i)
 	PutMissile(i);
 }
 
-//----- (0042F4A9) --------------------------------------------------------
 void __fastcall MI_Weapexp(int i)
 {
 	int v1; // esi
@@ -6358,7 +6250,6 @@ void __fastcall MI_Weapexp(int i)
 	}
 }
 
-//----- (0042F5D6) --------------------------------------------------------
 void __fastcall MI_Misexp(int i)
 {
 	int v1; // edi
@@ -6400,7 +6291,6 @@ void __fastcall MI_Misexp(int i)
 	}
 }
 
-//----- (0042F692) --------------------------------------------------------
 void __fastcall MI_Acidsplat(int i)
 {
 	int v1; // eax
@@ -6442,7 +6332,6 @@ void __fastcall MI_Acidsplat(int i)
 	}
 }
 
-//----- (0042F723) --------------------------------------------------------
 void __fastcall MI_Teleport(int i)
 {
 	int v1; // edi
@@ -6499,7 +6388,6 @@ void __fastcall MI_Teleport(int i)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0042F82C) --------------------------------------------------------
 void __fastcall MI_Stone(int i)
 {
 	int v1; // esi
@@ -6542,7 +6430,6 @@ void __fastcall MI_Stone(int i)
 	}
 }
 
-//----- (0042F8EE) --------------------------------------------------------
 void __fastcall MI_Boom(int i)
 {
 	int v1; // edi
@@ -6560,7 +6447,6 @@ void __fastcall MI_Boom(int i)
 	PutMissile(v1);
 }
 
-//----- (0042F94F) --------------------------------------------------------
 void __fastcall MI_Rhino(int i)
 {
 	int v1; // ebx
@@ -6632,7 +6518,6 @@ LABEL_12:
 	PutMissile(arglist);
 }
 
-//----- (0042FAD0) --------------------------------------------------------
 void __fastcall mi_null_32(int i)
 {
 	int v1; // edi
@@ -6716,7 +6601,6 @@ void __fastcall mi_null_32(int i)
 	PutMissile(arglist);
 }
 
-//----- (0042FC74) --------------------------------------------------------
 void __fastcall MI_FirewallC(int i)
 {
 	int v1; // esi
@@ -6805,7 +6689,6 @@ void __fastcall MI_FirewallC(int i)
 	}
 }
 
-//----- (0042FDE3) --------------------------------------------------------
 void __fastcall MI_Infra(int i)
 {
 	int v1; // eax
@@ -6825,7 +6708,6 @@ void __fastcall MI_Infra(int i)
 	}
 }
 
-//----- (0042FE20) --------------------------------------------------------
 void __fastcall MI_Apoca(int i)
 {
 	int v1; // esi
@@ -6890,7 +6772,6 @@ LABEL_18:
 	}
 }
 
-//----- (0042FF0B) --------------------------------------------------------
 void __fastcall MI_Wave(int i)
 {
 	int v1; // esi
@@ -6980,7 +6861,6 @@ void __fastcall MI_Wave(int i)
 		missile[v1]._miDelFlag = 1;
 }
 
-//----- (00430154) --------------------------------------------------------
 void __fastcall MI_Nova(int i)
 {
 	int v1; // edi
@@ -7036,13 +6916,11 @@ void __fastcall MI_Nova(int i)
 		missile[v1]._miDelFlag = 1;
 }
 
-//----- (004302A7) --------------------------------------------------------
 void __fastcall MI_Blodboil(int i)
 {
 	missile[i]._miDelFlag = 1;
 }
 
-//----- (004302B8) --------------------------------------------------------
 void __fastcall MI_Flame(int i)
 {
 	int v1; // ebx
@@ -7086,7 +6964,6 @@ void __fastcall MI_Flame(int i)
 		PutMissile(v1);
 }
 
-//----- (0043037E) --------------------------------------------------------
 void __fastcall MI_Flamec(int i)
 {
 	int v1; // edi
@@ -7139,7 +7016,6 @@ void __fastcall MI_Flamec(int i)
 		missile[v2]._miDelFlag = 1;
 }
 
-//----- (0043045C) --------------------------------------------------------
 void __fastcall MI_Cbolt(int i)
 {
 	int v1; // esi
@@ -7223,7 +7099,6 @@ void __fastcall MI_Cbolt(int i)
 	PutMissile(ia);
 }
 
-//----- (004305E2) --------------------------------------------------------
 void __fastcall MI_Hbolt(int i)
 {
 	int v1; // edi
@@ -7280,7 +7155,6 @@ void __fastcall MI_Hbolt(int i)
 	PutMissile(v1);
 }
 
-//----- (0043071F) --------------------------------------------------------
 void __fastcall MI_Element(int i)
 {
 	int v1; // esi
@@ -7395,7 +7269,6 @@ void __fastcall MI_Element(int i)
 	PutMissile(ia);
 }
 
-//----- (00430A98) --------------------------------------------------------
 void __fastcall MI_Bonespirit(int i)
 {
 	int v1; // ebx
@@ -7486,7 +7359,6 @@ void __fastcall MI_Bonespirit(int i)
 	PutMissile(v5);
 }
 
-//----- (00430C8D) --------------------------------------------------------
 void __fastcall MI_ResurrectBeam(int i)
 {
 	int v1; // eax
@@ -7500,7 +7372,6 @@ void __fastcall MI_ResurrectBeam(int i)
 	PutMissile(i);
 }
 
-//----- (00430CAC) --------------------------------------------------------
 void __fastcall MI_Rportal(int i)
 {
 	int v1; // esi
@@ -7554,7 +7425,6 @@ LABEL_13:
 	PutMissile(ia);
 }
 
-//----- (00430DDA) --------------------------------------------------------
 void __cdecl ProcessMissiles()
 {
 	int v0; // eax
@@ -7656,7 +7526,6 @@ void __cdecl ProcessMissiles()
 }
 // 64CCD4: using guessed type int MissilePreFlag;
 
-//----- (00430F35) --------------------------------------------------------
 void __cdecl missiles_process_charge()
 {
 	int v0; // ebx
@@ -7695,7 +7564,6 @@ void __cdecl missiles_process_charge()
 	}
 }
 
-//----- (00430FB9) --------------------------------------------------------
 void __fastcall ClearMissileSpot(int mi)
 {
 	dFlags[missile[mi]._mix][missile[mi]._miy] &= 0xFE;

--- a/Source/missiles.h
+++ b/Source/missiles.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __MISSILES_H__
+#define __MISSILES_H__
 
-//missile
 extern int missileactive[125];
 extern int missileavail[125];
 extern MissileStruct missile[125];
@@ -150,3 +151,5 @@ extern MissileData missiledata[68];
 extern MisFileData misfiledata[47];
 extern int XDirAdd[8];
 extern int YDirAdd[8];
+
+#endif /* __MISSILES_H__ */

--- a/Source/monster.cpp
+++ b/Source/monster.cpp
@@ -347,7 +347,6 @@ void (__fastcall *AiProc[])(int i) =
   &MAI_Warlord
 };
 
-//----- (00430FE4) --------------------------------------------------------
 struct monster_cpp_init
 {
 	monster_cpp_init()
@@ -358,7 +357,6 @@ struct monster_cpp_init
 // 47F130: using guessed type int monster_inf;
 // 64CCE4: using guessed type int monster_cpp_init_value;
 
-//----- (00430FEF) --------------------------------------------------------
 void __fastcall InitMonsterTRN(int monst, int special)
 {
 	signed int i; // ecx
@@ -408,7 +406,6 @@ void __fastcall InitMonsterTRN(int monst, int special)
 	}
 }
 
-//----- (0043107B) --------------------------------------------------------
 void __cdecl InitLevelMonsters()
 {
 	int i; // eax
@@ -434,7 +431,6 @@ void __cdecl InitLevelMonsters()
 // 6599D9: using guessed type int END_Monsters_17;
 // 659AE8: using guessed type int monstimgtot;
 
-//----- (004310CF) --------------------------------------------------------
 int __fastcall AddMonsterType(int type, int placeflag)
 {
 	bool done; // eax
@@ -465,7 +461,6 @@ int __fastcall AddMonsterType(int type, int placeflag)
 }
 // 659AE8: using guessed type int monstimgtot;
 
-//----- (0043114F) --------------------------------------------------------
 void __cdecl GetLevelMTypes() /* note-decompile this function again and check */
 {
 	//int v0; // eax
@@ -608,7 +603,6 @@ void __cdecl GetLevelMTypes() /* note-decompile this function again and check */
 // 43114F: using guessed type int var_1C0[111];
 // 43114F: using guessed type int var_324[89];
 
-//----- (004313F9) --------------------------------------------------------
 void __fastcall InitMonsterGFX(int monst)
 {
 	int v1; // esi
@@ -774,7 +768,6 @@ void __fastcall InitMonsterGFX(int monst)
 }
 // 64CCE0: using guessed type int MissileFileFlag;
 
-//----- (004316AE) --------------------------------------------------------
 void __fastcall ClearMVars(int i)
 {
 	monster[i]._mVar1 = 0;
@@ -787,7 +780,6 @@ void __fastcall ClearMVars(int i)
 	monster[i]._mVar8 = 0;
 }
 
-//----- (004316E7) --------------------------------------------------------
 void __fastcall InitMonster(int i, int rd, int mtype, int x, int y)
 {
 	int v5; // ebx
@@ -929,7 +921,6 @@ void __fastcall InitMonster(int i, int rd, int mtype, int x, int y)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00431A6B) --------------------------------------------------------
 void __cdecl ClrAllMonsters()
 {
 	int i; // edi
@@ -967,7 +958,6 @@ void __cdecl ClrAllMonsters()
 }
 // 67862C: using guessed type char gbActivePlayers;
 
-//----- (00431B10) --------------------------------------------------------
 bool __fastcall MonstPlace(int xp, int yp)
 {
 	if ( xp < 0 || xp >= 112
@@ -985,14 +975,12 @@ bool __fastcall MonstPlace(int xp, int yp)
 	}
 }
 
-//----- (00431B5D) --------------------------------------------------------
 void __fastcall PlaceMonster(int i, int mtype, int x, int y)
 {
 	dMonster[x][y] = i + 1;
 	InitMonster(i, random(90, 8), mtype, x, y);
 }
 
-//----- (00431B99) --------------------------------------------------------
 void __fastcall PlaceUniqueMonst(int uniqindex, int miniontype, int unpackfilesize)
 {
 	MonsterStruct *v3; // esi
@@ -1318,7 +1306,6 @@ LABEL_83:
 // 679660: using guessed type char gbMaxPlayers;
 // 6AAA64: using guessed type int zharlib;
 
-//----- (00432088) --------------------------------------------------------
 void __cdecl PlaceQuestMonsters()
 {
 	int skeltype; // esi
@@ -1404,7 +1391,6 @@ void __cdecl PlaceQuestMonsters()
 // 679660: using guessed type char gbMaxPlayers;
 // 6AAA64: using guessed type int zharlib;
 
-//----- (004322FA) --------------------------------------------------------
 void __fastcall PlaceGroup(int mtype, int num, unsigned char leaderf, int leader)
 {
 	int v4; // ecx
@@ -1543,7 +1529,6 @@ void __fastcall PlaceGroup(int mtype, int num, unsigned char leaderf, int leader
 }
 // 658550: using guessed type int totalmonsters;
 
-//----- (00432585) --------------------------------------------------------
 void __cdecl LoadDiabMonsts()
 {
 	unsigned char *lpSetPiece; // esi
@@ -1564,7 +1549,6 @@ void __cdecl LoadDiabMonsts()
 // 5289C4: using guessed type int diabquad1x;
 // 5289C8: using guessed type int diabquad1y;
 
-//----- (00432637) --------------------------------------------------------
 void __cdecl InitMonsters()
 {
 	int v0; // ebp
@@ -1732,7 +1716,6 @@ LABEL_42:
 // 679660: using guessed type char gbMaxPlayers;
 // 432637: using guessed type int var_1BC[111];
 
-//----- (0043283D) --------------------------------------------------------
 void __cdecl PlaceUniques()
 {
 	int v0; // edi
@@ -1811,7 +1794,6 @@ LABEL_23:
 	}
 }
 
-//----- (0043290E) --------------------------------------------------------
 void __fastcall SetMapMonsters(char *pMap, int startx, int starty)
 {
 	char *v3; // esi
@@ -1876,7 +1858,6 @@ void __fastcall SetMapMonsters(char *pMap, int startx, int starty)
 // 5CCB10: using guessed type char setlvlnum;
 // 5CF31D: using guessed type char setlevel;
 
-//----- (00432A4D) --------------------------------------------------------
 void __fastcall DeleteMonster(int i)
 {
 	int *v1; // ecx
@@ -1891,7 +1872,6 @@ void __fastcall DeleteMonster(int i)
 	*v1 = v3;
 }
 
-//----- (00432A71) --------------------------------------------------------
 int __fastcall AddMonster(int x, int y, int dir, int mtype, int InMap)
 {
 	int i; // esi
@@ -1905,7 +1885,6 @@ int __fastcall AddMonster(int x, int y, int dir, int mtype, int InMap)
 	return i;
 }
 
-//----- (00432AC1) --------------------------------------------------------
 void __fastcall NewMonsterAnim(int i, AnimStruct *anim, int md)
 {
 	MonsterStruct *v3; // eax
@@ -1924,7 +1903,6 @@ void __fastcall NewMonsterAnim(int i, AnimStruct *anim, int md)
 	v3->_mdir = md;
 }
 
-//----- (00432AFF) --------------------------------------------------------
 bool __fastcall M_Ranged(int i)
 {
 	char v1; // cl
@@ -1933,7 +1911,6 @@ bool __fastcall M_Ranged(int i)
 	return v1 == AI_SKELBOW || v1 == AI_GOATBOW || v1 == AI_SUCC || v1 == AI_LAZHELP;
 }
 
-//----- (00432B26) --------------------------------------------------------
 bool __fastcall M_Talker(int i)
 {
 	char v1; // cl
@@ -1948,7 +1925,6 @@ bool __fastcall M_Talker(int i)
 		|| v1 == AI_LAZHELP;
 }
 
-//----- (00432B5C) --------------------------------------------------------
 void __fastcall M_Enemy(int i)
 {
 	MonsterStruct *v1; // esi
@@ -2093,7 +2069,6 @@ LABEL_40:
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00432E15) --------------------------------------------------------
 int __fastcall M_GetDir(int i)
 {
 	return GetDirection(
@@ -2103,7 +2078,6 @@ int __fastcall M_GetDir(int i)
 			   (unsigned char)monster[i]._menemyy);
 }
 
-//----- (00432E3D) --------------------------------------------------------
 void __fastcall M_CheckEFlag(int i)
 {
 	int v1; // ecx
@@ -2127,7 +2101,6 @@ LABEL_9:
 		monster[v1]._meflag = 0;
 }
 
-//----- (00432E9D) --------------------------------------------------------
 void __fastcall M_StartStand(int i, int md)
 {
 	int v2; // ebx
@@ -2163,7 +2136,6 @@ void __fastcall M_StartStand(int i, int md)
 	M_Enemy(v3);
 }
 
-//----- (00432F29) --------------------------------------------------------
 void __fastcall M_StartDelay(int i, int len)
 {
 	int v2; // eax
@@ -2179,7 +2151,6 @@ void __fastcall M_StartDelay(int i, int len)
 	}
 }
 
-//----- (00432F4F) --------------------------------------------------------
 void __fastcall M_StartSpStand(int i, int md)
 {
 	int v2; // ebx
@@ -2205,7 +2176,6 @@ void __fastcall M_StartSpStand(int i, int md)
 	M_CheckEFlag(v2);
 }
 
-//----- (00432FBC) --------------------------------------------------------
 void __fastcall M_StartWalk(int i, int xvel, int yvel, int xadd, int yadd, int EndDir)
 {
 	int v6; // ST18_4
@@ -2238,7 +2208,6 @@ void __fastcall M_StartWalk(int i, int xvel, int yvel, int xadd, int yadd, int E
 	M_CheckEFlag(v6);
 }
 
-//----- (0043308F) --------------------------------------------------------
 void __fastcall M_StartWalk2(int i, int xvel, int yvel, int a4, int a5, int a6, int a7, int EndDir)
 {
 	int v8; // esi
@@ -2288,7 +2257,6 @@ void __fastcall M_StartWalk2(int i, int xvel, int yvel, int a4, int a5, int a6, 
 	M_CheckEFlag(ia);
 }
 
-//----- (004331AA) --------------------------------------------------------
 void __fastcall M_StartWalk3(int i, int xvel, int yvel, int a4, int a5, int a6, int a7, int a8, int a9, int EndDir)
 {
 	int v10; // esi
@@ -2341,7 +2309,6 @@ void __fastcall M_StartWalk3(int i, int xvel, int yvel, int a4, int a5, int a6, 
 	M_CheckEFlag(ia);
 }
 
-//----- (004332F6) --------------------------------------------------------
 void __fastcall M_StartAttack(int i)
 {
 	int v1; // edi
@@ -2367,7 +2334,6 @@ void __fastcall M_StartAttack(int i)
 	M_CheckEFlag(v1);
 }
 
-//----- (00433367) --------------------------------------------------------
 void __fastcall M_StartRAttack(int i, int missile_type, int dam)
 {
 	int v3; // ebp
@@ -2397,7 +2363,6 @@ void __fastcall M_StartRAttack(int i, int missile_type, int dam)
 	M_CheckEFlag(v4);
 }
 
-//----- (004333EF) --------------------------------------------------------
 void __fastcall M_StartRSpAttack(int i, int missile_type, int dam)
 {
 	int v3; // ebp
@@ -2428,7 +2393,6 @@ void __fastcall M_StartRSpAttack(int i, int missile_type, int dam)
 	M_CheckEFlag(v4);
 }
 
-//----- (00433480) --------------------------------------------------------
 void __fastcall M_StartSpAttack(int i)
 {
 	int v1; // edi
@@ -2454,7 +2418,6 @@ void __fastcall M_StartSpAttack(int i)
 	M_CheckEFlag(v1);
 }
 
-//----- (004334F4) --------------------------------------------------------
 void __fastcall M_StartEat(int i)
 {
 	int v1; // edi
@@ -2477,7 +2440,6 @@ void __fastcall M_StartEat(int i)
 	M_CheckEFlag(v1);
 }
 
-//----- (0043355C) --------------------------------------------------------
 void __fastcall M_ClearSquares(int i)
 {
 	int v1; // edx
@@ -2526,7 +2488,6 @@ void __fastcall M_ClearSquares(int i)
 		dFlags[v1][v2 + 1] &= 0xEFu;
 }
 
-//----- (0043361B) --------------------------------------------------------
 void __fastcall M_GetKnockback(int i)
 {
 	int v1; // edi
@@ -2567,7 +2528,6 @@ void __fastcall M_GetKnockback(int i)
 	}
 }
 
-//----- (004336E5) --------------------------------------------------------
 void __fastcall M_StartHit(int i, int pnum, int dam)
 {
 	int v3; // ebx
@@ -2630,7 +2590,6 @@ void __fastcall M_StartHit(int i, int pnum, int dam)
 	}
 }
 
-//----- (0043385A) --------------------------------------------------------
 void __fastcall M_DiabloDeath(int i, unsigned char sendmsg)
 {
 	int v2; // esi
@@ -2706,7 +2665,6 @@ void __fastcall M_DiabloDeath(int i, unsigned char sendmsg)
 // 5256A0: using guessed type int gbProcessPlayers;
 // 64D32C: using guessed type int sgbSaveSoundOn;
 
-//----- (00433A4C) --------------------------------------------------------
 void __fastcall M2MStartHit(int mid, int i, int dam)
 {
 	int v3; // edi
@@ -2769,7 +2727,6 @@ void __fastcall M2MStartHit(int mid, int i, int dam)
 	}
 }
 
-//----- (00433BCC) --------------------------------------------------------
 void __fastcall MonstStartKill(int i, int pnum, unsigned char sendmsg)
 {
 	signed int v3; // edi
@@ -2840,7 +2797,6 @@ void __fastcall MonstStartKill(int i, int pnum, unsigned char sendmsg)
 		AddMissile(monster[v5]._mx, monster[v5]._my, 0, 0, 0, 59, 1, v3, (unsigned char)monster[v5]._mint + 1, 0);
 }
 
-//----- (00433DC2) --------------------------------------------------------
 void __fastcall M2MStartKill(int i, int mid)
 {
 	signed int v2; // ebx
@@ -2906,7 +2862,6 @@ void __fastcall M2MStartKill(int i, int mid)
 		AddMissile(monster[v4]._mx, monster[v4]._my, 0, 0, 0, 59, 1, v3, (unsigned char)monster[v4]._mint + 1, 0);
 }
 
-//----- (00433FC7) --------------------------------------------------------
 void __fastcall M_StartKill(int i, int pnum)
 {
 	int v2; // edi
@@ -2935,7 +2890,6 @@ void __fastcall M_StartKill(int i, int pnum)
 	MonstStartKill(v2, v3, 1u);
 }
 
-//----- (00434045) --------------------------------------------------------
 void __fastcall M_SyncStartKill(int i, int x, int y, int pnum)
 {
 	int v4; // esi
@@ -2971,7 +2925,6 @@ void __fastcall M_SyncStartKill(int i, int x, int y, int pnum)
 	}
 }
 
-//----- (004340E0) --------------------------------------------------------
 void __fastcall M_StartFadein(int i, int md, unsigned char backwards)
 {
 	int v3; // esi
@@ -3011,7 +2964,6 @@ void __fastcall M_StartFadein(int i, int md, unsigned char backwards)
 	}
 }
 
-//----- (004341AD) --------------------------------------------------------
 void __fastcall M_StartFadeout(int i, int md, unsigned char backwards)
 {
 	int v3; // ebx
@@ -3050,7 +3002,6 @@ void __fastcall M_StartFadeout(int i, int md, unsigned char backwards)
 	}
 }
 
-//----- (00434272) --------------------------------------------------------
 void __fastcall M_StartHeal(int i)
 {
 	int v1; // edi
@@ -3076,7 +3027,6 @@ void __fastcall M_StartHeal(int i)
 	monster[v2]._mVar1 = monster[v2]._mmaxhp / (16 * (random(v4, 5) + 4));
 }
 
-//----- (0043430A) --------------------------------------------------------
 void __fastcall M_ChangeLightOffset(int monst)
 {
 	int v1; // esi
@@ -3120,7 +3070,6 @@ void __fastcall M_ChangeLightOffset(int monst)
 	ChangeLightOff((unsigned char)monster[v2].mlid, v8, v9 * (v6 >> 3));
 }
 
-//----- (00434374) --------------------------------------------------------
 int __fastcall M_DoStand(int i)
 {
 	int v1; // edi
@@ -3148,7 +3097,6 @@ int __fastcall M_DoStand(int i)
 	return 0;
 }
 
-//----- (004343F3) --------------------------------------------------------
 int __fastcall M_DoWalk(int i)
 {
 	int v1; // ebx
@@ -3206,7 +3154,6 @@ int __fastcall M_DoWalk(int i)
 	return v3;
 }
 
-//----- (00434509) --------------------------------------------------------
 int __fastcall M_DoWalk2(int i)
 {
 	int v1; // ebp
@@ -3256,7 +3203,6 @@ int __fastcall M_DoWalk2(int i)
 	return v5;
 }
 
-//----- (004345FC) --------------------------------------------------------
 int __fastcall M_DoWalk3(int i)
 {
 	int v1; // ebp
@@ -3320,7 +3266,6 @@ int __fastcall M_DoWalk3(int i)
 	return v10;
 }
 
-//----- (00434722) --------------------------------------------------------
 void __fastcall M_TryM2MHit(int i, int mid, int hper, int mind, int maxd)
 {
 	int v5; // edi
@@ -3382,7 +3327,6 @@ LABEL_15:
 	}
 }
 
-//----- (0043482C) --------------------------------------------------------
 void __fastcall M_TryH2HHit(int i, int pnum, int Hit, int MinDam, int MaxDam)
 {
 	int v5; // esi
@@ -3614,7 +3558,6 @@ LABEL_23:
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00434C3B) --------------------------------------------------------
 int __fastcall M_DoAttack(int i)
 {
 	int v1; // edi
@@ -3675,7 +3618,6 @@ int __fastcall M_DoAttack(int i)
 	return 1;
 }
 
-//----- (00434DBD) --------------------------------------------------------
 int __fastcall M_DoRAttack(int i)
 {
 	int v1; // ebx
@@ -3731,7 +3673,6 @@ int __fastcall M_DoRAttack(int i)
 	return 1;
 }
 
-//----- (00434EB2) --------------------------------------------------------
 int __fastcall M_DoRSpAttack(int i)
 {
 	int v1; // ebx
@@ -3788,7 +3729,6 @@ int __fastcall M_DoRSpAttack(int i)
 	return 1;
 }
 
-//----- (00434FC7) --------------------------------------------------------
 int __fastcall M_DoSAttack(int i)
 {
 	int v1; // ebx
@@ -3822,7 +3762,6 @@ int __fastcall M_DoSAttack(int i)
 	return 1;
 }
 
-//----- (0043507E) --------------------------------------------------------
 int __fastcall M_DoFadein(int i)
 {
 	int v1; // edi
@@ -3842,7 +3781,6 @@ int __fastcall M_DoFadein(int i)
 	return 1;
 }
 
-//----- (004350E3) --------------------------------------------------------
 int __fastcall M_DoFadeout(int i)
 {
 	int v1; // esi
@@ -3873,7 +3811,6 @@ int __fastcall M_DoFadeout(int i)
 	return 1;
 }
 
-//----- (00435165) --------------------------------------------------------
 int __fastcall M_DoHeal(int i)
 {
 	int v1; // esi
@@ -3917,7 +3854,6 @@ int __fastcall M_DoHeal(int i)
 	return 0;
 }
 
-//----- (004351F5) --------------------------------------------------------
 int __fastcall M_DoTalk(int i)
 {
 	int v1; // edi
@@ -4016,7 +3952,6 @@ int __fastcall M_DoTalk(int i)
 // 5CF334: using guessed type int setpc_w;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0043547A) --------------------------------------------------------
 void __fastcall M_Teleport(int i)
 {
 	int v1; // ebx
@@ -4099,7 +4034,6 @@ void __fastcall M_Teleport(int i)
 	}
 }
 
-//----- (004355BB) --------------------------------------------------------
 int __fastcall M_DoGotHit(int i)
 {
 	int v1; // edi
@@ -4117,7 +4051,6 @@ int __fastcall M_DoGotHit(int i)
 	return 1;
 }
 
-//----- (0043561E) --------------------------------------------------------
 void __fastcall M_UpdateLeader(int i)
 {
 	int v1; // edi
@@ -4143,7 +4076,6 @@ void __fastcall M_UpdateLeader(int i)
 	}
 }
 
-//----- (00435697) --------------------------------------------------------
 void __cdecl DoEnding()
 {
 	char v0; // al
@@ -4185,7 +4117,6 @@ void __cdecl DoEnding()
 // 659AFC: using guessed type int loop_movie;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0043575C) --------------------------------------------------------
 void __cdecl PrepDoEnding()
 {
 	int *v0; // eax
@@ -4227,7 +4158,6 @@ void __cdecl PrepDoEnding()
 // 64D32C: using guessed type int sgbSaveSoundOn;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (004357DF) --------------------------------------------------------
 int __fastcall M_DoDeath(int i)
 {
 	int v1; // edi
@@ -4288,7 +4218,6 @@ int __fastcall M_DoDeath(int i)
 	return 0;
 }
 
-//----- (004358EC) --------------------------------------------------------
 int __fastcall M_DoSpStand(int i)
 {
 	int v1; // ebx
@@ -4308,7 +4237,6 @@ int __fastcall M_DoSpStand(int i)
 	return 1;
 }
 
-//----- (0043596B) --------------------------------------------------------
 int __fastcall M_DoDelay(int i)
 {
 	int v1; // ebp
@@ -4344,7 +4272,6 @@ int __fastcall M_DoDelay(int i)
 	return 1;
 }
 
-//----- (00435A14) --------------------------------------------------------
 int __fastcall M_DoStone(int i)
 {
 	int v1; // esi
@@ -4364,7 +4291,6 @@ int __fastcall M_DoStone(int i)
 	return 0;
 }
 
-//----- (00435A62) --------------------------------------------------------
 void __fastcall M_WalkDir(int i, int md)
 {
 	int v2; // esi
@@ -4444,7 +4370,6 @@ LABEL_10:
 	}
 }
 
-//----- (00435BB5) --------------------------------------------------------
 void __fastcall GroupUnity(int i)
 {
 	int v1; // ebx
@@ -4550,7 +4475,6 @@ LABEL_18:
 	}
 }
 
-//----- (00435DA8) --------------------------------------------------------
 bool __fastcall M_CallWalk(int i, int md)
 {
 	int v2; // esi
@@ -4640,7 +4564,6 @@ LABEL_20:
 	return 0;
 }
 
-//----- (00435EB5) --------------------------------------------------------
 bool __fastcall M_PathWalk(int i)
 {
 	int v1; // esi
@@ -4666,7 +4589,6 @@ bool __fastcall M_PathWalk(int i)
 	return 1;
 }
 
-//----- (00435F35) --------------------------------------------------------
 bool __fastcall M_CallWalk2(int i, int md)
 {
 	int v2; // esi
@@ -4719,7 +4641,6 @@ LABEL_10:
 	return 0;
 }
 
-//----- (00435FBA) --------------------------------------------------------
 bool __fastcall M_DumbWalk(int i, int md)
 {
 	int v2; // esi
@@ -4736,7 +4657,6 @@ bool __fastcall M_DumbWalk(int i, int md)
 	return v5;
 }
 
-//----- (00435FDB) --------------------------------------------------------
 bool __fastcall M_RoundWalk(int i, int md, int *dir)
 {
 	int *v3; // ebp
@@ -4794,7 +4714,6 @@ LABEL_12:
 	return v7;
 }
 
-//----- (004360B1) --------------------------------------------------------
 void __fastcall MAI_Zombie(int i)
 {
 	int v1; // esi
@@ -4866,7 +4785,6 @@ void __fastcall MAI_Zombie(int i)
 	}
 }
 
-//----- (004361F7) --------------------------------------------------------
 void __fastcall MAI_SkelSd(int i)
 {
 	int v1; // esi
@@ -4943,7 +4861,6 @@ LABEL_16:
 	}
 }
 
-//----- (00436331) --------------------------------------------------------
 bool __fastcall MAI_Path(int i)
 {
 	int v1; // edi
@@ -4989,7 +4906,6 @@ bool __fastcall MAI_Path(int i)
 	return 0;
 }
 
-//----- (004363F9) --------------------------------------------------------
 void __fastcall MAI_Snake(int i)
 {
 	int esi1; // esi
@@ -5191,7 +5107,6 @@ LABEL_46:
 	}
 }
 
-//----- (0043668F) --------------------------------------------------------
 void __fastcall MAI_Bat(int i)
 {
 	int esi1; // esi
@@ -5308,7 +5223,6 @@ void __fastcall MAI_Bat(int i)
 	}
 }
 
-//----- (004368F7) --------------------------------------------------------
 void __fastcall MAI_SkelBow(int i)
 {
 	int v1; // esi
@@ -5382,7 +5296,6 @@ void __fastcall MAI_SkelBow(int i)
 	}
 }
 
-//----- (00436A38) --------------------------------------------------------
 void __fastcall MAI_Fat(int i)
 {
 	int v1; // esi
@@ -5439,7 +5352,6 @@ void __fastcall MAI_Fat(int i)
 	}
 }
 
-//----- (00436B60) --------------------------------------------------------
 void __fastcall MAI_Sneak(int i)
 {
 	int v1; // edi
@@ -5545,7 +5457,6 @@ void __fastcall MAI_Sneak(int i)
 }
 // 642A14: using guessed type char lightmax;
 
-//----- (00436DC8) --------------------------------------------------------
 void __fastcall MAI_Fireman(int i)
 {
 	int esi1; // esi
@@ -5663,7 +5574,6 @@ LABEL_29:
 	}
 }
 
-//----- (00436FEC) --------------------------------------------------------
 void __fastcall MAI_Fallen(int i)
 {
 	int v1; // edi
@@ -5775,7 +5685,6 @@ void __fastcall MAI_Fallen(int i)
 	}
 }
 
-//----- (004371D7) --------------------------------------------------------
 void __fastcall MAI_Cleaver(int i)
 {
 	int v1; // esi
@@ -5809,7 +5718,6 @@ void __fastcall MAI_Cleaver(int i)
 	}
 }
 
-//----- (00437285) --------------------------------------------------------
 void __fastcall MAI_Round(int i, unsigned char special)
 {
 	int v2; // esi
@@ -5943,13 +5851,11 @@ LABEL_26:
 	}
 }
 
-//----- (00437520) --------------------------------------------------------
 void __fastcall MAI_GoatMc(int i)
 {
 	MAI_Round(i, 1u);
 }
 
-//----- (00437528) --------------------------------------------------------
 void __fastcall MAI_Ranged(int i, int missile_type, unsigned char special)
 {
 	int v3; // edi
@@ -6034,25 +5940,21 @@ void __fastcall MAI_Ranged(int i, int missile_type, unsigned char special)
 	}
 }
 
-//----- (004376B3) --------------------------------------------------------
 void __fastcall MAI_GoatBow(int i)
 {
 	MAI_Ranged(i, 0, 0);
 }
 
-//----- (004376BD) --------------------------------------------------------
 void __fastcall MAI_Succ(int i)
 {
 	MAI_Ranged(i, 24, 0);
 }
 
-//----- (004376C8) --------------------------------------------------------
 void __fastcall MAI_AcidUniq(int i)
 {
 	MAI_Ranged(i, 57, 1u);
 }
 
-//----- (004376D3) --------------------------------------------------------
 void __fastcall MAI_Scav(int i)
 {
 	int v1; // edi
@@ -6215,7 +6117,6 @@ LABEL_10:
 	}
 }
 
-//----- (00437957) --------------------------------------------------------
 void __fastcall MAI_Garg(int i)
 {
 	int v1; // ebp
@@ -6267,7 +6168,6 @@ void __fastcall MAI_Garg(int i)
 	}
 }
 
-//----- (00437A8B) --------------------------------------------------------
 void __fastcall MAI_RoundRanged(int i, int missile_type, unsigned char checkdoors, int dam, int lessmissiles)
 {
 	int v5; // esi
@@ -6426,31 +6326,26 @@ LABEL_28:
 	}
 }
 
-//----- (00437D93) --------------------------------------------------------
 void __fastcall MAI_Magma(int i)
 {
 	MAI_RoundRanged(i, 21, 1u, 4, 0);
 }
 
-//----- (00437DA2) --------------------------------------------------------
 void __fastcall MAI_Storm(int i)
 {
 	MAI_RoundRanged(i, 22, 1u, 4, 0);
 }
 
-//----- (00437DB1) --------------------------------------------------------
 void __fastcall MAI_Acid(int i)
 {
 	MAI_RoundRanged(i, 57, 0, 4, 1);
 }
 
-//----- (00437DC0) --------------------------------------------------------
 void __fastcall MAI_Diablo(int i)
 {
 	MAI_RoundRanged(i, 67, 0, 40, 0);
 }
 
-//----- (00437DCF) --------------------------------------------------------
 void __fastcall MAI_RR2(int i, int mistype, int dam)
 {
 	int v3; // ebx
@@ -6628,13 +6523,11 @@ LABEL_48:
 	}
 }
 
-//----- (004380DE) --------------------------------------------------------
 void __fastcall MAI_Mega(int i)
 {
 	MAI_RR2(i, 49, 0);
 }
 
-//----- (004380E9) --------------------------------------------------------
 void __fastcall MAI_Golum(int i)
 {
 	int v1; // edi
@@ -6748,7 +6641,6 @@ void __fastcall MAI_Golum(int i)
 	}
 }
 
-//----- (00438304) --------------------------------------------------------
 void __fastcall MAI_SkelKing(int i)
 {
 	int v1; // esi
@@ -6914,7 +6806,6 @@ LABEL_26:
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0043862D) --------------------------------------------------------
 void __fastcall MAI_Rhino(int i)
 {
 	int esi1; // esi
@@ -7079,7 +6970,6 @@ LABEL_23:
 	}
 }
 
-//----- (0043891F) --------------------------------------------------------
 void __fastcall MAI_Counselor(int i)
 {
 	int v1; // ebx
@@ -7260,7 +7150,6 @@ LABEL_29:
 	}
 }
 
-//----- (00438C79) --------------------------------------------------------
 void __fastcall MAI_Garbud(int i)
 {
 	int v1; // esi
@@ -7314,7 +7203,6 @@ void __fastcall MAI_Garbud(int i)
 	}
 }
 
-//----- (00438D7E) --------------------------------------------------------
 void __fastcall MAI_Zhar(int i)
 {
 	int v1; // ebp
@@ -7373,7 +7261,6 @@ void __fastcall MAI_Zhar(int i)
 	}
 }
 
-//----- (00438EC2) --------------------------------------------------------
 void __fastcall MAI_SnotSpil(int i)
 {
 	int v1; // ebp
@@ -7435,7 +7322,6 @@ void __fastcall MAI_SnotSpil(int i)
 // 5CF330: using guessed type int setpc_h;
 // 5CF334: using guessed type int setpc_w;
 
-//----- (00439016) --------------------------------------------------------
 void __fastcall MAI_Lazurus(int i)
 {
 	int v1; // ebx
@@ -7505,7 +7391,6 @@ LABEL_29:
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00439196) --------------------------------------------------------
 void __fastcall MAI_Lazhelp(int i)
 {
 	int v1; // esi
@@ -7548,7 +7433,6 @@ LABEL_10:
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00439253) --------------------------------------------------------
 void __fastcall MAI_Lachdanan(int i)
 {
 	int v1; // ebp
@@ -7591,7 +7475,6 @@ void __fastcall MAI_Lachdanan(int i)
 	}
 }
 
-//----- (00439338) --------------------------------------------------------
 void __fastcall MAI_Warlord(int i)
 {
 	int v1; // ebp
@@ -7634,7 +7517,6 @@ void __fastcall MAI_Warlord(int i)
 	}
 }
 
-//----- (00439419) --------------------------------------------------------
 void __cdecl DeleteMonsterList()
 {
 	int *v0; // eax
@@ -7671,7 +7553,6 @@ void __cdecl DeleteMonsterList()
 	}
 }
 
-//----- (0043947E) --------------------------------------------------------
 void __cdecl ProcessMonsters()
 {
 	int v0; // edi
@@ -7876,7 +7757,6 @@ LABEL_60:
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (004397C5) --------------------------------------------------------
 void __cdecl FreeMonsters()
 {
 	void **v0; // edi
@@ -7915,7 +7795,6 @@ void __cdecl FreeMonsters()
 	FreeMissiles2();
 }
 
-//----- (00439831) --------------------------------------------------------
 bool __fastcall DirOK(int i, int mdir)
 {
 	int v2; // ebx
@@ -8049,7 +7928,6 @@ LABEL_24:
 	return v26 == (unsigned char)monster[v4].unpackfilesize;
 }
 
-//----- (00439A32) --------------------------------------------------------
 bool __fastcall PosOkMissile(int x, int y)
 {
 	int v2; // ecx
@@ -8062,13 +7940,11 @@ bool __fastcall PosOkMissile(int x, int y)
 	return result;
 }
 
-//----- (00439A57) --------------------------------------------------------
 bool __fastcall CheckNoSolid(int x, int y)
 {
 	return nSolidTable[dPiece[0][y + 112 * x]] == 0;
 }
 
-//----- (00439A71) --------------------------------------------------------
 bool __fastcall LineClearF(bool (__fastcall *Clear)(int, int), int x1, int y1, int x2, int y2)
 {
 	int v5; // esi
@@ -8201,13 +8077,11 @@ LABEL_29:
 	return 0;
 }
 
-//----- (00439BE0) --------------------------------------------------------
 bool __fastcall LineClear(int x1, int y1, int x2, int y2)
 {
 	return LineClearF(PosOkMissile, x1, y1, x2, y2);
 }
 
-//----- (00439BFA) --------------------------------------------------------
 bool __fastcall LineClearF1(bool (__fastcall *Clear)(int, int, int), int monst, int x1, int y1, int x2, int y2)
 {
 	int v6; // esi
@@ -8338,7 +8212,6 @@ LABEL_29:
 	return 0;
 }
 
-//----- (00439D75) --------------------------------------------------------
 void __fastcall SyncMonsterAnim(int i)
 {
 	int v1; // esi
@@ -8420,7 +8293,6 @@ LABEL_13:
 	monster[v2]._mAnimLen = v12;
 }
 
-//----- (00439EA8) --------------------------------------------------------
 void __fastcall M_FallenFear(int x, int y)
 {
 	int v2; // eax
@@ -8502,7 +8374,6 @@ LABEL_16:
 	}
 }
 
-//----- (00439F92) --------------------------------------------------------
 void __fastcall PrintMonstHistory(int mt)
 {
 	int v1; // edi
@@ -8589,7 +8460,6 @@ void __fastcall PrintMonstHistory(int mt)
 // 4B8824: using guessed type int pinfoflag;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0043A13A) --------------------------------------------------------
 void __cdecl PrintUniqueHistory()
 {
 	char v0; // bl
@@ -8620,7 +8490,6 @@ LABEL_4:
 }
 // 4B8824: using guessed type int pinfoflag;
 
-//----- (0043A1C1) --------------------------------------------------------
 void __fastcall MissToMonst(int i, int x, int y)
 {
 	int v3; // edi
@@ -8757,7 +8626,6 @@ void __fastcall MissToMonst(int i, int x, int y)
 	}
 }
 
-//----- (0043A45E) --------------------------------------------------------
 bool __fastcall PosOkMonst(int i, int x, int y)
 {
 	int v3; // edi
@@ -8818,7 +8686,6 @@ LABEL_24:
 	return result;
 }
 
-//----- (0043A547) --------------------------------------------------------
 bool __fastcall PosOkMonst2(int i, int x, int y)
 {
 	int v3; // edi
@@ -8880,7 +8747,6 @@ LABEL_23:
 	return result;
 }
 
-//----- (0043A613) --------------------------------------------------------
 bool __fastcall PosOkMonst3(int i, int x, int y)
 {
 	int v3; // esi
@@ -8957,7 +8823,6 @@ LABEL_33:
 	return result;
 }
 
-//----- (0043A73B) --------------------------------------------------------
 bool __fastcall IsSkel(int mt)
 {
 	return mt >= MT_WSKELAX && mt <= MT_XSKELAX
@@ -8965,13 +8830,11 @@ bool __fastcall IsSkel(int mt)
 		|| mt >= MT_WSKELSD && mt <= MT_XSKELSD;
 }
 
-//----- (0043A760) --------------------------------------------------------
 bool __fastcall IsGoat(int mt)
 {
 	return mt >= MT_NGOATMC && mt <= MT_GGOATMC || mt >= MT_NGOATBW && mt <= MT_GGOATBW;
 }
 
-//----- (0043A77B) --------------------------------------------------------
 int __fastcall M_SpawnSkel(int x, int y, int dir)
 {
 	CMonster *v3; // ebx
@@ -9029,7 +8892,6 @@ int __fastcall M_SpawnSkel(int x, int y, int dir)
 	return v10;
 }
 
-//----- (0043A828) --------------------------------------------------------
 void __fastcall ActivateSpawn(int i, int x, int y, int dir)
 {
 	int v4; // eax
@@ -9045,7 +8907,6 @@ void __fastcall ActivateSpawn(int i, int x, int y, int dir)
 	M_StartSpStand(i, dir);
 }
 
-//----- (0043A879) --------------------------------------------------------
 bool __fastcall SpawnSkeleton(int ii, int x, int y)
 {
 	int v3; // esi
@@ -9142,7 +9003,6 @@ bool __fastcall SpawnSkeleton(int ii, int x, int y)
 }
 // 43A879: using guessed type int var_34[9];
 
-//----- (0043A979) --------------------------------------------------------
 int __cdecl PreSpawnSkeleton()
 {
 	int skeltypes; // edx
@@ -9178,7 +9038,6 @@ int __cdecl PreSpawnSkeleton()
 	return skel;
 }
 
-//----- (0043AA0C) --------------------------------------------------------
 void __fastcall TalktoMonster(int i)
 {
 	int v1; // esi
@@ -9219,7 +9078,6 @@ void __fastcall TalktoMonster(int i)
 	}
 }
 
-//----- (0043AADA) --------------------------------------------------------
 void __fastcall SpawnGolum(int i, int x, int y, int mi)
 {
 	int v4; // edi
@@ -9272,7 +9130,6 @@ void __fastcall SpawnGolum(int i, int x, int y, int mi)
 	}
 }
 
-//----- (0043AC0C) --------------------------------------------------------
 bool __fastcall CanTalkToMonst(int m)
 {
 	int v1; // esi
@@ -9290,7 +9147,6 @@ bool __fastcall CanTalkToMonst(int m)
 	return result;
 }
 
-//----- (0043AC43) --------------------------------------------------------
 bool __fastcall CheckMonsterHit(int m, bool *ret)
 {
 	int v2; // edi
@@ -9324,7 +9180,6 @@ bool __fastcall CheckMonsterHit(int m, bool *ret)
 	return result;
 }
 
-//----- (0043ACB5) --------------------------------------------------------
 int __fastcall encode_enemy(int m)
 {
 	int v1; // ecx
@@ -9337,7 +9192,6 @@ int __fastcall encode_enemy(int m)
 	return result;
 }
 
-//----- (0043ACCE) --------------------------------------------------------
 void __fastcall decode_enemy(int m, int enemy)
 {
 	int v2; // eax

--- a/Source/monster.h
+++ b/Source/monster.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __MONSTER_H__
+#define __MONSTER_H__
 
-//monster
 extern int MissileFileFlag; // weak
 extern int monster_cpp_init_value; // weak
 extern int monstkills[200];
@@ -190,3 +191,5 @@ extern int rnd60[4];
 //
 
 extern void (__fastcall *AiProc[])(int i);
+
+#endif /* __MONSTER_H__ */

--- a/Source/movie.cpp
+++ b/Source/movie.cpp
@@ -8,7 +8,6 @@ int loop_movie; // weak
 
 int movie_inf = 0x7F800000; // weak
 
-//----- (0043AD38) --------------------------------------------------------
 struct movie_cpp_init
 {
 	movie_cpp_init()
@@ -19,7 +18,6 @@ struct movie_cpp_init
 // 47F144: using guessed type int movie_inf;
 // 659AF4: using guessed type int movie_cpp_init_value;
 
-//----- (0043AD43) --------------------------------------------------------
 void __fastcall play_movie(char *pszMovie, bool user_can_close)
 {
 	char *v2; // esi
@@ -71,7 +69,6 @@ void __fastcall play_movie(char *pszMovie, bool user_can_close)
 // 659AF8: using guessed type int movie_playing;
 // 659AFC: using guessed type int loop_movie;
 
-//----- (0043AE3E) --------------------------------------------------------
 LRESULT __stdcall MovieWndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam)
 {
 	if ( Msg == WM_KEYFIRST || Msg == WM_CHAR )

--- a/Source/movie.h
+++ b/Source/movie.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __MOVIE_H__
+#define __MOVIE_H__
 
-//movie
 extern int movie_cpp_init_value; // weak
 extern char movie_playing; // weak
 extern int loop_movie; // weak
@@ -12,3 +13,5 @@ LRESULT __stdcall MovieWndProc(HWND hWnd, UINT Msg, WPARAM wParam, LPARAM lParam
 /* data */
 
 extern int movie_inf; // weak
+
+#endif /* __MOVIE_H__ */

--- a/Source/mpqapi.cpp
+++ b/Source/mpqapi.cpp
@@ -16,7 +16,6 @@ int mpqapi_inf = 0x7F800000; // weak
 
 HANDLE sghArchive = (HANDLE)0xFFFFFFFF; // idb
 
-//----- (0043AE95) --------------------------------------------------------
 struct mpqapi_cpp_init
 {
 	mpqapi_cpp_init()
@@ -27,7 +26,6 @@ struct mpqapi_cpp_init
 // 47F148: using guessed type int mpqapi_inf;
 // 659B00: using guessed type int mpqapi_cpp_init_value;
 
-//----- (0043AEA0) --------------------------------------------------------
 bool __fastcall mpqapi_set_hidden(char *pszArchive, bool hidden)
 {
 	char *v2; // edi
@@ -49,7 +47,6 @@ bool __fastcall mpqapi_set_hidden(char *pszArchive, bool hidden)
 	return result;
 }
 
-//----- (0043AEDC) --------------------------------------------------------
 void __fastcall mpqapi_store_creation_time(char *pszArchive, int dwChar)
 {
 	int v2; // esi
@@ -77,7 +74,6 @@ void __fastcall mpqapi_store_creation_time(char *pszArchive, int dwChar)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0043AF4F) --------------------------------------------------------
 bool __fastcall mpqapi_reg_load_modification_time(char *dst, int size)
 {
 	unsigned int v2; // esi
@@ -106,7 +102,6 @@ bool __fastcall mpqapi_reg_load_modification_time(char *dst, int size)
 	return 1;
 }
 
-//----- (0043AFA5) --------------------------------------------------------
 void __fastcall mpqapi_xor_buf(char *pbData)
 {
 	signed int v1; // eax
@@ -126,7 +121,6 @@ void __fastcall mpqapi_xor_buf(char *pbData)
 	while ( v3 );
 }
 
-//----- (0043AFC4) --------------------------------------------------------
 bool __fastcall mpqapi_reg_store_modification_time(char *pbData, int dwLen)
 {
 	int v2; // ebx
@@ -153,7 +147,6 @@ bool __fastcall mpqapi_reg_store_modification_time(char *pbData, int dwLen)
 	return SRegSaveData("Diablo", "Video Player ", 0, (unsigned char *)v3, v2);
 }
 
-//----- (0043B002) --------------------------------------------------------
 void __fastcall mpqapi_remove_hash_entry(char *pszName)
 {
 	int v1; // eax
@@ -177,7 +170,6 @@ void __fastcall mpqapi_remove_hash_entry(char *pszName)
 }
 // 65AB0C: using guessed type int save_archive_modified;
 
-//----- (0043B054) --------------------------------------------------------
 void __fastcall mpqapi_alloc_block(int block_offset, int block_size)
 {
 	int v2; // esi
@@ -235,7 +227,6 @@ LABEL_11:
 	}
 }
 
-//----- (0043B0E4) --------------------------------------------------------
 _BLOCKENTRY *__fastcall mpqapi_new_block(int *block_index)
 {
 	_BLOCKENTRY *result; // eax
@@ -258,7 +249,6 @@ _BLOCKENTRY *__fastcall mpqapi_new_block(int *block_index)
 	return result;
 }
 
-//----- (0043B123) --------------------------------------------------------
 int __fastcall mpqapi_get_hash_index_of_path(char *pszName) // FetchHandle
 {
 	char *v1; // esi
@@ -273,7 +263,6 @@ int __fastcall mpqapi_get_hash_index_of_path(char *pszName) // FetchHandle
 	return mpqapi_get_hash_index(v4, v3, v2, 0);
 }
 
-//----- (0043B153) --------------------------------------------------------
 int __fastcall mpqapi_get_hash_index(short index, int hash_a, int hash_b, int locale)
 {
 	int v4; // ecx
@@ -303,7 +292,6 @@ int __fastcall mpqapi_get_hash_index(short index, int hash_a, int hash_b, int lo
 	return i;
 }
 
-//----- (0043B1BD) --------------------------------------------------------
 void __fastcall mpqapi_remove_hash_entries(bool (__stdcall *fnGetName)(int, char *))
 {
 	bool (__stdcall *v1)(int, char *); // edi
@@ -321,7 +309,6 @@ void __fastcall mpqapi_remove_hash_entries(bool (__stdcall *fnGetName)(int, char
 	}
 }
 
-//----- (0043B1F8) --------------------------------------------------------
 bool __fastcall mpqapi_write_file(char *pszName, char *pbData, int dwLen)
 {
 	char *v3; // edi
@@ -340,7 +327,6 @@ bool __fastcall mpqapi_write_file(char *pszName, char *pbData, int dwLen)
 }
 // 65AB0C: using guessed type int save_archive_modified;
 
-//----- (0043B23D) --------------------------------------------------------
 _BLOCKENTRY *__fastcall mpqapi_add_file(char *pszName, _BLOCKENTRY *pBlk, int block_index)
 {
 	char *v3; // edi
@@ -387,7 +373,6 @@ _BLOCKENTRY *__fastcall mpqapi_add_file(char *pszName, _BLOCKENTRY *pBlk, int bl
 	return v12;
 }
 
-//----- (0043B317) --------------------------------------------------------
 bool __fastcall mpqapi_write_file_contents(char *pszName, char *pbData, int dwLen, _BLOCKENTRY *pBlk)
 {
 	char *v4; // esi
@@ -491,7 +476,6 @@ LABEL_25:
 	return 1;
 }
 
-//----- (0043B51C) --------------------------------------------------------
 int __fastcall mpqapi_find_free_block(int size, int *block_size)
 {
 	_BLOCKENTRY *v2; // eax
@@ -529,7 +513,6 @@ int __fastcall mpqapi_find_free_block(int size, int *block_size)
 	return v5;
 }
 
-//----- (0043B570) --------------------------------------------------------
 void __fastcall mpqapi_rename(char *pszOld, char *pszNew)
 {
 	char *v2; // esi
@@ -552,13 +535,11 @@ void __fastcall mpqapi_rename(char *pszOld, char *pszNew)
 }
 // 65AB0C: using guessed type int save_archive_modified;
 
-//----- (0043B5AF) --------------------------------------------------------
 bool __fastcall mpqapi_has_file(char *pszName)
 {
 	return mpqapi_get_hash_index_of_path(pszName) != -1;
 }
 
-//----- (0043B5BF) --------------------------------------------------------
 bool __fastcall mpqapi_open_archive(char *pszArchive, bool hidden, int dwChar) // OpenMPQ
 {
 	char *v3; // ebp
@@ -627,7 +608,6 @@ LABEL_15:
 // 65AB14: using guessed type char save_archive_open;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0043B791) --------------------------------------------------------
 bool __fastcall mpqapi_parse_archive_header(TMPQHeader *pHdr, int *pdwNextFileStart) // ParseMPQHeader
 {
 	int *v2; // ebp
@@ -671,7 +651,6 @@ bool __fastcall mpqapi_parse_archive_header(TMPQHeader *pHdr, int *pdwNextFileSt
 // 65AB0C: using guessed type int save_archive_modified;
 // 65AB14: using guessed type char save_archive_open;
 
-//----- (0043B882) --------------------------------------------------------
 void __fastcall mpqapi_close_archive(char *pszArchive, bool bFree, int dwChar) // CloseMPQ
 {
 	char *v3; // esi
@@ -707,7 +686,6 @@ void __fastcall mpqapi_close_archive(char *pszArchive, bool bFree, int dwChar) /
 // 65AB0C: using guessed type int save_archive_modified;
 // 65AB14: using guessed type char save_archive_open;
 
-//----- (0043B8FD) --------------------------------------------------------
 void __fastcall mpqapi_store_modified_time(char *pszArchive, int dwChar)
 {
 	int v2; // esi
@@ -735,7 +713,6 @@ void __fastcall mpqapi_store_modified_time(char *pszArchive, int dwChar)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0043B970) --------------------------------------------------------
 void __fastcall mpqapi_flush_and_close(char *pszArchive, bool bFree, int dwChar)
 {
 	if ( sghArchive != (HANDLE)-1 )
@@ -756,7 +733,6 @@ void __fastcall mpqapi_flush_and_close(char *pszArchive, bool bFree, int dwChar)
 }
 // 65AB0C: using guessed type int save_archive_modified;
 
-//----- (0043B9CA) --------------------------------------------------------
 bool __cdecl mpqapi_write_header() // WriteMPQHeader
 {
 	bool result; // al
@@ -780,7 +756,6 @@ bool __cdecl mpqapi_write_header() // WriteMPQHeader
 	return result;
 }
 
-//----- (0043BA60) --------------------------------------------------------
 bool __cdecl mpqapi_write_block_table()
 {
 	int v1; // eax
@@ -798,7 +773,6 @@ bool __cdecl mpqapi_write_block_table()
 	return v2 && NumberOfBytesWritten == 0x8000;
 }
 
-//----- (0043BAEB) --------------------------------------------------------
 bool __cdecl mpqapi_write_hash_table()
 {
 	int v1; // eax
@@ -816,7 +790,6 @@ bool __cdecl mpqapi_write_hash_table()
 	return v2 && NumberOfBytesWritten == 0x8000;
 }
 
-//----- (0043BB79) --------------------------------------------------------
 bool __cdecl mpqapi_can_seek()
 {
 	bool result; // al

--- a/Source/mpqapi.h
+++ b/Source/mpqapi.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __MPQAPI_H__
+#define __MPQAPI_H__
 
-//mpqapi
 extern int mpqapi_cpp_init_value; // weak
 extern int sgdwMpqOffset; // idb
 extern char mpq_buf[4096];
@@ -45,3 +46,5 @@ extern int mpqapi_inf; // weak
 /* rdata */
 
 extern HANDLE sghArchive; // idb
+
+#endif /* __MPQAPI_H__ */

--- a/Source/msg.cpp
+++ b/Source/msg.cpp
@@ -23,7 +23,6 @@ int msg_err_timer; // weak
 
 int msg_inf = 0x7F800000; // weak
 
-//----- (0043BBA9) --------------------------------------------------------
 struct msg_cpp_init
 {
 	msg_cpp_init()
@@ -34,7 +33,6 @@ struct msg_cpp_init
 // 47F14C: using guessed type int msg_inf;
 // 65AB1C: using guessed type int msg_cpp_init_value;
 
-//----- (0043BBB4) --------------------------------------------------------
 void __fastcall msg_send_drop_pkt(int pnum, int reason)
 {
 	TFakeDropPlr cmd; // [esp+0h] [ebp-8h]
@@ -45,7 +43,6 @@ void __fastcall msg_send_drop_pkt(int pnum, int reason)
 	msg_send_packet(pnum, &cmd, 6);
 }
 
-//----- (0043BBCF) --------------------------------------------------------
 void __fastcall msg_send_packet(int pnum, void *packet, int dwSize)
 {
 	void *v3; // edi
@@ -71,7 +68,6 @@ void __fastcall msg_send_packet(int pnum, void *packet, int dwSize)
 }
 // 65AB24: using guessed type int sgnCurrMegaPlayer;
 
-//----- (0043BC31) --------------------------------------------------------
 TMegaPkt *__cdecl msg_get_next_packet()
 {
 	TMegaPkt *v0; // eax
@@ -93,7 +89,6 @@ TMegaPkt *__cdecl msg_get_next_packet()
 	return result;
 }
 
-//----- (0043BC6D) --------------------------------------------------------
 int __cdecl msg_wait_resync()
 {
 	int v0; // eax
@@ -128,7 +123,6 @@ LABEL_6:
 // 676194: using guessed type char gbBufferMsgs;
 // 67862D: using guessed type char gbGameDestroyed;
 
-//----- (0043BCED) --------------------------------------------------------
 void __cdecl msg_free_packets()
 {
 	TMegaPkt *v0; // eax
@@ -146,7 +140,6 @@ void __cdecl msg_free_packets()
 	}
 }
 
-//----- (0043BD19) --------------------------------------------------------
 int __cdecl msg_wait_for_turns()
 {
 	//int v0; // eax
@@ -191,7 +184,6 @@ int __cdecl msg_wait_for_turns()
 // 6796E4: using guessed type char gbDeltaSender;
 // 679738: using guessed type int gdwTurnsInTransit;
 
-//----- (0043BDEB) --------------------------------------------------------
 void __cdecl msg_process_net_packets()
 {
 	if ( gbMaxPlayers != 1 )
@@ -205,7 +197,6 @@ void __cdecl msg_process_net_packets()
 // 676194: using guessed type char gbBufferMsgs;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0043BE0D) --------------------------------------------------------
 void __cdecl msg_pre_packet()
 {
 	TMegaPkt *v0; // edi
@@ -247,7 +238,6 @@ void __cdecl msg_pre_packet()
 	}
 }
 
-//----- (0043BE74) --------------------------------------------------------
 void __fastcall DeltaExportData(int pnum)
 {
 	char *v1; // edi
@@ -290,7 +280,6 @@ void __fastcall DeltaExportData(int pnum)
 }
 // 67618C: using guessed type char sgbDeltaChanged;
 
-//----- (0043BF2B) --------------------------------------------------------
 void *__fastcall DeltaExportItem(void *dst, void *src)
 {
 	_BYTE *v2; // edi
@@ -318,7 +307,6 @@ void *__fastcall DeltaExportItem(void *dst, void *src)
 	return v3;
 }
 
-//----- (0043BF5B) --------------------------------------------------------
 void *__fastcall DeltaExportObject(void *dst, void *src)
 {
 	char *v2; // esi
@@ -328,7 +316,6 @@ void *__fastcall DeltaExportObject(void *dst, void *src)
 	return v2 + 127;
 }
 
-//----- (0043BF6F) --------------------------------------------------------
 void *__fastcall DeltaExportMonster(void *dst, void *src)
 {
 	_BYTE *v2; // edi
@@ -356,7 +343,6 @@ void *__fastcall DeltaExportMonster(void *dst, void *src)
 	return v3;
 }
 
-//----- (0043BFA1) --------------------------------------------------------
 char *__fastcall DeltaExportJunk(char *a1)
 {
 	char *v1; // ebx
@@ -402,7 +388,6 @@ char *__fastcall DeltaExportJunk(char *a1)
 	return v1;
 }
 
-//----- (0043C019) --------------------------------------------------------
 int __fastcall msg_comp_level(char *buffer, int size)
 {
 	char *v2; // esi
@@ -416,7 +401,6 @@ int __fastcall msg_comp_level(char *buffer, int size)
 	return v4 + 1;
 }
 
-//----- (0043C035) --------------------------------------------------------
 void __cdecl delta_init()
 {
 	sgbDeltaChanged = 0;
@@ -428,7 +412,6 @@ void __cdecl delta_init()
 // 67618C: using guessed type char sgbDeltaChanged;
 // 676190: using guessed type int deltaload;
 
-//----- (0043C07C) --------------------------------------------------------
 void __fastcall delta_kill_monster(int mi, unsigned char x, unsigned char y, unsigned char bLevel)
 {
 	DMonsterStr *v4; // eax
@@ -448,7 +431,6 @@ void __fastcall delta_kill_monster(int mi, unsigned char x, unsigned char y, uns
 // 67618C: using guessed type char sgbDeltaChanged;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0043C0C2) --------------------------------------------------------
 void __fastcall delta_monster_hp(int mi, int hp, unsigned char bLevel)
 {
 	DMonsterStr *v3; // eax
@@ -464,7 +446,6 @@ void __fastcall delta_monster_hp(int mi, int hp, unsigned char bLevel)
 // 67618C: using guessed type char sgbDeltaChanged;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0043C0F2) --------------------------------------------------------
 void __fastcall delta_sync_monster(TCmdLocParam1 *packet, char level)
 {
 	DMonsterStr *v2; // eax
@@ -487,7 +468,6 @@ void __fastcall delta_sync_monster(TCmdLocParam1 *packet, char level)
 // 67618C: using guessed type char sgbDeltaChanged;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0043C134) --------------------------------------------------------
 void __fastcall delta_sync_golem(TCmdGolem *pG, int pnum, int bLevel)
 {
 	DMonsterStr *v3; // eax
@@ -509,7 +489,6 @@ void __fastcall delta_sync_golem(TCmdGolem *pG, int pnum, int bLevel)
 // 67618C: using guessed type char sgbDeltaChanged;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0043C17D) --------------------------------------------------------
 void __fastcall delta_leave_sync(unsigned char bLevel)
 {
 	unsigned char v1; // bl
@@ -556,19 +535,16 @@ void __fastcall delta_leave_sync(unsigned char bLevel)
 // 67618C: using guessed type char sgbDeltaChanged;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0043C24F) --------------------------------------------------------
 bool __fastcall delta_portal_inited(int portal_num)
 {
 	return sgJunk[0].portal[portal_num].x == -1;
 }
 
-//----- (0043C25D) --------------------------------------------------------
 bool __fastcall delta_quest_inited(int quest_num)
 {
 	return sgJunk[0].quests[quest_num].qstate != -1;
 }
 
-//----- (0043C26B) --------------------------------------------------------
 void __fastcall DeltaAddItem(int ii)
 {
 	int v1; // eax
@@ -641,7 +617,6 @@ void __fastcall DeltaAddItem(int ii)
 // 67618C: using guessed type char sgbDeltaChanged;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0043C372) --------------------------------------------------------
 void __cdecl DeltaSaveLevel()
 {
 	int v0; // eax
@@ -669,7 +644,6 @@ void __cdecl DeltaSaveLevel()
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0043C3BA) --------------------------------------------------------
 void __cdecl DeltaLoadLevel()
 {
 	int v0; // ebx
@@ -933,7 +907,6 @@ void __cdecl DeltaLoadLevel()
 // 676190: using guessed type int deltaload;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0043C873) --------------------------------------------------------
 void __fastcall NetSendCmd(unsigned char bHiPri, unsigned char bCmd)
 {
 	TCmd cmd; // [esp+3h] [ebp-1h]
@@ -945,7 +918,6 @@ void __fastcall NetSendCmd(unsigned char bHiPri, unsigned char bCmd)
 		NetSendLoPri((unsigned char *)&cmd, 1u);
 }
 
-//----- (0043C891) --------------------------------------------------------
 void __fastcall NetSendCmdGolem(unsigned char mx, unsigned char my, unsigned char dir, unsigned char menemy, int hp, int cl)
 {
 	TCmdGolem cmd; // [esp+0h] [ebp-Ch]
@@ -960,7 +932,6 @@ void __fastcall NetSendCmdGolem(unsigned char mx, unsigned char my, unsigned cha
 	NetSendLoPri((unsigned char *)&cmd, 0xAu);
 }
 
-//----- (0043C8C7) --------------------------------------------------------
 void __fastcall NetSendCmdLoc(unsigned char bHiPri, unsigned char bCmd, unsigned char x, unsigned char y)
 {
 	TCmdLoc cmd; // [esp+1h] [ebp-3h]
@@ -974,7 +945,6 @@ void __fastcall NetSendCmdLoc(unsigned char bHiPri, unsigned char bCmd, unsigned
 		NetSendLoPri((unsigned char *)&cmd, 3u);
 }
 
-//----- (0043C8F3) --------------------------------------------------------
 void __fastcall NetSendCmdLocParam1(unsigned char bHiPri, unsigned char bCmd, unsigned char x, unsigned char y, int wParam1)
 {
 	TCmdLocParam1 cmd; // [esp+0h] [ebp-8h]
@@ -989,7 +959,6 @@ void __fastcall NetSendCmdLocParam1(unsigned char bHiPri, unsigned char bCmd, un
 		NetSendLoPri((unsigned char *)&cmd, 5u);
 }
 
-//----- (0043C928) --------------------------------------------------------
 void __fastcall NetSendCmdLocParam2(unsigned char bHiPri, unsigned char bCmd, unsigned char x, unsigned char y, int wParam1, int wParam2)
 {
 	TCmdLocParam2 cmd; // [esp+0h] [ebp-8h]
@@ -1005,7 +974,6 @@ void __fastcall NetSendCmdLocParam2(unsigned char bHiPri, unsigned char bCmd, un
 		NetSendLoPri((unsigned char *)&cmd, 7u);
 }
 
-//----- (0043C965) --------------------------------------------------------
 void __fastcall NetSendCmdLocParam3(unsigned char bHiPri, unsigned char bCmd, unsigned char x, unsigned char y, int wParam1, int wParam2, int wParam3)
 {
 	TCmdLocParam3 cmd; // [esp+0h] [ebp-Ch]
@@ -1022,7 +990,6 @@ void __fastcall NetSendCmdLocParam3(unsigned char bHiPri, unsigned char bCmd, un
 		NetSendLoPri((unsigned char *)&cmd, 9u);
 }
 
-//----- (0043C9AB) --------------------------------------------------------
 void __fastcall NetSendCmdParam1(unsigned char bHiPri, unsigned char bCmd, unsigned short wParam1)
 {
 	TCmdParam1 cmd; // [esp+1h] [ebp-3h]
@@ -1035,7 +1002,6 @@ void __fastcall NetSendCmdParam1(unsigned char bHiPri, unsigned char bCmd, unsig
 		NetSendLoPri((unsigned char *)&cmd, 3u);
 }
 
-//----- (0043C9D3) --------------------------------------------------------
 void __fastcall NetSendCmdParam2(unsigned char bHiPri, unsigned char bCmd, unsigned short wParam1, unsigned short wParam2)
 {
 	TCmdParam2 cmd; // [esp+0h] [ebp-8h]
@@ -1049,7 +1015,6 @@ void __fastcall NetSendCmdParam2(unsigned char bHiPri, unsigned char bCmd, unsig
 		NetSendLoPri((unsigned char *)&cmd, 5u);
 }
 
-//----- (0043CA04) --------------------------------------------------------
 void __fastcall NetSendCmdParam3(unsigned char bHiPri, unsigned char bCmd, unsigned short wParam1, unsigned short wParam2, int wParam3)
 {
 	TCmdParam3 cmd; // [esp+0h] [ebp-8h]
@@ -1064,7 +1029,6 @@ void __fastcall NetSendCmdParam3(unsigned char bHiPri, unsigned char bCmd, unsig
 		NetSendLoPri((unsigned char *)&cmd, 7u);
 }
 
-//----- (0043CA3D) --------------------------------------------------------
 void __fastcall NetSendCmdQuest(unsigned char bHiPri, unsigned char q)
 {
 	int v2; // eax
@@ -1085,7 +1049,6 @@ void __fastcall NetSendCmdQuest(unsigned char bHiPri, unsigned char q)
 		NetSendLoPri((unsigned char *)&cmd, 5u);
 }
 
-//----- (0043CA84) --------------------------------------------------------
 void __fastcall NetSendCmdGItem(unsigned char bHiPri, unsigned char bCmd, unsigned char mast, unsigned char pnum, int ii)
 {
 	int v5; // eax
@@ -1146,7 +1109,6 @@ void __fastcall NetSendCmdGItem(unsigned char bHiPri, unsigned char bCmd, unsign
 		NetSendLoPri((unsigned char *)&cmd, 0x1Eu);
 }
 
-//----- (0043CC09) --------------------------------------------------------
 void __fastcall NetSendCmdGItem2(unsigned char usonly, unsigned char bCmd, unsigned char mast, unsigned char pnum, struct TCmdGItem *p)
 {
 	unsigned char v5; // bl
@@ -1179,7 +1141,6 @@ void __fastcall NetSendCmdGItem2(unsigned char usonly, unsigned char bCmd, unsig
 	multi_msg_add(&cmd.bCmd, 0x1Eu);
 }
 
-//----- (0043CC74) --------------------------------------------------------
 bool __fastcall NetSendCmdReq2(unsigned char bCmd, unsigned char mast, unsigned char pnum, struct TCmdGItem *p)
 {
 	unsigned char v4; // bl
@@ -1206,7 +1167,6 @@ LABEL_3:
 	return 0;
 }
 
-//----- (0043CCCF) --------------------------------------------------------
 void __fastcall NetSendCmdExtra(struct TCmdGItem *p)
 {
 	TCmdGItem cmd; // [esp+0h] [ebp-20h]
@@ -1217,7 +1177,6 @@ void __fastcall NetSendCmdExtra(struct TCmdGItem *p)
 	NetSendHiPri((unsigned char *)&cmd, 0x1Eu);
 }
 
-//----- (0043CCF8) --------------------------------------------------------
 void __fastcall NetSendCmdPItem(unsigned char bHiPri, unsigned char bCmd, unsigned char x, unsigned char y)
 {
 	int v4; // eax
@@ -1275,7 +1234,6 @@ void __fastcall NetSendCmdPItem(unsigned char bHiPri, unsigned char bCmd, unsign
 		NetSendLoPri((unsigned char *)&cmd, 0x16u);
 }
 
-//----- (0043CE5B) --------------------------------------------------------
 void __fastcall NetSendCmdChItem(unsigned char bHiPri, unsigned char bLoc)
 {
 	short v2; // dx
@@ -1296,7 +1254,6 @@ void __fastcall NetSendCmdChItem(unsigned char bHiPri, unsigned char bLoc)
 		NetSendLoPri((unsigned char *)&cmd, 0xBu);
 }
 
-//----- (0043CEB2) --------------------------------------------------------
 void __fastcall NetSendCmdDelItem(unsigned char bHiPri, unsigned char bLoc)
 {
 	TCmdDelItem cmd; // [esp+2h] [ebp-2h]
@@ -1309,7 +1266,6 @@ void __fastcall NetSendCmdDelItem(unsigned char bHiPri, unsigned char bLoc)
 		NetSendLoPri((unsigned char *)&cmd, 2u);
 }
 
-//----- (0043CED4) --------------------------------------------------------
 void __fastcall NetSendCmdDItem(unsigned char bHiPri, int ii)
 {
 	int v2; // eax
@@ -1367,7 +1323,6 @@ void __fastcall NetSendCmdDItem(unsigned char bHiPri, int ii)
 		NetSendLoPri((unsigned char *)&cmd, 0x16u);
 }
 
-//----- (0043D039) --------------------------------------------------------
 void __fastcall NetSendCmdDamage(unsigned char bHiPri, unsigned char bPlr, unsigned int dwDam)
 {
 	TCmdDamage cmd; // [esp+0h] [ebp-8h]
@@ -1381,7 +1336,6 @@ void __fastcall NetSendCmdDamage(unsigned char bHiPri, unsigned char bPlr, unsig
 		NetSendLoPri((unsigned char *)&cmd, 6u);
 }
 
-//----- (0043D064) --------------------------------------------------------
 void __fastcall NetSendCmdString(int a1, const char *pszStr)
 {
 	const char *v2; // esi
@@ -1397,7 +1351,6 @@ void __fastcall NetSendCmdString(int a1, const char *pszStr)
 	multi_send_msg_packet(v3, &cmd.bCmd, dwStrLen + 2);
 }
 
-//----- (0043D09D) --------------------------------------------------------
 void __fastcall RemovePlrPortal(int pnum)
 {
 	memset((char *)sgJunk + 5 * pnum, 255, 5u);
@@ -1405,7 +1358,6 @@ void __fastcall RemovePlrPortal(int pnum)
 }
 // 67618C: using guessed type char sgbDeltaChanged;
 
-//----- (0043D0BC) --------------------------------------------------------
 int __fastcall ParseCmd(int pnum, TCmd *pCmd)
 {
 	bool v2; // zf
@@ -1637,7 +1589,6 @@ LABEL_100:
 // 67618D: using guessed type char sgbDeltaChunks;
 // 6796E4: using guessed type char gbDeltaSender;
 
-//----- (0043D632) --------------------------------------------------------
 void __fastcall DeltaImportData(unsigned char cmd, int recv_offset)
 {
 	unsigned char v2; // bl
@@ -1669,7 +1620,6 @@ void __fastcall DeltaImportData(unsigned char cmd, int recv_offset)
 // 67618C: using guessed type char sgbDeltaChanged;
 // 67618D: using guessed type char sgbDeltaChunks;
 
-//----- (0043D6BA) --------------------------------------------------------
 void *__fastcall DeltaImportItem(void *src, void *dst)
 {
 	char *v2; // edi
@@ -1698,7 +1648,6 @@ void *__fastcall DeltaImportItem(void *src, void *dst)
 	return v3;
 }
 
-//----- (0043D6F5) --------------------------------------------------------
 void *__fastcall DeltaImportObject(void *src, void *dst)
 {
 	char *v2; // esi
@@ -1708,7 +1657,6 @@ void *__fastcall DeltaImportObject(void *src, void *dst)
 	return v2 + 127;
 }
 
-//----- (0043D709) --------------------------------------------------------
 void *__fastcall DeltaImportMonster(void *src, void *dst)
 {
 	char *v2; // edi
@@ -1737,7 +1685,6 @@ void *__fastcall DeltaImportMonster(void *src, void *dst)
 	return v3;
 }
 
-//----- (0043D746) --------------------------------------------------------
 char __fastcall DeltaImportJunk(int a1)
 {
 	_BYTE *v1; // ebx
@@ -1797,13 +1744,11 @@ char __fastcall DeltaImportJunk(int a1)
 	return result;
 }
 
-//----- (0043D7F1) --------------------------------------------------------
 int __fastcall On_SYNCDATA(void *packet, int pnum)
 {
 	return SyncData(pnum, (TSyncHeader *)packet);
 }
 
-//----- (0043D7FC) --------------------------------------------------------
 int __fastcall On_WALKXY(struct TCmdLoc *pCmd, int pnum)
 {
 	int v2; // ebx
@@ -1826,7 +1771,6 @@ int __fastcall On_WALKXY(struct TCmdLoc *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043D84A) --------------------------------------------------------
 int __fastcall On_ADDSTR(struct TCmdParam1 *pCmd, int pnum)
 {
 	unsigned short v2; // cx
@@ -1845,7 +1789,6 @@ int __fastcall On_ADDSTR(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043D87B) --------------------------------------------------------
 int __fastcall On_ADDMAG(struct TCmdParam1 *pCmd, int pnum)
 {
 	unsigned short v2; // cx
@@ -1864,7 +1807,6 @@ int __fastcall On_ADDMAG(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043D8AC) --------------------------------------------------------
 int __fastcall On_ADDDEX(struct TCmdParam1 *pCmd, int pnum)
 {
 	unsigned short v2; // cx
@@ -1883,7 +1825,6 @@ int __fastcall On_ADDDEX(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043D8DD) --------------------------------------------------------
 int __fastcall On_ADDVIT(struct TCmdParam1 *pCmd, int pnum)
 {
 	unsigned short v2; // cx
@@ -1902,7 +1843,6 @@ int __fastcall On_ADDVIT(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043D90E) --------------------------------------------------------
 int __fastcall On_SBSPELL(struct TCmdParam1 *pCmd, int pnum)
 {
 	int v2; // eax
@@ -1926,7 +1866,6 @@ int __fastcall On_SBSPELL(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043D97D) --------------------------------------------------------
 void msg_errorf(char *pszFmt, ...)
 {
 	DWORD v1; // eax
@@ -1944,7 +1883,6 @@ void msg_errorf(char *pszFmt, ...)
 }
 // 67619C: using guessed type int msg_err_timer;
 
-//----- (0043D9C4) --------------------------------------------------------
 int __fastcall On_GOTOGETITEM(struct TCmdLocParam1 *pCmd, int pnum)
 {
 	struct TCmdLocParam1 *v2; // edi
@@ -1965,7 +1903,6 @@ int __fastcall On_GOTOGETITEM(struct TCmdLocParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043DA16) --------------------------------------------------------
 int __fastcall On_REQUESTGITEM(struct TCmdGItem *pCmd, int pnum)
 {
 	struct TCmdGItem *v2; // esi
@@ -2013,7 +1950,6 @@ int __fastcall On_REQUESTGITEM(struct TCmdGItem *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043DAE6) --------------------------------------------------------
 bool __fastcall i_own_level(int nReqLevel)
 {
 	int v1; // edx
@@ -2033,7 +1969,6 @@ bool __fastcall i_own_level(int nReqLevel)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043DB2D) --------------------------------------------------------
 int __fastcall On_GETITEM(struct TCmdGItem *pCmd, int pnum)
 {
 	struct TCmdGItem *v2; // esi
@@ -2106,7 +2041,6 @@ int __fastcall On_GETITEM(struct TCmdGItem *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043DC3D) --------------------------------------------------------
 bool __fastcall delta_get_item(struct TCmdGItem *pI, unsigned char bLevel)
 {
 	struct TCmdGItem *v2; // esi
@@ -2181,7 +2115,6 @@ LABEL_15:
 // 67618C: using guessed type char sgbDeltaChanged;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0043DD40) --------------------------------------------------------
 int __fastcall On_GOTOAGETITEM(struct TCmdLocParam1 *pCmd, int pnum)
 {
 	struct TCmdLocParam1 *v2; // edi
@@ -2202,7 +2135,6 @@ int __fastcall On_GOTOAGETITEM(struct TCmdLocParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043DD92) --------------------------------------------------------
 int __fastcall On_REQUESTAGITEM(struct TCmdGItem *pCmd, int pnum)
 {
 	struct TCmdGItem *v2; // esi
@@ -2250,7 +2182,6 @@ int __fastcall On_REQUESTAGITEM(struct TCmdGItem *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043DE60) --------------------------------------------------------
 int __fastcall On_AGETITEM(struct TCmdGItem *pCmd, int pnum)
 {
 	struct TCmdGItem *v2; // esi
@@ -2322,7 +2253,6 @@ int __fastcall On_AGETITEM(struct TCmdGItem *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043DF6E) --------------------------------------------------------
 int __fastcall On_ITEMEXTRA(struct TCmdGItem *pCmd, int pnum)
 {
 	int v2; // edi
@@ -2349,7 +2279,6 @@ int __fastcall On_ITEMEXTRA(struct TCmdGItem *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043DFC9) --------------------------------------------------------
 int __fastcall On_PUTITEM(struct TCmdPItem *pCmd, int pnum)
 {
 	int v2; // edi
@@ -2406,7 +2335,6 @@ int __fastcall On_PUTITEM(struct TCmdPItem *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043E0CE) --------------------------------------------------------
 void __fastcall delta_put_item(struct TCmdPItem *pI, int x, int y, unsigned char bLevel)
 {
 	struct TCmdPItem *v4; // ebx
@@ -2461,7 +2389,6 @@ void __fastcall delta_put_item(struct TCmdPItem *pI, int x, int y, unsigned char
 // 67618C: using guessed type char sgbDeltaChanged;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0043E179) --------------------------------------------------------
 void __fastcall check_update_plr(int pnum)
 {
 	if ( gbMaxPlayers != 1 && pnum == myplr )
@@ -2469,7 +2396,6 @@ void __fastcall check_update_plr(int pnum)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0043E193) --------------------------------------------------------
 int __fastcall On_SYNCPUTITEM(struct TCmdPItem *pCmd, int pnum)
 {
 	int v2; // ebx
@@ -2519,7 +2445,6 @@ int __fastcall On_SYNCPUTITEM(struct TCmdPItem *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043E284) --------------------------------------------------------
 int __fastcall On_RESPAWNITEM(struct TCmdPItem *pCmd, int pnum)
 {
 	struct TCmdPItem *v2; // esi
@@ -2556,7 +2481,6 @@ int __fastcall On_RESPAWNITEM(struct TCmdPItem *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043E32A) --------------------------------------------------------
 int __fastcall On_ATTACKXY(struct TCmdLoc *pCmd, int pnum)
 {
 	struct TCmdLoc *v2; // edi
@@ -2578,7 +2502,6 @@ int __fastcall On_ATTACKXY(struct TCmdLoc *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043E386) --------------------------------------------------------
 int __fastcall On_SATTACKXY(struct TCmdLoc *pCmd, int pnum)
 {
 	struct TCmdLoc *v2; // edi
@@ -2600,7 +2523,6 @@ int __fastcall On_SATTACKXY(struct TCmdLoc *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043E3D5) --------------------------------------------------------
 int __fastcall On_RATTACKXY(struct TCmdLoc *pCmd, int pnum)
 {
 	struct TCmdLoc *v2; // edi
@@ -2622,7 +2544,6 @@ int __fastcall On_RATTACKXY(struct TCmdLoc *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043E424) --------------------------------------------------------
 int __fastcall On_SPELLXYD(struct TCmdLocParam3 *pCmd, int pnum)
 {
 	struct TCmdLocParam3 *v2; // edi
@@ -2658,7 +2579,6 @@ int __fastcall On_SPELLXYD(struct TCmdLocParam3 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043E4D2) --------------------------------------------------------
 int __fastcall On_SPELLXY(struct TCmdLocParam2 *pCmd, int pnum)
 {
 	struct TCmdLocParam2 *v2; // edi
@@ -2693,7 +2613,6 @@ int __fastcall On_SPELLXY(struct TCmdLocParam2 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043E576) --------------------------------------------------------
 int __fastcall On_TSPELLXY(struct TCmdLocParam2 *pCmd, int pnum)
 {
 	struct TCmdLocParam2 *v2; // edi
@@ -2726,7 +2645,6 @@ int __fastcall On_TSPELLXY(struct TCmdLocParam2 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043E61A) --------------------------------------------------------
 int __fastcall On_OPOBJXY(struct TCmdLocParam1 *pCmd, int pnum)
 {
 	struct TCmdLocParam1 *v2; // esi
@@ -2752,7 +2670,6 @@ int __fastcall On_OPOBJXY(struct TCmdLocParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043E68A) --------------------------------------------------------
 int __fastcall On_DISARMXY(struct TCmdLocParam1 *pCmd, int pnum)
 {
 	struct TCmdLocParam1 *v2; // esi
@@ -2778,7 +2695,6 @@ int __fastcall On_DISARMXY(struct TCmdLocParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043E6FA) --------------------------------------------------------
 int __fastcall On_OPOBJT(struct TCmdParam1 *pCmd, int pnum)
 {
 	int v2; // eax
@@ -2796,7 +2712,6 @@ int __fastcall On_OPOBJT(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043E732) --------------------------------------------------------
 int __fastcall On_ATTACKID(struct TCmdParam1 *pCmd, int pnum)
 {
 	int v2; // ebp
@@ -2828,7 +2743,6 @@ int __fastcall On_ATTACKID(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043E7DF) --------------------------------------------------------
 int __fastcall On_ATTACKPID(struct TCmdParam1 *pCmd, int pnum)
 {
 	struct TCmdParam1 *v2; // edi
@@ -2849,7 +2763,6 @@ int __fastcall On_ATTACKPID(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043E840) --------------------------------------------------------
 int __fastcall On_RATTACKID(struct TCmdParam1 *pCmd, int pnum)
 {
 	struct TCmdParam1 *v2; // edi
@@ -2870,7 +2783,6 @@ int __fastcall On_RATTACKID(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043E885) --------------------------------------------------------
 int __fastcall On_RATTACKPID(struct TCmdParam1 *pCmd, int pnum)
 {
 	struct TCmdParam1 *v2; // edi
@@ -2891,7 +2803,6 @@ int __fastcall On_RATTACKPID(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043E8CA) --------------------------------------------------------
 int __fastcall On_SPELLID(struct TCmdLocParam2 *pCmd, int pnum)
 {
 	struct TCmdLocParam2 *v2; // edi
@@ -2925,7 +2836,6 @@ int __fastcall On_SPELLID(struct TCmdLocParam2 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043E964) --------------------------------------------------------
 int __fastcall On_SPELLPID(struct TCmdLocParam2 *pCmd, int pnum)
 {
 	struct TCmdLocParam2 *v2; // edi
@@ -2959,7 +2869,6 @@ int __fastcall On_SPELLPID(struct TCmdLocParam2 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043E9FE) --------------------------------------------------------
 int __fastcall On_TSPELLID(struct TCmdLocParam2 *pCmd, int pnum)
 {
 	struct TCmdLocParam2 *v2; // edi
@@ -2991,7 +2900,6 @@ int __fastcall On_TSPELLID(struct TCmdLocParam2 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043EA98) --------------------------------------------------------
 int __fastcall On_TSPELLPID(struct TCmdLocParam2 *pCmd, int pnum)
 {
 	struct TCmdLocParam2 *v2; // edi
@@ -3023,7 +2931,6 @@ int __fastcall On_TSPELLPID(struct TCmdLocParam2 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043EB32) --------------------------------------------------------
 int __fastcall On_KNOCKBACK(struct TCmdParam1 *pCmd, int pnum)
 {
 	int v2; // edi
@@ -3040,7 +2947,6 @@ int __fastcall On_KNOCKBACK(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043EB74) --------------------------------------------------------
 int __fastcall On_RESURRECT(struct TCmdParam1 *pCmd, int pnum)
 {
 	int v2; // esi
@@ -3059,7 +2965,6 @@ int __fastcall On_RESURRECT(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043EBA4) --------------------------------------------------------
 int __fastcall On_HEALOTHER(struct TCmdParam1 *pCmd, int pnum)
 {
 	if ( gbBufferMsgs != 1 && currlevel == plr[pnum].plrlevel )
@@ -3068,7 +2973,6 @@ int __fastcall On_HEALOTHER(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043EBD5) --------------------------------------------------------
 int __fastcall On_TALKXY(struct TCmdLocParam1 *pCmd, int pnum)
 {
 	struct TCmdLocParam1 *v2; // edi
@@ -3089,7 +2993,6 @@ int __fastcall On_TALKXY(struct TCmdLocParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043EC27) --------------------------------------------------------
 int __fastcall On_NEWLVL(struct TCmdParam2 *pCmd, int pnum)
 {
 	if ( gbBufferMsgs == 1 )
@@ -3104,7 +3007,6 @@ int __fastcall On_NEWLVL(struct TCmdParam2 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043EC5B) --------------------------------------------------------
 int __fastcall On_WARP(struct TCmdParam1 *pCmd, int pnum)
 {
 	int v2; // esi
@@ -3127,7 +3029,6 @@ int __fastcall On_WARP(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043ECBA) --------------------------------------------------------
 int __fastcall On_MONSTDEATH(struct TCmdLocParam1 *pCmd, int pnum)
 {
 	struct TCmdLocParam1 *v2; // esi
@@ -3149,7 +3050,6 @@ int __fastcall On_MONSTDEATH(struct TCmdLocParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043ED23) --------------------------------------------------------
 int __fastcall On_KILLGOLEM(struct TCmdLocParam1 *pCmd, int pnum)
 {
 	int v2; // edi
@@ -3171,7 +3071,6 @@ int __fastcall On_KILLGOLEM(struct TCmdLocParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043ED89) --------------------------------------------------------
 int __fastcall On_AWAKEGOLEM(struct TCmdGolem *pCmd, int pnum)
 {
 	int v2; // esi
@@ -3229,7 +3128,6 @@ LABEL_16:
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043EE3D) --------------------------------------------------------
 int __fastcall On_MONSTDAMAGE(struct TCmdLocParam1 *pCmd, int pnum)
 {
 	int v2; // edi
@@ -3267,7 +3165,6 @@ int __fastcall On_MONSTDAMAGE(struct TCmdLocParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043EEF5) --------------------------------------------------------
 int __fastcall On_PLRDEAD(struct TCmdParam1 *pCmd, int pnum)
 {
 	if ( gbBufferMsgs == 1 )
@@ -3286,7 +3183,6 @@ int __fastcall On_PLRDEAD(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043EF2D) --------------------------------------------------------
 int __fastcall On_PLRDAMAGE(struct TCmdDamage *pCmd, int pnum)
 {
 	int v2; // edi
@@ -3326,7 +3222,6 @@ int __fastcall On_PLRDAMAGE(struct TCmdDamage *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043EFDD) --------------------------------------------------------
 int __fastcall On_OPENDOOR(struct TCmdParam1 *pCmd, int pnum)
 {
 	struct TCmdParam1 *v2; // edi
@@ -3348,7 +3243,6 @@ int __fastcall On_OPENDOOR(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043F033) --------------------------------------------------------
 void __fastcall delta_sync_object(int oi, unsigned char bCmd, unsigned char bLevel)
 {
 	if ( gbMaxPlayers != 1 )
@@ -3360,7 +3254,6 @@ void __fastcall delta_sync_object(int oi, unsigned char bCmd, unsigned char bLev
 // 67618C: using guessed type char sgbDeltaChanged;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0043F058) --------------------------------------------------------
 int __fastcall On_CLOSEDOOR(struct TCmdParam1 *pCmd, int pnum)
 {
 	struct TCmdParam1 *v2; // edi
@@ -3382,7 +3275,6 @@ int __fastcall On_CLOSEDOOR(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043F0AE) --------------------------------------------------------
 int __fastcall On_OPERATEOBJ(struct TCmdParam1 *pCmd, int pnum)
 {
 	struct TCmdParam1 *v2; // edi
@@ -3404,7 +3296,6 @@ int __fastcall On_OPERATEOBJ(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043F104) --------------------------------------------------------
 int __fastcall On_PLROPOBJ(struct TCmdParam2 *pCmd, int pnum)
 {
 	struct TCmdParam2 *v2; // esi
@@ -3426,7 +3317,6 @@ int __fastcall On_PLROPOBJ(struct TCmdParam2 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043F15C) --------------------------------------------------------
 int __fastcall On_BREAKOBJ(struct TCmdParam2 *pCmd, int pnum)
 {
 	struct TCmdParam2 *v2; // esi
@@ -3448,7 +3338,6 @@ int __fastcall On_BREAKOBJ(struct TCmdParam2 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043F1B0) --------------------------------------------------------
 int __fastcall On_CHANGEPLRITEMS(struct TCmdChItem *pCmd, int pnum)
 {
 	int v2; // eax
@@ -3474,7 +3363,6 @@ int __fastcall On_CHANGEPLRITEMS(struct TCmdChItem *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043F1F0) --------------------------------------------------------
 int __fastcall On_DELPLRITEMS(struct TCmdDelItem *pCmd, int pnum)
 {
 	int v2; // eax
@@ -3493,7 +3381,6 @@ int __fastcall On_DELPLRITEMS(struct TCmdDelItem *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043F21E) --------------------------------------------------------
 int __fastcall On_PLRLEVEL(struct TCmdParam1 *pCmd, int pnum)
 {
 	if ( gbBufferMsgs == 1 )
@@ -3508,7 +3395,6 @@ int __fastcall On_PLRLEVEL(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043F258) --------------------------------------------------------
 int __fastcall On_DROPITEM(struct TCmdPItem *pCmd, int pnum)
 {
 	if ( gbBufferMsgs == 1 )
@@ -3519,7 +3405,6 @@ int __fastcall On_DROPITEM(struct TCmdPItem *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043F28F) --------------------------------------------------------
 int __fastcall On_SEND_PLRINFO(struct TCmdPlrInfoHdr *pCmd, int pnum)
 {
 	struct TCmdPlrInfoHdr *v2; // esi
@@ -3538,7 +3423,6 @@ int __fastcall On_ACK_PLRINFO(struct TCmdPlrInfoHdr *pCmd, int pnum)
   return On_SEND_PLRINFO(pCmd, pnum);
 }
 
-//----- (0043F2CE) --------------------------------------------------------
 int __fastcall On_PLAYER_JOINLEVEL(struct TCmdLocParam1 *pCmd, int pnum)
 {
 	int v2; // ebx
@@ -3612,7 +3496,6 @@ int __fastcall On_PLAYER_JOINLEVEL(struct TCmdLocParam1 *pCmd, int pnum)
 // 676194: using guessed type char gbBufferMsgs;
 // 67862C: using guessed type char gbActivePlayers;
 
-//----- (0043F448) --------------------------------------------------------
 int __fastcall On_ACTIVATEPORTAL(DJunk *pCmd, int pnum)
 {
 	signed int v2; // ebx
@@ -3690,7 +3573,6 @@ LABEL_19:
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043F521) --------------------------------------------------------
 void __fastcall delta_open_portal(int pnum, int x, int y, int bLevel, int bLType, int bSetLvl)
 {
 	int v6; // eax
@@ -3705,7 +3587,6 @@ void __fastcall delta_open_portal(int pnum, int x, int y, int bLevel, int bLType
 }
 // 67618C: using guessed type char sgbDeltaChanged;
 
-//----- (0043F55C) --------------------------------------------------------
 int __fastcall On_DEACTIVATEPORTAL(struct TCmd *pCmd, int pnum)
 {
 	int v2; // esi
@@ -3726,7 +3607,6 @@ int __fastcall On_DEACTIVATEPORTAL(struct TCmd *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043F59A) --------------------------------------------------------
 int __fastcall On_RETOWN(struct TCmd *pCmd, int pnum)
 {
 	int v2; // esi
@@ -3749,7 +3629,6 @@ int __fastcall On_RETOWN(struct TCmd *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043F5D3) --------------------------------------------------------
 int __fastcall On_SETSTR(struct TCmdParam1 *pCmd, int pnum)
 {
 	unsigned short v2; // cx
@@ -3768,7 +3647,6 @@ int __fastcall On_SETSTR(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043F60C) --------------------------------------------------------
 int __fastcall On_SETDEX(struct TCmdParam1 *pCmd, int pnum)
 {
 	unsigned short v2; // cx
@@ -3787,7 +3665,6 @@ int __fastcall On_SETDEX(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043F645) --------------------------------------------------------
 int __fastcall On_SETMAG(struct TCmdParam1 *pCmd, int pnum)
 {
 	unsigned short v2; // cx
@@ -3806,7 +3683,6 @@ int __fastcall On_SETMAG(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043F67E) --------------------------------------------------------
 int __fastcall On_SETVIT(struct TCmdParam1 *pCmd, int pnum)
 {
 	unsigned short v2; // cx
@@ -3825,7 +3701,6 @@ int __fastcall On_SETVIT(struct TCmdParam1 *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043F6B7) --------------------------------------------------------
 int __fastcall On_STRING(struct TCmdString *pCmd, int pnum)
 {
 	const char *v2; // esi
@@ -3841,7 +3716,6 @@ int __fastcall On_STRING(struct TCmdString *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043F6EC) --------------------------------------------------------
 int __fastcall On_SYNCQUEST(struct TCmdQuest *pCmd, int pnum)
 {
 	if ( gbBufferMsgs == 1 )
@@ -3863,7 +3737,6 @@ int __fastcall On_SYNCQUEST(struct TCmdQuest *pCmd, int pnum)
 // 67618C: using guessed type char sgbDeltaChanged;
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043F72E) --------------------------------------------------------
 int __fastcall On_ENDSHIELD(int a1, int pnum)
 {
 	int v2; // ebx
@@ -3915,13 +3788,11 @@ int __fastcall On_CHEAT_SPELL_LEVEL(struct TCmd *pCmd, int pnum)
 }
 #endif
 
-//----- (0043F7A5) --------------------------------------------------------
 int __cdecl On_DEBUG()
 {
 	return 1;
 }
 
-//----- (0043F7A9) --------------------------------------------------------
 int __fastcall On_NOVA(struct TCmdLoc *pCmd, int pnum)
 {
 	struct TCmdLoc *v2; // edi
@@ -3946,7 +3817,6 @@ int __fastcall On_NOVA(struct TCmdLoc *pCmd, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043F818) --------------------------------------------------------
 int __fastcall On_SETSHIELD(int unused, int pnum)
 {
 	int result; // eax
@@ -3958,7 +3828,6 @@ int __fastcall On_SETSHIELD(int unused, int pnum)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043F830) --------------------------------------------------------
 int __fastcall On_REMSHIELD(int unused, int pnum)
 {
 	int result; // eax

--- a/Source/msg.h
+++ b/Source/msg.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __MSG_H__
+#define __MSG_H__
 
-//msg
 extern int sgdwOwnerWait; // weak
 extern int msg_cpp_init_value; // weak
 extern int sgdwRecvOffset; // idb
@@ -160,3 +161,5 @@ int __fastcall On_REMSHIELD(int unused, int pnum);
 /* data */
 
 extern int msg_inf; // weak
+
+#endif /* __MSG_H__ */

--- a/Source/msgcmd.cpp
+++ b/Source/msgcmd.cpp
@@ -8,7 +8,6 @@ int sgdwMsgCmdTimer;
 
 int msgcmd_inf = 0x7F800000; // weak
 
-//----- (0043F84E) --------------------------------------------------------
 struct msgcmd_cpp_init_1
 {
 	msgcmd_cpp_init_1()
@@ -19,7 +18,6 @@ struct msgcmd_cpp_init_1
 // 47F150: using guessed type int msgcmd_inf;
 // 6761A0: using guessed type int msgcmd_cpp_init_value;
 
-//----- (0043F859) --------------------------------------------------------
 struct msgcmd_cpp_init_2
 {
 	msgcmd_cpp_init_2()
@@ -29,32 +27,27 @@ struct msgcmd_cpp_init_2
 	}
 } _msgcmd_cpp_init_2;
 
-//----- (0043F863) --------------------------------------------------------
 void __cdecl msgcmd_init_event()
 {
 	msgcmd_init_chatcmd(&sgChat_Cmd);
 }
 
-//----- (0043F86D) --------------------------------------------------------
 void __cdecl msgcmd_cleanup_chatcmd_atexit()
 {
 	atexit(msgcmd_cleanup_chatcmd);
 }
 
-//----- (0043F879) --------------------------------------------------------
 void __cdecl msgcmd_cleanup_chatcmd()
 {
 	msgcmd_cleanup_chatcmd_1(&sgChat_Cmd);
 	msgcmd_cleanup_extern_msg(sgChat_Cmd.extern_msgs);
 }
 
-//----- (0043F88D) --------------------------------------------------------
 void __cdecl msgcmd_cmd_cleanup()
 {
 	msgcmd_free_event(&sgChat_Cmd);
 }
 
-//----- (0043F897) --------------------------------------------------------
 void __cdecl msgcmd_send_chat()
 {
 	ServerCommand *v0; // esi
@@ -73,7 +66,6 @@ void __cdecl msgcmd_send_chat()
 	}
 }
 
-//----- (0043F8D4) --------------------------------------------------------
 bool __fastcall msgcmd_add_server_cmd_W(char *chat_message)
 {
 	if ( *chat_message != '/' )
@@ -82,7 +74,6 @@ bool __fastcall msgcmd_add_server_cmd_W(char *chat_message)
 	return 1;
 }
 
-//----- (0043F8E5) --------------------------------------------------------
 void __fastcall msgcmd_add_server_cmd(char *command)
 {
 	char *v1; // edi
@@ -104,7 +95,6 @@ void __fastcall msgcmd_add_server_cmd(char *command)
 	}
 }
 
-//----- (0043F920) --------------------------------------------------------
 void __fastcall msgcmd_init_chatcmd(ChatCmd *chat_cmd)
 {
 	ServerCommand **v1; // edx
@@ -117,7 +107,6 @@ void __fastcall msgcmd_init_chatcmd(ChatCmd *chat_cmd)
 	chat_cmd->extern_msgs[1] = (ServerCommand *)~(unsigned int)chat_cmd->extern_msgs;
 }
 
-//----- (0043F936) --------------------------------------------------------
 void __fastcall msgcmd_free_event(ChatCmd *a1)
 {
 	int v1; // edx
@@ -135,7 +124,6 @@ void __fastcall msgcmd_free_event(ChatCmd *a1)
 	}
 }
 
-//----- (0043F95E) --------------------------------------------------------
 bool __fastcall msgcmd_delete_server_cmd_W(ChatCmd *cmd, ServerCommand *extern_msg)
 {
 	char *v2; // eax
@@ -156,7 +144,6 @@ bool __fastcall msgcmd_delete_server_cmd_W(ChatCmd *cmd, ServerCommand *extern_m
 	return v4;
 }
 
-//----- (0043F999) --------------------------------------------------------
 ChatCmd *__fastcall msgcmd_alloc_event(ChatCmd *a1, int a2, int a3, int a4, int a5)
 {
 	int v5; // eax
@@ -184,7 +171,6 @@ ChatCmd *__fastcall msgcmd_alloc_event(ChatCmd *a1, int a2, int a3, int a4, int 
 	return v9;
 }
 
-//----- (0043F9E5) --------------------------------------------------------
 void __fastcall msgcmd_remove_event(ChatCmd *a1, int a2)
 {
 	ServerCommand **v2; // esi
@@ -199,7 +185,6 @@ void __fastcall msgcmd_remove_event(ChatCmd *a1, int a2)
 	}
 }
 
-//----- (0043FA14) --------------------------------------------------------
 void __fastcall msgcmd_event_type(ChatCmd *a1, int a2, int *a3, int a4, int a5)
 {
 	ChatCmd *v5; // edi
@@ -248,7 +233,6 @@ void __fastcall msgcmd_event_type(ChatCmd *a1, int a2, int *a3, int a4, int a5)
 	}
 }
 
-//----- (0043FA85) --------------------------------------------------------
 void __fastcall msgcmd_cleanup_chatcmd_1(ChatCmd *a1)
 {
 	ChatCmd *v1; // esi
@@ -264,7 +248,6 @@ void __fastcall msgcmd_cleanup_chatcmd_1(ChatCmd *a1)
 	}
 }
 
-//----- (0043FA98) --------------------------------------------------------
 void __fastcall msgcmd_cleanup_extern_msg(ServerCommand **extern_msgs)
 {
 	ServerCommand *v1; // esi

--- a/Source/msgcmd.h
+++ b/Source/msgcmd.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __MSGCMD_H__
+#define __MSGCMD_H__
 
-//msgcmd
 extern int msgcmd_cpp_init_value; // weak
 extern ChatCmd sgChat_Cmd;
 extern int sgdwMsgCmdTimer;
@@ -26,3 +27,5 @@ void __fastcall msgcmd_cleanup_extern_msg(ServerCommand **extern_msgs);
 /* data */
 
 extern int msgcmd_inf; // weak
+
+#endif /* __MSGCMD_H__ */

--- a/Source/multi.cpp
+++ b/Source/multi.cpp
@@ -36,7 +36,6 @@ event_type event_types[3] =
   EVENT_TYPE_PLAYER_MESSAGE
 };
 
-//----- (0043FAC9) --------------------------------------------------------
 struct multi_cpp_init
 {
 	multi_cpp_init()
@@ -47,7 +46,6 @@ struct multi_cpp_init
 // 47F154: using guessed type int multi_inf;
 // 678620: using guessed type int multi_cpp_init_value;
 
-//----- (0043FAD4) --------------------------------------------------------
 void __fastcall multi_msg_add(unsigned char *a1, unsigned char a2)
 {
 	if ( a1 )
@@ -57,7 +55,6 @@ void __fastcall multi_msg_add(unsigned char *a1, unsigned char a2)
 	}
 }
 
-//----- (0043FAE2) --------------------------------------------------------
 void __fastcall NetSendLoPri(unsigned char *pbMsg, unsigned char bLen)
 {
 	unsigned char *v2; // esi
@@ -77,7 +74,6 @@ void __fastcall NetSendLoPri(unsigned char *pbMsg, unsigned char bLen)
 	}
 }
 
-//----- (0043FB0B) --------------------------------------------------------
 void __fastcall multi_copy_packet(void *a1, void *packet, int size)
 {
 	int v3; // eax
@@ -96,7 +92,6 @@ void __fastcall multi_copy_packet(void *a1, void *packet, int size)
 	}
 }
 
-//----- (0043FB4D) --------------------------------------------------------
 void __fastcall multi_send_packet(void *packet, int dwSize)
 {
 	void *v2; // esi
@@ -112,7 +107,6 @@ void __fastcall multi_send_packet(void *packet, int dwSize)
 		nthread_terminate_game("SNetSendMessage0");
 }
 
-//----- (0043FBB5) --------------------------------------------------------
 void __fastcall NetRecvPlrData(TPkt *pkt)
 {
 	pkt->hdr.wCheck = 'ip';
@@ -127,7 +121,6 @@ void __fastcall NetRecvPlrData(TPkt *pkt)
 	pkt->hdr.bdex = plr[myplr]._pBaseDex;
 }
 
-//----- (0043FC6F) --------------------------------------------------------
 void __fastcall NetSendHiPri(unsigned char *pbMsg, unsigned char bLen)
 {
 	unsigned char *v2; // edi
@@ -166,7 +159,6 @@ void __fastcall NetSendHiPri(unsigned char *pbMsg, unsigned char bLen)
 // 678628: using guessed type int dword_678628;
 // 679760: using guessed type int gdwNormalMsgSize;
 
-//----- (0043FD27) --------------------------------------------------------
 unsigned char *__fastcall multi_recv_packet(void *packet, unsigned char *a2, int *a3)
 {
 	char *v3; // esi
@@ -200,7 +192,6 @@ unsigned char *__fastcall multi_recv_packet(void *packet, unsigned char *a2, int
 	return result;
 }
 
-//----- (0043FD90) --------------------------------------------------------
 void __fastcall multi_send_msg_packet(int a1, unsigned char *a2, unsigned char len)
 {
 	//const void *v3; // edx
@@ -230,7 +221,6 @@ void __fastcall multi_send_msg_packet(int a1, unsigned char *a2, unsigned char l
 	nthread_terminate_game("SNetSendMessage");
 }
 
-//----- (0043FE0E) --------------------------------------------------------
 void __cdecl multi_msg_countdown()
 {
 	int v0; // esi
@@ -248,7 +238,6 @@ void __cdecl multi_msg_countdown()
 	while ( v0 < 4 );
 }
 
-//----- (0043FE3D) --------------------------------------------------------
 void __fastcall multi_parse_turn(int pnum, int turn)
 {
 	int v2; // esi
@@ -269,7 +258,6 @@ void __fastcall multi_parse_turn(int pnum, int turn)
 // 679704: using guessed type char byte_679704;
 // 679738: using guessed type int gdwTurnsInTransit;
 
-//----- (0043FE85) --------------------------------------------------------
 void __fastcall multi_handle_turn_upper_bit(int pnum)
 {
 	signed int v1; // eax
@@ -293,7 +281,6 @@ void __fastcall multi_handle_turn_upper_bit(int pnum)
 }
 // 6796E4: using guessed type char gbDeltaSender;
 
-//----- (0043FEB7) --------------------------------------------------------
 void __fastcall multi_player_left(int pnum, int reason)
 {
 	sgbPlayerLeftGameTbl[pnum] = 1;
@@ -301,7 +288,6 @@ void __fastcall multi_player_left(int pnum, int reason)
 	multi_clear_left_tbl();
 }
 
-//----- (0043FECA) --------------------------------------------------------
 void __cdecl multi_clear_left_tbl()
 {
 	int v0; // esi
@@ -324,7 +310,6 @@ void __cdecl multi_clear_left_tbl()
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0043FF0E) --------------------------------------------------------
 void __fastcall multi_player_left_msg(int pnum, int left)
 {
 	int v2; // edi
@@ -367,7 +352,6 @@ void __fastcall multi_player_left_msg(int pnum, int left)
 // 6761B8: using guessed type char gbSomebodyWonGameKludge;
 // 67862C: using guessed type char gbActivePlayers;
 
-//----- (0043FF9D) --------------------------------------------------------
 void __cdecl multi_net_ping()
 {
 	sgbTimeout = 1;
@@ -376,7 +360,6 @@ void __cdecl multi_net_ping()
 // 678644: using guessed type int sglTimeoutStart;
 // 679661: using guessed type char sgbTimeout;
 
-//----- (0043FFB0) --------------------------------------------------------
 int __cdecl multi_handle_delta()
 {
 	int v0; // esi
@@ -427,14 +410,12 @@ int __cdecl multi_handle_delta()
 // 67862D: using guessed type char gbGameDestroyed;
 // 679661: using guessed type char sgbTimeout;
 
-//----- (00440058) --------------------------------------------------------
 // Microsoft VisualC 2-11/net runtime
 int __fastcall multi_check_pkt_valid(char *a1)
 {
 	return *(_DWORD *)a1 == 0;
 }
 
-//----- (00440060) --------------------------------------------------------
 void __cdecl multi_mon_seeds()
 {
 	unsigned int v0; // eax
@@ -454,7 +435,6 @@ void __cdecl multi_mon_seeds()
 	while ( (signed int)v2 < (signed int)&monster[200]._mAISeed );
 }
 
-//----- (00440093) --------------------------------------------------------
 void __cdecl multi_begin_timeout()
 {
 	unsigned char bGroupPlayers; // bl
@@ -524,7 +504,6 @@ void __cdecl multi_begin_timeout()
 // 678644: using guessed type int sglTimeoutStart;
 // 679661: using guessed type char sgbTimeout;
 
-//----- (00440128) --------------------------------------------------------
 void __cdecl multi_check_drop_player()
 {
 	int v0; // esi
@@ -544,7 +523,6 @@ void __cdecl multi_check_drop_player()
 	while ( v0 < 4 );
 }
 
-//----- (00440153) --------------------------------------------------------
 void __cdecl multi_process_network_packets()
 {
 	//int v0; // eax
@@ -651,7 +629,6 @@ void __cdecl multi_process_network_packets()
 // 676194: using guessed type char gbBufferMsgs;
 // 676198: using guessed type int dword_676198;
 
-//----- (0044041D) --------------------------------------------------------
 void __fastcall multi_handle_all_packets(int players, TPkt *packet, int a3)
 {
 	TCmd *v3; // esi
@@ -668,7 +645,6 @@ void __fastcall multi_handle_all_packets(int players, TPkt *packet, int a3)
 	}
 }
 
-//----- (00440444) --------------------------------------------------------
 void __cdecl multi_process_tmsgs()
 {
 	int v0; // eax
@@ -683,7 +659,6 @@ void __cdecl multi_process_tmsgs()
 	}
 }
 
-//----- (00440477) --------------------------------------------------------
 void __fastcall multi_send_zero_packet(int pnum, char a2, void *pbSrc, int dwLen)
 {
 	unsigned int v4; // edi
@@ -729,7 +704,6 @@ void __fastcall multi_send_zero_packet(int pnum, char a2, void *pbSrc, int dwLen
 }
 // 67975C: using guessed type int gdwLargestMsgSize;
 
-//----- (0044055D) --------------------------------------------------------
 void __cdecl NetClose()
 {
 	if ( sgbNetInited )
@@ -748,7 +722,6 @@ void __cdecl NetClose()
 // 679660: using guessed type char gbMaxPlayers;
 // 6796E8: using guessed type int sgbNetInited;
 
-//----- (004405A4) --------------------------------------------------------
 char __fastcall multi_event_handler(int a1)
 {
 	int v1; // edi
@@ -776,7 +749,6 @@ char __fastcall multi_event_handler(int a1)
 	return v4;
 }
 
-//----- (004405EC) --------------------------------------------------------
 void __stdcall multi_handle_events(_SNETEVENT *pEvt)
 {
 	int v1; // ecx
@@ -814,7 +786,6 @@ void __stdcall multi_handle_events(_SNETEVENT *pEvt)
 // 6761B8: using guessed type char gbSomebodyWonGameKludge;
 // 6796E4: using guessed type char gbDeltaSender;
 
-//----- (00440694) --------------------------------------------------------
 int __fastcall NetInit(int bSinglePlayer, int *pfExitProgram)
 {
 	int v2; // ebx
@@ -936,14 +907,12 @@ int __fastcall NetInit(int bSinglePlayer, int *pfExitProgram)
 // 6796E4: using guessed type char gbDeltaSender;
 // 6796E8: using guessed type int sgbNetInited;
 
-//----- (00440992) --------------------------------------------------------
 void __fastcall multi_clear_pkt(char *a1)
 {
 	*(_DWORD *)a1 = 0;
 	a1[4] = 0;
 }
 
-//----- (0044099A) --------------------------------------------------------
 void __fastcall multi_send_pinfo(int pnum, TCmdPlrInfoHdr *cmd)
 {
 	char v2; // bl
@@ -958,7 +927,6 @@ void __fastcall multi_send_pinfo(int pnum, TCmdPlrInfoHdr *cmd)
 	dthread_send_delta(v3, v4, &pkplr, 1266);
 }
 
-//----- (004409D5) --------------------------------------------------------
 int __fastcall InitNewSeed(int newseed)
 {
 	int result; // eax
@@ -985,7 +953,6 @@ int __fastcall InitNewSeed(int newseed)
 	return result;
 }
 
-//----- (00440A05) --------------------------------------------------------
 void __cdecl SetupLocalCoords()
 {
 	int x; // ecx
@@ -1025,7 +992,6 @@ void __cdecl SetupLocalCoords()
 // 5CF31D: using guessed type char setlevel;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00440A9B) --------------------------------------------------------
 int __fastcall multi_init_single(_SNETPROGRAMDATA *client_info, _SNETPLAYERDATA *user_info, _SNETUIDATA *ui_info)
 {
 	//int v3; // eax
@@ -1056,7 +1022,6 @@ int __fastcall multi_init_single(_SNETPROGRAMDATA *client_info, _SNETPLAYERDATA 
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00440B09) --------------------------------------------------------
 int __fastcall multi_init_multi(_SNETPROGRAMDATA *client_info, _SNETPLAYERDATA *user_info, _SNETUIDATA *ui_info, int *a4)
 {
 	_SNETPLAYERDATA *v4; // ebx
@@ -1097,7 +1062,6 @@ int __fastcall multi_init_multi(_SNETPROGRAMDATA *client_info, _SNETPLAYERDATA *
 // 678640: using guessed type char byte_678640;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00440BDB) --------------------------------------------------------
 int __fastcall multi_upgrade(int *a1)
 {
 	int *v1; // esi
@@ -1122,7 +1086,6 @@ int __fastcall multi_upgrade(int *a1)
 	return result;
 }
 
-//----- (00440C17) --------------------------------------------------------
 void __fastcall multi_player_joins(int pnum, TCmdPlrInfoHdr *cmd, int a3)
 {
 	int v3; // ebx

--- a/Source/multi.h
+++ b/Source/multi.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __MULTI_H__
+#define __MULTI_H__
 
-//multi
 extern char gbSomebodyWonGameKludge; // weak
 extern char pkdata_6761C0[4100];
 extern char szPlayerDescript[128];
@@ -69,3 +70,5 @@ void __fastcall multi_player_joins(int pnum, TCmdPlrInfoHdr *cmd, int a3);
 
 extern int multi_inf; // weak
 extern event_type event_types[3];
+
+#endif /* __MULTI_H__ */

--- a/Source/nthread.cpp
+++ b/Source/nthread.cpp
@@ -25,7 +25,6 @@ int nthread_inf = 0x7F800000; // weak
 /* rdata */
 static HANDLE sghThread = (HANDLE)0xFFFFFFFF; // idb
 
-//----- (00440DB3) --------------------------------------------------------
 struct nthread_cpp_init_1
 {
 	nthread_cpp_init_1()
@@ -36,7 +35,6 @@ struct nthread_cpp_init_1
 // 47F164: using guessed type int nthread_inf;
 // 679700: using guessed type int nthread_cpp_init_value;
 
-//----- (00440DBE) --------------------------------------------------------
 struct nthread_cpp_init_2
 {
 	nthread_cpp_init_2()
@@ -46,25 +44,21 @@ struct nthread_cpp_init_2
 	}
 } _nthread_cpp_init_2;
 
-//----- (00440DC8) --------------------------------------------------------
 void __cdecl nthread_init_mutex()
 {
 	InitializeCriticalSection(&sgMemCrit);
 }
 
-//----- (00440DD4) --------------------------------------------------------
 void __cdecl nthread_cleanup_mutex_atexit()
 {
 	atexit(nthread_cleanup_mutex);
 }
 
-//----- (00440DE0) --------------------------------------------------------
 void __cdecl nthread_cleanup_mutex()
 {
 	DeleteCriticalSection(&sgMemCrit);
 }
 
-//----- (00440DEC) --------------------------------------------------------
 void __fastcall nthread_terminate_game(char *pszFcn)
 {
 	char *v1; // esi
@@ -88,7 +82,6 @@ void __fastcall nthread_terminate_game(char *pszFcn)
 }
 // 67862D: using guessed type char gbGameDestroyed;
 
-//----- (00440E28) --------------------------------------------------------
 int __fastcall nthread_send_and_recv_turn(int cur_turn, int turn_delta)
 {
 	int v2; // ebx
@@ -130,7 +123,6 @@ int __fastcall nthread_send_and_recv_turn(int cur_turn, int turn_delta)
 // 679738: using guessed type int gdwTurnsInTransit;
 // 679754: using guessed type int dword_679754;
 
-//----- (00440EAA) --------------------------------------------------------
 int __fastcall nthread_recv_turns(int *pfSendAsync)
 {
 	int *v1; // esi
@@ -174,14 +166,12 @@ LABEL_11:
 // 679759: using guessed type char sgbPacketCountdown;
 // 679764: using guessed type int dword_679764;
 
-//----- (00440F56) --------------------------------------------------------
 void __cdecl nthread_set_turn_upper_bit()
 {
 	dword_679754 = 0x80000000;
 }
 // 679754: using guessed type int dword_679754;
 
-//----- (00440F61) --------------------------------------------------------
 void __fastcall nthread_start(bool set_turn_upper_bit)
 {
 	BOOL v1; // esi
@@ -262,7 +252,6 @@ void __fastcall nthread_start(bool set_turn_upper_bit)
 // 679760: using guessed type int gdwNormalMsgSize;
 // 679764: using guessed type int dword_679764;
 
-//----- (004410CF) --------------------------------------------------------
 unsigned int __stdcall nthread_handler(void *a1)
 {
 	signed int v1; // esi
@@ -293,7 +282,6 @@ unsigned int __stdcall nthread_handler(void *a1)
 // 679734: using guessed type char byte_679734;
 // 679764: using guessed type int dword_679764;
 
-//----- (00441145) --------------------------------------------------------
 void __cdecl nthread_cleanup()
 {
 	char *v0; // eax
@@ -321,7 +309,6 @@ void __cdecl nthread_cleanup()
 // 67975C: using guessed type int gdwLargestMsgSize;
 // 679760: using guessed type int gdwNormalMsgSize;
 
-//----- (004411C4) --------------------------------------------------------
 void __fastcall nthread_ignore_mutex(bool bStart)
 {
 	bool v1; // bl
@@ -338,7 +325,6 @@ void __fastcall nthread_ignore_mutex(bool bStart)
 }
 // 67975A: using guessed type char sgbThreadIsRunning;
 
-//----- (004411EF) --------------------------------------------------------
 bool __cdecl nthread_has_500ms_passed()
 {
 	DWORD v0; // eax

--- a/Source/nthread.h
+++ b/Source/nthread.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __NTHREAD_H__
+#define __NTHREAD_H__
 
-//nthread
 extern int nthread_cpp_init_value; // weak
 extern char byte_679704; // weak
 extern int gdwMsgLenTbl[4];
@@ -36,3 +37,5 @@ bool __cdecl nthread_has_500ms_passed();
 /* data */
 
 extern int nthread_inf; // weak
+
+#endif /* __NTHREAD_H__ */

--- a/Source/objects.cpp
+++ b/Source/objects.cpp
@@ -360,7 +360,6 @@ int StoryText[3][3] =
   { QUEST_BOOK31, QUEST_BOOK32, QUEST_BOOK33 }
 };
 
-//----- (0044121D) --------------------------------------------------------
 void __cdecl InitObjectGFX()
 {
 	ObjDataStruct *v0; // eax
@@ -425,7 +424,6 @@ void __cdecl InitObjectGFX()
 // 67D7C4: using guessed type int numobjfiles;
 // 44121D: using guessed type char fileload[56];
 
-//----- (00441317) --------------------------------------------------------
 void __cdecl FreeObjectGFX()
 {
 	int i; // esi
@@ -441,7 +439,6 @@ void __cdecl FreeObjectGFX()
 }
 // 67D7C4: using guessed type int numobjfiles;
 
-//----- (00441345) --------------------------------------------------------
 bool __fastcall RndLocOk(int xp, int yp)
 {
 	int v2; // ecx
@@ -462,7 +459,6 @@ bool __fastcall RndLocOk(int xp, int yp)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (004413A0) --------------------------------------------------------
 void __fastcall InitRndLocObj(int min, int max, int objtype)
 {
 	int numobjs; // ebx
@@ -513,7 +509,6 @@ void __fastcall InitRndLocObj(int min, int max, int objtype)
 	}
 }
 
-//----- (00441477) --------------------------------------------------------
 void __fastcall InitRndLocBigObj(int min, int max, int objtype)
 {
 	int xp; // edi
@@ -573,7 +568,6 @@ void __fastcall InitRndLocBigObj(int min, int max, int objtype)
 	}
 }
 
-//----- (00441584) --------------------------------------------------------
 void __fastcall InitRndLocObj5x5(int min, int max, int objtype)
 {
 	int v3; // esi
@@ -636,7 +630,6 @@ void __fastcall InitRndLocObj5x5(int min, int max, int objtype)
 	}
 }
 
-//----- (0044163B) --------------------------------------------------------
 void __cdecl ClrAllObjects()
 {
 	int *v0; // eax
@@ -677,7 +670,6 @@ void __cdecl ClrAllObjects()
 // 67976C: using guessed type int trapdir;
 // 67D7C8: using guessed type int hero_cpp_init_value;
 
-//----- (004416A8) --------------------------------------------------------
 void __cdecl AddTortures()
 {
 	int v0; // esi
@@ -715,7 +707,6 @@ void __cdecl AddTortures()
 	while ( v0 < 112 );
 }
 
-//----- (0044179F) --------------------------------------------------------
 void __cdecl AddCandles()
 {
 	int v0; // esi
@@ -732,7 +723,6 @@ void __cdecl AddCandles()
 	AddObject(OBJ_STORYCANDLE, v0 + 2, v1);
 }
 
-//----- (004417E8) --------------------------------------------------------
 void __fastcall AddBookLever(int lx1, int ly1, int lx2, int ly2, int x1, int y1, int x2, int y2, int msg)
 {
 	int v9; // esi
@@ -793,7 +783,6 @@ void __fastcall AddBookLever(int lx1, int ly1, int lx2, int ly2, int x1, int y1,
 	object[v16]._oVar6 = object[v16]._oAnimFrame + 1;
 }
 
-//----- (00441904) --------------------------------------------------------
 void __cdecl InitRndBarrels()
 {
 	int v0; // ebp
@@ -854,7 +843,6 @@ void __cdecl InitRndBarrels()
 	}
 }
 
-//----- (00441A00) --------------------------------------------------------
 void __fastcall AddL1Objs(int x1, int y1, int x2, int y2)
 {
 	int v4; // ebx
@@ -887,7 +875,6 @@ void __fastcall AddL1Objs(int x1, int y1, int x2, int y2)
 	}
 }
 
-//----- (00441A98) --------------------------------------------------------
 void __fastcall AddL2Objs(int x1, int y1, int x2, int y2)
 {
 	int v4; // ebx
@@ -918,7 +905,6 @@ void __fastcall AddL2Objs(int x1, int y1, int x2, int y2)
 	}
 }
 
-//----- (00441B16) --------------------------------------------------------
 void __fastcall AddL3Objs(int x1, int y1, int x2, int y2)
 {
 	int v4; // edi
@@ -949,13 +935,11 @@ void __fastcall AddL3Objs(int x1, int y1, int x2, int y2)
 	}
 }
 
-//----- (00441B8A) --------------------------------------------------------
 bool __fastcall WallTrapLocOk(int xp, int yp)
 {
 	return (~dFlags[xp][yp] & 8u) >> 3;
 }
 
-//----- (00441BA0) --------------------------------------------------------
 void __cdecl AddL2Torches()
 {
 	int v0; // esi
@@ -1019,7 +1003,6 @@ LABEL_18:
 	while ( (signed int)v7 < (signed int)dPiece[1] );
 }
 
-//----- (00441C8C) --------------------------------------------------------
 bool __fastcall TorchLocOK(int xp, int yp)
 {
 	int v2; // ecx
@@ -1033,7 +1016,6 @@ bool __fastcall TorchLocOK(int xp, int yp)
 	return result;
 }
 
-//----- (00441CB3) --------------------------------------------------------
 void __cdecl AddObjTraps()
 {
 	int v0; // esi
@@ -1128,7 +1110,6 @@ LABEL_28:
 	while ( (signed int)v12 < (signed int)dPiece );
 }
 
-//----- (00441E58) --------------------------------------------------------
 void __cdecl AddChestTraps()
 {
 	signed int v0; // ebp
@@ -1172,7 +1153,6 @@ void __cdecl AddChestTraps()
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (00441EE4) --------------------------------------------------------
 void __fastcall LoadMapObjects(unsigned char *pMap, int startx, int starty, int x1, int y1, int w, int h, int leveridx)
 {
 	unsigned char *v8; // ebx
@@ -1229,7 +1209,6 @@ void __fastcall LoadMapObjects(unsigned char *pMap, int startx, int starty, int 
 }
 // 67D7C0: using guessed type int InitObjFlag;
 
-//----- (00441FAF) --------------------------------------------------------
 void __fastcall LoadMapObjs(unsigned char *pMap, int startx, int starty)
 {
 	unsigned char *v3; // esi
@@ -1276,7 +1255,6 @@ void __fastcall LoadMapObjs(unsigned char *pMap, int startx, int starty)
 }
 // 67D7C0: using guessed type int InitObjFlag;
 
-//----- (00442036) --------------------------------------------------------
 void __cdecl AddDiabObjs()
 {
 	unsigned char *v0; // esi
@@ -1296,7 +1274,6 @@ void __cdecl AddDiabObjs()
 // 5289C4: using guessed type int diabquad1x;
 // 5289C8: using guessed type int diabquad1y;
 
-//----- (004420F2) --------------------------------------------------------
 void __cdecl AddStoryBooks()
 {
 	int v0; // esi
@@ -1344,7 +1321,6 @@ void __cdecl AddStoryBooks()
 	AddObject(OBJ_STORYCANDLE, v4, v1 + 1);
 }
 
-//----- (004421CA) --------------------------------------------------------
 void __fastcall AddHookedBodies(int freq)
 {
 	int v1; // ebx
@@ -1436,7 +1412,6 @@ LABEL_22:
 	while ( v1 < 96 );
 }
 
-//----- (0044229F) --------------------------------------------------------
 void __cdecl AddL4Goodies()
 {
 	AddHookedBodies(6);
@@ -1451,7 +1426,6 @@ void __cdecl AddL4Goodies()
 	InitRndLocObj(1, 3, OBJ_CAULDRON);
 }
 
-//----- (00442316) --------------------------------------------------------
 void __cdecl AddLazStand()
 {
 	int v0; // edi
@@ -1505,7 +1479,6 @@ void __cdecl AddLazStand()
 	AddObject(OBJ_STORYCANDLE, v4, v1 + 1);
 }
 
-//----- (00442418) --------------------------------------------------------
 void __fastcall InitObjects(int a1)
 {
 	//int v1; // eax
@@ -1684,7 +1657,6 @@ void __fastcall InitObjects(int a1)
 // 679660: using guessed type char gbMaxPlayers;
 // 67D7C0: using guessed type int InitObjFlag;
 
-//----- (004427C5) --------------------------------------------------------
 void __fastcall SetMapObjects(char *pMap, int startx, int starty)
 {
 	char *v3; // esi
@@ -1794,7 +1766,6 @@ void __fastcall SetMapObjects(char *pMap, int startx, int starty)
 // 67D7C4: using guessed type int numobjfiles;
 // 4427C5: using guessed type int var_10C[56];
 
-//----- (0044292B) --------------------------------------------------------
 void __fastcall DeleteObject(int oi, int i)
 {
 	int v2; // eax
@@ -1811,7 +1782,6 @@ void __fastcall DeleteObject(int oi, int i)
 		objectactive[i] = objectactive[v2];
 }
 
-//----- (0044297B) --------------------------------------------------------
 void __fastcall SetupObject(int i, int x, int y, int ot)
 {
 	int v4; // esi
@@ -1873,7 +1843,6 @@ void __fastcall SetupObject(int i, int x, int y, int ot)
 	object[v4]._oDoorFlag = 0;
 }
 
-//----- (00442A9D) --------------------------------------------------------
 void __fastcall SetObjMapRange(int i, int x1, int y1, int x2, int y2, int v)
 {
 	object[i]._oVar1 = x1;
@@ -1883,13 +1852,11 @@ void __fastcall SetObjMapRange(int i, int x1, int y1, int x2, int y2, int v)
 	object[i]._oVar8 = v;
 }
 
-//----- (00442AD1) --------------------------------------------------------
 void __fastcall SetBookMsg(int i, int msg)
 {
 	object[i]._oVar7 = msg;
 }
 
-//----- (00442ADB) --------------------------------------------------------
 void __fastcall AddL1Door(int i, int x, int y, int ot)
 {
 	int v4; // ecx
@@ -1919,7 +1886,6 @@ void __fastcall AddL1Door(int i, int x, int y, int ot)
 	object[v4]._oVar2 = v8;
 }
 
-//----- (00442B2C) --------------------------------------------------------
 void __fastcall AddSCambBook(int i)
 {
 	object[i]._oVar1 = setpc_x;
@@ -1931,7 +1897,6 @@ void __fastcall AddSCambBook(int i)
 // 5CF330: using guessed type int setpc_h;
 // 5CF334: using guessed type int setpc_w;
 
-//----- (00442B75) --------------------------------------------------------
 void __fastcall AddChest(int i, int t)
 {
 	int v2; // edi
@@ -1991,7 +1956,6 @@ LABEL_22:
 }
 // 5CF31D: using guessed type char setlevel;
 
-//----- (00442C27) --------------------------------------------------------
 void __fastcall AddL2Door(int i, int x, int y, int ot)
 {
 	int v4; // esi
@@ -2005,7 +1969,6 @@ void __fastcall AddL2Door(int i, int x, int y, int ot)
 	object[v4]._oVar4 = 0;
 }
 
-//----- (00442C62) --------------------------------------------------------
 void __fastcall AddL3Door(int i, int x, int y, int ot)
 {
 	int v4; // esi
@@ -2019,7 +1982,6 @@ void __fastcall AddL3Door(int i, int x, int y, int ot)
 	object[v4]._oVar4 = 0;
 }
 
-//----- (00442C9D) --------------------------------------------------------
 void __fastcall AddSarc(int i)
 {
 	int v1; // esi
@@ -2043,7 +2005,6 @@ void __fastcall AddSarc(int i)
 		object[v1]._oVar2 = PreSpawnSkeleton();
 }
 
-//----- (00442CEE) --------------------------------------------------------
 void __fastcall AddFlameTrap(int i)
 {
 	object[i]._oVar1 = trapid;
@@ -2054,7 +2015,6 @@ void __fastcall AddFlameTrap(int i)
 // 679768: using guessed type int trapid;
 // 67976C: using guessed type int trapdir;
 
-//----- (00442D16) --------------------------------------------------------
 void __fastcall AddFlameLvr(int i)
 {
 	object[i]._oVar1 = trapid;
@@ -2062,7 +2022,6 @@ void __fastcall AddFlameLvr(int i)
 }
 // 679768: using guessed type int trapid;
 
-//----- (00442D2F) --------------------------------------------------------
 void __fastcall AddTrap(int i)
 {
 	int mt; // eax
@@ -2077,7 +2036,6 @@ void __fastcall AddTrap(int i)
 	object[i]._oVar4 = 0;
 }
 
-//----- (00442D8A) --------------------------------------------------------
 void __fastcall AddObjLight(int i, int r)
 {
 	if ( InitObjFlag )
@@ -2092,7 +2050,6 @@ void __fastcall AddObjLight(int i, int r)
 }
 // 67D7C0: using guessed type int InitObjFlag;
 
-//----- (00442DC1) --------------------------------------------------------
 void __fastcall AddBarrel(int i)
 {
 	int v1; // esi
@@ -2120,7 +2077,6 @@ void __fastcall AddBarrel(int i)
 		object[v1]._oVar4 = PreSpawnSkeleton();
 }
 
-//----- (00442E0F) --------------------------------------------------------
 void __fastcall AddShrine(int i)
 {
 	int v1; // esi
@@ -2173,7 +2129,6 @@ void __fastcall AddShrine(int i)
 // 679660: using guessed type char gbMaxPlayers;
 // 442E0F: using guessed type int var_68[26];
 
-//----- (00442EB2) --------------------------------------------------------
 void __fastcall AddBookcase(int i)
 {
 	int v1; // esi
@@ -2183,7 +2138,6 @@ void __fastcall AddBookcase(int i)
 	object[v1]._oPreFlag = 1;
 }
 
-//----- (00442ECF) --------------------------------------------------------
 void __fastcall AddPurifyingFountain(int i)
 {
 	char *v1; // eax
@@ -2195,7 +2149,6 @@ void __fastcall AddPurifyingFountain(int i)
 	object[i]._oRndSeed = GetRndSeed();
 }
 
-//----- (00442F08) --------------------------------------------------------
 void __fastcall AddArmorStand(int i)
 {
 	int v1; // eax
@@ -2210,7 +2163,6 @@ void __fastcall AddArmorStand(int i)
 }
 // 6AAA3C: using guessed type int armorFlag;
 
-//----- (00442F3A) --------------------------------------------------------
 void __fastcall AddDecap(int i)
 {
 	int v1; // esi
@@ -2227,7 +2179,6 @@ void __fastcall AddDecap(int i)
 	object[v1]._oAnimFrame = v4 + 1;
 }
 
-//----- (00442F68) --------------------------------------------------------
 void __fastcall AddVilebook(int i)
 {
 	if ( setlevel )
@@ -2239,7 +2190,6 @@ void __fastcall AddVilebook(int i)
 // 5CCB10: using guessed type char setlvlnum;
 // 5CF31D: using guessed type char setlevel;
 
-//----- (00442F88) --------------------------------------------------------
 void __fastcall AddMagicCircle(int i)
 {
 	int v1; // esi
@@ -2253,13 +2203,11 @@ void __fastcall AddMagicCircle(int i)
 	object[v1]._oVar5 = 1;
 }
 
-//----- (00442FB1) --------------------------------------------------------
 void __fastcall AddBookstand(int i)
 {
 	object[i]._oRndSeed = GetRndSeed();
 }
 
-//----- (00442FC4) --------------------------------------------------------
 void __fastcall AddPedistal(int i)
 {
 	int v1; // ecx
@@ -2283,7 +2231,6 @@ void __fastcall AddPedistal(int i)
 // 5CF330: using guessed type int setpc_h;
 // 5CF334: using guessed type int setpc_w;
 
-//----- (00442FFC) --------------------------------------------------------
 void __fastcall AddStoryBook(int i)
 {
 	int bookframe; // eax
@@ -2305,7 +2252,6 @@ void __fastcall AddStoryBook(int i)
 	object[i]._oVar4 = v7 + 1;
 }
 
-//----- (0044308E) --------------------------------------------------------
 void __fastcall AddWeaponRack(int i)
 {
 	if ( !weaponFlag )
@@ -2317,7 +2263,6 @@ void __fastcall AddWeaponRack(int i)
 }
 // 6AAA50: using guessed type int weaponFlag;
 
-//----- (004430C0) --------------------------------------------------------
 void __fastcall AddTorturedBody(int i)
 {
 	object[i]._oRndSeed = GetRndSeed();
@@ -2325,7 +2270,6 @@ void __fastcall AddTorturedBody(int i)
 	object[i]._oAnimFrame = random(0, 4) + 1;
 }
 
-//----- (004430EE) --------------------------------------------------------
 void __fastcall GetRndObjLoc(int randarea, int *xx, int *yy)
 {
 	int *v3; // ebx
@@ -2382,7 +2326,6 @@ LABEL_3:
 	}
 }
 
-//----- (00443178) --------------------------------------------------------
 void __cdecl AddMushPatch()
 {
 	int i; // bl
@@ -2400,7 +2343,6 @@ void __cdecl AddMushPatch()
 	}
 }
 
-//----- (004431D4) --------------------------------------------------------
 void __cdecl AddSlainHero()
 {
 	int x; // [esp+0h] [ebp-8h]
@@ -2410,7 +2352,6 @@ void __cdecl AddSlainHero()
 	AddObject(OBJ_SLAINHERO, x + 2, y + 2);
 }
 
-//----- (004431FF) --------------------------------------------------------
 void __fastcall AddObject(int ot, int ox, int oy)
 {
 	int v3; // ebp
@@ -2563,7 +2504,6 @@ LABEL_31:
 	}
 }
 
-//----- (004434CB) --------------------------------------------------------
 void __fastcall Obj_Light(int i, int lr)
 {
 	int v2; // esi
@@ -2622,7 +2562,6 @@ LABEL_15:
 }
 // 646A28: using guessed type int lightflag;
 
-//----- (004435B5) --------------------------------------------------------
 void __fastcall Obj_Circle(int i)
 {
 	int v1; // ecx
@@ -2685,7 +2624,6 @@ void __fastcall Obj_Circle(int i)
 }
 // 525748: using guessed type char sgbMouseDown;
 
-//----- (00443727) --------------------------------------------------------
 void __fastcall Obj_StopAnim(int i)
 {
 	if ( object[i]._oAnimFrame == object[i]._oAnimLen )
@@ -2695,7 +2633,6 @@ void __fastcall Obj_StopAnim(int i)
 	}
 }
 
-//----- (0044374A) --------------------------------------------------------
 void __fastcall Obj_Door(int i)
 {
 	int dy; // edx
@@ -2720,14 +2657,12 @@ void __fastcall Obj_Door(int i)
 	}
 }
 
-//----- (004437CD) --------------------------------------------------------
 void __fastcall Obj_Sarc(int i)
 {
 	if ( object[i]._oAnimFrame == object[i]._oAnimLen )
 		object[i]._oAnimFlag = 0;
 }
 
-//----- (004437E6) --------------------------------------------------------
 void __fastcall ActivateTrapLine(int ttype, int tid)
 {
 	int v2; // edi
@@ -2754,7 +2689,6 @@ void __fastcall ActivateTrapLine(int ttype, int tid)
 	}
 }
 
-//----- (00443855) --------------------------------------------------------
 void __fastcall Obj_FlameTrap(int i)
 {
 	int v1; // ecx
@@ -2845,7 +2779,6 @@ LABEL_24:
 		ActivateTrapLine(object[v1]._otype, object[v1]._oVar1);
 }
 
-//----- (00443966) --------------------------------------------------------
 void __fastcall Obj_Trap(int i)
 {
 	int edi1; // edi
@@ -2942,7 +2875,6 @@ LABEL_10:
 }
 // 676190: using guessed type int deltaload;
 
-//----- (00443AD5) --------------------------------------------------------
 void __fastcall Obj_BCrossDamage(int i)
 {
 	int v1; // esi
@@ -3003,7 +2935,6 @@ LABEL_15:
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (00443BD2) --------------------------------------------------------
 void __cdecl ProcessObjects()
 {
 	int v0; // ebx
@@ -3144,7 +3075,6 @@ LABEL_45:
 	}
 }
 
-//----- (00443D69) --------------------------------------------------------
 void __fastcall ObjSetMicro(int dx, int dy, int pn)
 {
 	int v3; // esi
@@ -3182,7 +3112,6 @@ void __fastcall ObjSetMicro(int dx, int dy, int pn)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (00443DEA) --------------------------------------------------------
 void __fastcall objects_set_door_piece(int x, int y)
 {
 	int v2; // edi
@@ -3200,7 +3129,6 @@ void __fastcall objects_set_door_piece(int x, int y)
 	dpiece_defs_map_1[0][0][16 * gendung_get_dpiece_num_from_coord(v3, v2) + 1] = v6;
 }
 
-//----- (00443E62) --------------------------------------------------------
 void __fastcall ObjSetMini(int x, int y, int v)
 {
 	unsigned short *v3; // esi
@@ -3233,7 +3161,6 @@ void __fastcall ObjSetMini(int x, int y, int v)
 	ObjSetMicro(v10 + 1, v11, v9);
 }
 
-//----- (00443EDA) --------------------------------------------------------
 void __fastcall ObjL1Special(int x1, int y1, int x2, int y2)
 {
 	int i; // ebx
@@ -3292,7 +3219,6 @@ void __fastcall ObjL1Special(int x1, int y1, int x2, int y2)
 	}
 }
 
-//----- (00443FC6) --------------------------------------------------------
 void __fastcall ObjL2Special(int x1, int y1, int x2, int y2)
 {
 	int v4; // edi
@@ -3379,7 +3305,6 @@ void __fastcall ObjL2Special(int x1, int y1, int x2, int y2)
 	}
 }
 
-//----- (004440C2) --------------------------------------------------------
 void __fastcall DoorSet(int oi, int dx, int dy)
 {
 	int v3; // esi
@@ -3432,7 +3357,6 @@ LABEL_10:
 	}
 }
 
-//----- (00444246) --------------------------------------------------------
 void __cdecl RedoPlayerVision()
 {
 	int *v0; // esi
@@ -3450,7 +3374,6 @@ void __cdecl RedoPlayerVision()
 	while ( (signed int)v0 < (signed int)&plr[4].plrlevel );
 }
 
-//----- (0044427B) --------------------------------------------------------
 void __fastcall OperateL1RDoor(int pnum, int oi, unsigned char sendflag)
 {
 	int v3; // esi
@@ -3523,7 +3446,6 @@ void __fastcall OperateL1RDoor(int pnum, int oi, unsigned char sendflag)
 }
 // 676190: using guessed type int deltaload;
 
-//----- (0044443C) --------------------------------------------------------
 void __fastcall OperateL1LDoor(int pnum, int oi, unsigned char sendflag)
 {
 	int v3; // esi
@@ -3599,7 +3521,6 @@ void __fastcall OperateL1LDoor(int pnum, int oi, unsigned char sendflag)
 }
 // 676190: using guessed type int deltaload;
 
-//----- (00444613) --------------------------------------------------------
 void __fastcall OperateL2RDoor(int pnum, int oi, unsigned char sendflag)
 {
 	int v3; // esi
@@ -3654,7 +3575,6 @@ void __fastcall OperateL2RDoor(int pnum, int oi, unsigned char sendflag)
 }
 // 676190: using guessed type int deltaload;
 
-//----- (00444775) --------------------------------------------------------
 void __fastcall OperateL2LDoor(int pnum, int oi, unsigned char sendflag)
 {
 	int v3; // esi
@@ -3709,7 +3629,6 @@ void __fastcall OperateL2LDoor(int pnum, int oi, unsigned char sendflag)
 }
 // 676190: using guessed type int deltaload;
 
-//----- (004448D7) --------------------------------------------------------
 void __fastcall OperateL3RDoor(int pnum, int oi, unsigned char sendflag)
 {
 	int v3; // esi
@@ -3764,7 +3683,6 @@ void __fastcall OperateL3RDoor(int pnum, int oi, unsigned char sendflag)
 }
 // 676190: using guessed type int deltaload;
 
-//----- (00444A3C) --------------------------------------------------------
 void __fastcall OperateL3LDoor(int pnum, int oi, unsigned char sendflag)
 {
 	int v3; // esi
@@ -3819,7 +3737,6 @@ void __fastcall OperateL3LDoor(int pnum, int oi, unsigned char sendflag)
 }
 // 676190: using guessed type int deltaload;
 
-//----- (00444BA1) --------------------------------------------------------
 void __fastcall MonstCheckDoors(int m)
 {
 	int v1; // ecx
@@ -3964,7 +3881,6 @@ LABEL_17:
 	}
 }
 
-//----- (00444DC3) --------------------------------------------------------
 void __fastcall ObjChangeMap(int x1, int y1, int x2, int y2)
 {
 	int v4; // ebx
@@ -4013,7 +3929,6 @@ void __fastcall ObjChangeMap(int x1, int y1, int x2, int y2)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (00444E9E) --------------------------------------------------------
 void __fastcall ObjChangeMapResync(int x1, int y1, int x2, int y2)
 {
 	int v4; // edi
@@ -4052,7 +3967,6 @@ void __fastcall ObjChangeMapResync(int x1, int y1, int x2, int y2)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (00444F4F) --------------------------------------------------------
 void __fastcall OperateL1Door(int pnum, int i, unsigned char sendflag)
 {
 	int v3; // ebx
@@ -4096,7 +4010,6 @@ LABEL_6:
 		OperateL1RDoor(pnuma, v3, sendflag);
 }
 
-//----- (00444FDE) --------------------------------------------------------
 void __fastcall OperateLever(int pnum, int i)
 {
 	int v2; // esi
@@ -4144,7 +4057,6 @@ LABEL_17:
 }
 // 676190: using guessed type int deltaload;
 
-//----- (004450AC) --------------------------------------------------------
 void __fastcall OperateBook(int pnum, int i)
 {
 	int esi1; // esi
@@ -4260,7 +4172,6 @@ LABEL_17:
 // 5CF31D: using guessed type char setlevel;
 // 676190: using guessed type int deltaload;
 
-//----- (004452D1) --------------------------------------------------------
 void __fastcall OperateBookLever(int pnum, int i)
 {
 	int v2; // esi
@@ -4334,7 +4245,6 @@ void __fastcall OperateBookLever(int pnum, int i)
 // 5A5590: using guessed type char TransVal;
 // 646D00: using guessed type char qtextflag;
 
-//----- (00445483) --------------------------------------------------------
 void __fastcall OperateSChambBk(int pnum, int i)
 {
 	int v2; // esi
@@ -4382,7 +4292,6 @@ void __fastcall OperateSChambBk(int pnum, int i)
 }
 // 646D00: using guessed type char qtextflag;
 
-//----- (0044555A) --------------------------------------------------------
 void __fastcall OperateChest(int pnum, int i, unsigned char sendmsg)
 {
 	int v3; // esi
@@ -4477,7 +4386,6 @@ LABEL_26:
 // 5CF31D: using guessed type char setlevel;
 // 676190: using guessed type int deltaload;
 
-//----- (004456E3) --------------------------------------------------------
 void __fastcall OperateMushPatch(int pnum, int i)
 {
 	int v2; // esi
@@ -4533,7 +4441,6 @@ void __fastcall OperateMushPatch(int pnum, int i)
 }
 // 676190: using guessed type int deltaload;
 
-//----- (004457B8) --------------------------------------------------------
 void __fastcall OperateInnSignChest(int pnum, int i)
 {
 	char v2; // al
@@ -4581,7 +4488,6 @@ LABEL_8:
 }
 // 676190: using guessed type int deltaload;
 
-//----- (00445880) --------------------------------------------------------
 void __fastcall OperateSlainHero(int pnum, int i, unsigned char sendmsg)
 {
 	unsigned short v3; // di
@@ -4631,7 +4537,6 @@ LABEL_10:
 }
 // 676190: using guessed type int deltaload;
 
-//----- (00445954) --------------------------------------------------------
 void __fastcall OperateTrapLvr(int i)
 {
 	int v1; // ecx
@@ -4684,7 +4589,6 @@ void __fastcall OperateTrapLvr(int i)
 	}
 }
 
-//----- (00445A0B) --------------------------------------------------------
 void __fastcall OperateSarc(int pnum, int i, unsigned char sendmsg)
 {
 	unsigned short v3; // bp
@@ -4723,7 +4627,6 @@ void __fastcall OperateSarc(int pnum, int i, unsigned char sendmsg)
 }
 // 676190: using guessed type int deltaload;
 
-//----- (00445ADC) --------------------------------------------------------
 void __fastcall OperateL2Door(int pnum, int i, unsigned char sendflag)
 {
 	int v3; // ebx
@@ -4767,7 +4670,6 @@ LABEL_6:
 		OperateL2RDoor(pnuma, v3, sendflag);
 }
 
-//----- (00445B6C) --------------------------------------------------------
 void __fastcall OperateL3Door(int pnum, int i, unsigned char sendflag)
 {
 	int v3; // ebx
@@ -4811,7 +4713,6 @@ LABEL_6:
 		OperateL3LDoor(pnuma, v3, sendflag);
 }
 
-//----- (00445BFC) --------------------------------------------------------
 void __fastcall OperatePedistal(int pnum, int i)
 {
 	int v2; // esi
@@ -4857,7 +4758,6 @@ void __fastcall OperatePedistal(int pnum, int i)
 // 5CF334: using guessed type int setpc_w;
 // 676190: using guessed type int deltaload;
 
-//----- (00445D5F) --------------------------------------------------------
 void __fastcall TryDisarm(int pnum, int i)
 {
 	int v2; // edi
@@ -4907,7 +4807,6 @@ void __fastcall TryDisarm(int pnum, int i)
 	}
 }
 
-//----- (00445E33) --------------------------------------------------------
 int __fastcall ItemMiscIdIdx(int imiscid)
 {
 	int result; // eax
@@ -4919,7 +4818,6 @@ int __fastcall ItemMiscIdIdx(int imiscid)
 	return result;
 }
 
-//----- (00445E4B) --------------------------------------------------------
 void __fastcall OperateShrine(int pnum, int i, int sType)
 {
 	int v3; // esi
@@ -5954,7 +5852,6 @@ LABEL_280:
 // 5BB1ED: using guessed type char leveltype;
 // 676190: using guessed type int deltaload;
 
-//----- (00446E6A) --------------------------------------------------------
 void __fastcall OperateSkelBook(int pnum, int i, unsigned char sendmsg)
 {
 	unsigned short v3; // di
@@ -5994,7 +5891,6 @@ void __fastcall OperateSkelBook(int pnum, int i, unsigned char sendmsg)
 }
 // 676190: using guessed type int deltaload;
 
-//----- (00446F08) --------------------------------------------------------
 void __fastcall OperateBookCase(int pnum, int i, unsigned char sendmsg)
 {
 	unsigned short v3; // di
@@ -6035,7 +5931,6 @@ void __fastcall OperateBookCase(int pnum, int i, unsigned char sendmsg)
 }
 // 676190: using guessed type int deltaload;
 
-//----- (00446FE8) --------------------------------------------------------
 void __fastcall OperateDecap(int pnum, int i, unsigned char sendmsg)
 {
 	unsigned short v3; // bp
@@ -6063,7 +5958,6 @@ void __fastcall OperateDecap(int pnum, int i, unsigned char sendmsg)
 }
 // 676190: using guessed type int deltaload;
 
-//----- (00447046) --------------------------------------------------------
 void __fastcall OperateArmorStand(int pnum, int i, unsigned char sendmsg)
 {
 	unsigned short v3; // di
@@ -6122,7 +6016,6 @@ LABEL_15:
 }
 // 676190: using guessed type int deltaload;
 
-//----- (0044710C) --------------------------------------------------------
 int __fastcall FindValidShrine(int i)
 {
 	bool done; // esi
@@ -6149,7 +6042,6 @@ int __fastcall FindValidShrine(int i)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0044715F) --------------------------------------------------------
 void __fastcall OperateGoatShrine(int pnum, int i, int sType)
 {
 	int v3; // edi
@@ -6167,7 +6059,6 @@ void __fastcall OperateGoatShrine(int pnum, int i, int sType)
 }
 // 52571C: using guessed type int drawpanflag;
 
-//----- (004471AA) --------------------------------------------------------
 void __fastcall OperateCauldron(int pnum, int i, int sType)
 {
 	int v3; // edi
@@ -6186,7 +6077,6 @@ void __fastcall OperateCauldron(int pnum, int i, int sType)
 }
 // 52571C: using guessed type int drawpanflag;
 
-//----- (004471FC) --------------------------------------------------------
 bool __fastcall OperateFountains(int pnum, int i)
 {
 	unsigned short v2; // bx
@@ -6366,7 +6256,6 @@ LABEL_38:
 // 5BB1ED: using guessed type char leveltype;
 // 676190: using guessed type int deltaload;
 
-//----- (004474AD) --------------------------------------------------------
 void __fastcall OperateWeaponRack(int pnum, int i, unsigned char sendmsg)
 {
 	unsigned short v3; // di
@@ -6436,7 +6325,6 @@ LABEL_12:
 // 5BB1ED: using guessed type char leveltype;
 // 676190: using guessed type int deltaload;
 
-//----- (00447558) --------------------------------------------------------
 void __fastcall OperateStoryBook(int pnum, int i)
 {
 	unsigned short v2; // di
@@ -6459,7 +6347,6 @@ void __fastcall OperateStoryBook(int pnum, int i)
 // 646D00: using guessed type char qtextflag;
 // 676190: using guessed type int deltaload;
 
-//----- (004475BB) --------------------------------------------------------
 void __fastcall OperateLazStand(int pnum, int i)
 {
 	int v2; // eax
@@ -6480,7 +6367,6 @@ void __fastcall OperateLazStand(int pnum, int i)
 // 646D00: using guessed type char qtextflag;
 // 676190: using guessed type int deltaload;
 
-//----- (00447620) --------------------------------------------------------
 void __fastcall OperateObject(int pnum, int i, unsigned char TeleFlag)
 {
 	int v3; // esi
@@ -6625,7 +6511,6 @@ void __fastcall OperateObject(int pnum, int i, unsigned char TeleFlag)
 	}
 }
 
-//----- (00447932) --------------------------------------------------------
 void __fastcall SyncOpL1Door(int pnum, int cmd, int i)
 {
 	signed int v3; // eax
@@ -6653,7 +6538,6 @@ void __fastcall SyncOpL1Door(int pnum, int cmd, int i)
 	}
 }
 
-//----- (004479A3) --------------------------------------------------------
 void __fastcall SyncOpL2Door(int pnum, int cmd, int i)
 {
 	signed int v3; // eax
@@ -6681,7 +6565,6 @@ void __fastcall SyncOpL2Door(int pnum, int cmd, int i)
 	}
 }
 
-//----- (00447A15) --------------------------------------------------------
 void __fastcall SyncOpL3Door(int pnum, int cmd, int i)
 {
 	signed int v3; // eax
@@ -6709,7 +6592,6 @@ void __fastcall SyncOpL3Door(int pnum, int cmd, int i)
 	}
 }
 
-//----- (00447A87) --------------------------------------------------------
 void __fastcall SyncOpObject(int pnum, int cmd, int i)
 {
 	switch ( object[i]._otype )
@@ -6799,7 +6681,6 @@ void __fastcall SyncOpObject(int pnum, int cmd, int i)
 	}
 }
 
-//----- (00447C2D) --------------------------------------------------------
 void __fastcall BreakCrux(int i)
 {
 	int v1; // esi
@@ -6845,7 +6726,6 @@ LABEL_15:
 }
 // 676190: using guessed type int deltaload;
 
-//----- (00447CEF) --------------------------------------------------------
 void __fastcall BreakBarrel(int pnum, int i, int dam, unsigned char forcebreak, int sendmsg)
 {
 	int v5; // esi
@@ -6971,7 +6851,6 @@ void __fastcall BreakBarrel(int pnum, int i, int dam, unsigned char forcebreak, 
 }
 // 676190: using guessed type int deltaload;
 
-//----- (00447F63) --------------------------------------------------------
 void __fastcall BreakObject(int pnum, int oi)
 {
 	int v2; // ebx
@@ -7010,7 +6889,6 @@ void __fastcall BreakObject(int pnum, int oi)
 	}
 }
 
-//----- (00447FEF) --------------------------------------------------------
 void __fastcall SyncBreakObj(int pnum, int oi)
 {
 	int v2; // eax
@@ -7020,7 +6898,6 @@ void __fastcall SyncBreakObj(int pnum, int oi)
 		BreakBarrel(pnum, oi, 0, 1u, 0);
 }
 
-//----- (00448010) --------------------------------------------------------
 void __fastcall SyncL1Doors(int i)
 {
 	int v1; // ebx
@@ -7061,7 +6938,6 @@ void __fastcall SyncL1Doors(int i)
 	}
 }
 
-//----- (004480BB) --------------------------------------------------------
 void __fastcall SyncCrux(int i)
 {
 	signed int v1; // ebx
@@ -7091,7 +6967,6 @@ LABEL_13:
 		ObjChangeMap(object[i]._oVar1, object[i]._oVar2, object[i]._oVar3, object[i]._oVar4);
 }
 
-//----- (00448139) --------------------------------------------------------
 void __fastcall SyncLever(int i)
 {
 	int v1; // ecx
@@ -7101,7 +6976,6 @@ void __fastcall SyncLever(int i)
 		ObjChangeMap(object[v1]._oVar1, object[v1]._oVar2, object[v1]._oVar3, object[v1]._oVar4);
 }
 
-//----- (00448163) --------------------------------------------------------
 void __fastcall SyncQSTLever(int i)
 {
 	int v1; // esi
@@ -7130,7 +7004,6 @@ void __fastcall SyncQSTLever(int i)
 }
 // 5A5590: using guessed type char TransVal;
 
-//----- (004481D2) --------------------------------------------------------
 void __fastcall SyncPedistal(int i)
 {
 	int v1; // esi
@@ -7154,7 +7027,6 @@ void __fastcall SyncPedistal(int i)
 }
 // 5CF334: using guessed type int setpc_w;
 
-//----- (00448298) --------------------------------------------------------
 void __fastcall SyncL2Doors(int i)
 {
 	int v1; // eax
@@ -7202,7 +7074,6 @@ LABEL_18:
 	}
 }
 
-//----- (0044831E) --------------------------------------------------------
 void __fastcall SyncL3Doors(int i)
 {
 	int v1; // eax
@@ -7249,7 +7120,6 @@ LABEL_15:
 	}
 }
 
-//----- (004483B0) --------------------------------------------------------
 void __fastcall SyncObjectAnim(int o)
 {
 	int v1; // edx
@@ -7322,7 +7192,6 @@ LABEL_24:
 	}
 }
 
-//----- (0044845E) --------------------------------------------------------
 void __fastcall GetObjectStr(int i)
 {
 	int v1; // edi

--- a/Source/objects.h
+++ b/Source/objects.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __OBJECTS_H__
+#define __OBJECTS_H__
 
-//objects
 extern int trapid; // weak
 extern int trapdir; // weak
 extern int pObjCels[40];
@@ -158,3 +159,5 @@ extern unsigned char shrinemax[26];
 extern unsigned char shrineavail[26];
 extern char *StoryBookName[9];
 extern int StoryText[3][3];
+
+#endif /* __OBJECTS_H__ */

--- a/Source/pack.cpp
+++ b/Source/pack.cpp
@@ -6,7 +6,6 @@ int pack_cpp_init_value; // weak
 
 int pack_inf = 0x7F800000; // weak
 
-//----- (0044875A) --------------------------------------------------------
 struct pack_cpp_init
 {
 	pack_cpp_init()
@@ -17,7 +16,6 @@ struct pack_cpp_init
 // 47F168: using guessed type int pack_inf;
 // 67D7C8: using guessed type int pack_cpp_init_value;
 
-//----- (00448765) --------------------------------------------------------
 void __fastcall PackPlayer(PkPlayerStruct *pPack, int pnum, bool manashield)
 {
 	PlayerStruct *pPlayer; // edi
@@ -86,7 +84,6 @@ void __fastcall PackPlayer(PkPlayerStruct *pPack, int pnum, bool manashield)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00448953) --------------------------------------------------------
 void __fastcall PackItem(PkItemStruct *id, ItemStruct *is)
 {
 	short v2; // ax
@@ -130,7 +127,6 @@ void __fastcall PackItem(PkItemStruct *id, ItemStruct *is)
 	}
 }
 
-//----- (00448A5E) --------------------------------------------------------
 void __fastcall VerifyGoldSeeds(PlayerStruct *pPlayer)
 {
 	int i; // ebp
@@ -155,7 +151,6 @@ void __fastcall VerifyGoldSeeds(PlayerStruct *pPlayer)
 	}
 }
 
-//----- (00448AD0) --------------------------------------------------------
 void __fastcall UnPackPlayer(PkPlayerStruct *pPack, int pnum, bool killok)
 {
 	PlayerStruct *pPlayer; // esi
@@ -246,7 +241,6 @@ void __fastcall UnPackPlayer(PkPlayerStruct *pPack, int pnum, bool killok)
 	pPlayer->pManaShield = pPack->pManaShield;
 }
 
-//----- (00448D48) --------------------------------------------------------
 void __fastcall UnPackItem(PkItemStruct *is, ItemStruct *id)
 {
 	PkItemStruct *v2; // esi

--- a/Source/pack.h
+++ b/Source/pack.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __PACK_H__
+#define __PACK_H__
 
-//pack
 extern int pack_cpp_init_value; // weak
 
 void __cdecl pack_cpp_init();
@@ -13,3 +14,5 @@ void __fastcall UnPackItem(PkItemStruct *is, ItemStruct *id);
 /* data */
 
 extern int pack_inf; // weak
+
+#endif /* __PACK_H__ */

--- a/Source/palette.cpp
+++ b/Source/palette.cpp
@@ -16,7 +16,6 @@ int gamma_correction = 100; // idb
 int color_cycling_enabled = 1; // idb
 bool sgbFadedIn = 1;
 
-//----- (00448DFA) --------------------------------------------------------
 struct palette_cpp_init
 {
 	palette_cpp_init()
@@ -27,14 +26,12 @@ struct palette_cpp_init
 // 47F16C: using guessed type int palette_inf;
 // 67DBCC: using guessed type int palette_cpp_init_value;
 
-//----- (00448E05) --------------------------------------------------------
 void __cdecl palette_save_gamme()
 {
 	SRegSaveValue("Diablo", "Gamma Correction", 0, gamma_correction);
 	SRegSaveValue("Diablo", "Color Cycling", 0, color_cycling_enabled);
 }
 
-//----- (00448E33) --------------------------------------------------------
 void __cdecl palette_init()
 {
 	int v0; // eax
@@ -51,7 +48,6 @@ void __cdecl palette_init()
 		TermDlg(111, v1, "C:\\Src\\Diablo\\Source\\PALETTE.CPP", 146);
 }
 
-//----- (00448EAB) --------------------------------------------------------
 void __cdecl palette_load_gamma()
 {
 	int v3; // eax
@@ -77,7 +73,6 @@ void __cdecl palette_load_gamma()
 	color_cycling_enabled = v3;
 }
 
-//----- (00448F20) --------------------------------------------------------
 void __cdecl LoadSysPal()
 {
 	HDC hDC; // ebx
@@ -106,7 +101,6 @@ void __cdecl LoadSysPal()
 }
 // 484364: using guessed type int fullscreen;
 
-//----- (00448FC9) --------------------------------------------------------
 void __fastcall LoadPalette(char *pszFileName)
 {
 	int i; // eax
@@ -126,7 +120,6 @@ void __fastcall LoadPalette(char *pszFileName)
 	}
 }
 
-//----- (00449025) --------------------------------------------------------
 void __fastcall LoadRndLvlPal(int l)
 {
 	char *pszPal; // ecx
@@ -144,7 +137,6 @@ void __fastcall LoadRndLvlPal(int l)
 	LoadPalette(pszPal);
 }
 
-//----- (0044906C) --------------------------------------------------------
 void __cdecl ResetPal()
 {
 	if ( !lpDDSPrimary
@@ -155,7 +147,6 @@ void __cdecl ResetPal()
 	}
 }
 
-//----- (00449097) --------------------------------------------------------
 void __cdecl palette_inc_gamma()
 {
 	if ( gamma_correction < 100 )
@@ -168,7 +159,6 @@ void __cdecl palette_inc_gamma()
 	}
 }
 
-//----- (004490D0) --------------------------------------------------------
 void __cdecl palette_update()
 {
 	int v0; // ecx
@@ -188,7 +178,6 @@ void __cdecl palette_update()
 }
 // 484364: using guessed type int fullscreen;
 
-//----- (00449107) --------------------------------------------------------
 void __fastcall palette_apply_gamma_correction(PALETTEENTRY *dst, PALETTEENTRY *src, int n)
 {
 	PALETTEENTRY *v3; // edi
@@ -213,7 +202,6 @@ void __fastcall palette_apply_gamma_correction(PALETTEENTRY *dst, PALETTEENTRY *
 	}
 }
 
-//----- (004491D0) --------------------------------------------------------
 void __cdecl palette_dec_gamma()
 {
 	if ( gamma_correction > 30 )
@@ -226,7 +214,6 @@ void __cdecl palette_dec_gamma()
 	}
 }
 
-//----- (00449209) --------------------------------------------------------
 int __fastcall palette_update_gamma(int gamma)
 {
 	if ( gamma )
@@ -238,13 +225,11 @@ int __fastcall palette_update_gamma(int gamma)
 	return 130 - gamma_correction;
 }
 
-//----- (0044923E) --------------------------------------------------------
 void __cdecl BlackPalette()
 {
 	SetFadeLevel(0);
 }
 
-//----- (00449245) --------------------------------------------------------
 void __fastcall SetFadeLevel(int fadeval)
 {
 	int i; // eax
@@ -263,7 +248,6 @@ void __fastcall SetFadeLevel(int fadeval)
 	}
 }
 
-//----- (004492B0) --------------------------------------------------------
 void __fastcall PaletteFadeIn(int fr)
 {
 	int i; // ebp
@@ -278,7 +262,6 @@ void __fastcall PaletteFadeIn(int fr)
 	sgbFadedIn = 1;
 }
 
-//----- (00449306) --------------------------------------------------------
 void __fastcall PaletteFadeOut(int fr)
 {
 	int i; // esi
@@ -293,7 +276,6 @@ void __fastcall PaletteFadeOut(int fr)
 	}
 }
 
-//----- (00449336) --------------------------------------------------------
 void __cdecl palette_update_caves()
 {
 	BYTE v0; // cx
@@ -320,7 +302,6 @@ void __cdecl palette_update_caves()
 	palette_update();
 }
 
-//----- (00449398) --------------------------------------------------------
 void __fastcall palette_update_quest_palette(int n)
 {
 	int i; // eax
@@ -331,13 +312,11 @@ void __fastcall palette_update_quest_palette(int n)
 	palette_update();
 }
 
-//----- (004493C6) --------------------------------------------------------
 bool __cdecl palette_get_colour_cycling()
 {
 	return color_cycling_enabled;
 }
 
-//----- (004493CC) --------------------------------------------------------
 void __fastcall palette_set_color_cycling(bool enabled)
 {
 	color_cycling_enabled = enabled;

--- a/Source/palette.h
+++ b/Source/palette.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __PALETTE_H__
+#define __PALETTE_H__
 
-//palette
 extern PALETTEENTRY logical_palette[256];
 extern int palette_cpp_init_value; // weak
 extern PALETTEENTRY system_palette[256];
@@ -38,3 +39,5 @@ extern int palette_inf; // weak
 extern int gamma_correction; // idb
 extern int color_cycling_enabled; // idb
 extern bool sgbFadedIn;
+
+#endif /* __PALETTE_H__ */

--- a/Source/path.cpp
+++ b/Source/path.cpp
@@ -15,7 +15,6 @@ char pathydir[8] = { -1, 1, -1, 1, 0, -1, 0, 1 };
 /* rdata */
 char path_directions[9] = { 5, 1, 6, 2, 0, 3, 8, 4, 7 };
 
-//----- (004493D4) --------------------------------------------------------
 int __fastcall FindPath(bool (__fastcall *PosOk)(int, int, int), int PosOkArg, int sx, int sy, int dx, int dy, char *path)
 {
 	PATHNODE *v8; // esi
@@ -91,7 +90,6 @@ int __fastcall FindPath(bool (__fastcall *PosOk)(int, int, int), int PosOkArg, i
 	return result;
 }
 
-//----- (004494D3) --------------------------------------------------------
 int __fastcall path_get_h_cost(int sx, int sy, int dx, int dy)
 {
 	int v4; // esi
@@ -112,7 +110,6 @@ int __fastcall path_get_h_cost(int sx, int sy, int dx, int dy)
 	return 2 * (v7 + v6);
 }
 
-//----- (00449504) --------------------------------------------------------
 int __fastcall path_check_equal(PATHNODE *pPath, int dx, int dy)
 {
 	int v4; // [esp-4h] [ebp-4h]
@@ -124,7 +121,6 @@ int __fastcall path_check_equal(PATHNODE *pPath, int dx, int dy)
 	return v4;
 }
 
-//----- (0044951C) --------------------------------------------------------
 PATHNODE *__cdecl GetNextPath()
 {
 	PATHNODE *result; // eax
@@ -139,7 +135,6 @@ PATHNODE *__cdecl GetNextPath()
 	return result;
 }
 
-//----- (00449546) --------------------------------------------------------
 bool __fastcall path_solid_pieces(PATHNODE *pPath, int dx, int dy)
 {
 	bool result; // eax
@@ -189,7 +184,6 @@ LABEL_13:
 	return result;
 }
 
-//----- (004495ED) --------------------------------------------------------
 int __fastcall path_get_path(bool (__fastcall *PosOk)(int, int, int), int PosOkArg, PATHNODE *pPath, int x, int y)
 {
 	int v5; // eax
@@ -218,7 +212,6 @@ LABEL_8:
 	return 0;
 }
 
-//----- (0044966F) --------------------------------------------------------
 int __fastcall path_parent_path(PATHNODE *pPath, int dx, int dy, int sx, int sy)
 {
 	PATHNODE *v5; // edi
@@ -321,7 +314,6 @@ int __fastcall path_parent_path(PATHNODE *pPath, int dx, int dy, int sx, int sy)
 	return 1;
 }
 
-//----- (0044979A) --------------------------------------------------------
 PATHNODE *__fastcall path_get_node1(int dx, int dy)
 {
 	PATHNODE *result; // eax
@@ -333,7 +325,6 @@ PATHNODE *__fastcall path_get_node1(int dx, int dy)
 	return result;
 }
 
-//----- (004497B3) --------------------------------------------------------
 PATHNODE *__fastcall path_get_node2(int dx, int dy)
 {
 	PATHNODE *result; // eax
@@ -345,7 +336,6 @@ PATHNODE *__fastcall path_get_node2(int dx, int dy)
 	return result;
 }
 
-//----- (004497CC) --------------------------------------------------------
 void __fastcall path_next_node(PATHNODE *pPath)
 {
 	PATHNODE *v1; // edx
@@ -368,7 +358,6 @@ void __fastcall path_next_node(PATHNODE *pPath)
 	v1->NextNode = pPath;
 }
 
-//----- (004497F7) --------------------------------------------------------
 void __fastcall path_set_coords(PATHNODE *pPath)
 {
 	PATHNODE *PathOld; // edi
@@ -404,7 +393,6 @@ void __fastcall path_set_coords(PATHNODE *pPath)
 	}
 }
 
-//----- (00449890) --------------------------------------------------------
 void __fastcall path_push_active_step(PATHNODE *pPath)
 {
 	int v1; // eax
@@ -413,13 +401,11 @@ void __fastcall path_push_active_step(PATHNODE *pPath)
 	pnode_tblptr[v1] = pPath;
 }
 
-//----- (004498A3) --------------------------------------------------------
 PATHNODE *__cdecl path_pop_active_step()
 {
 	return pnode_tblptr[--gdwCurPathStep];
 }
 
-//----- (004498B6) --------------------------------------------------------
 PATHNODE *__cdecl path_new_step()
 {
 	PATHNODE *v1; // esi

--- a/Source/path.h
+++ b/Source/path.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __PATH_H__
+#define __PATH_H__
 
-//path
 extern PATHNODE path_nodes[300];
 extern int gdwCurPathStep;
 extern int pnode_vals[26];
@@ -30,3 +31,5 @@ extern char pathydir[8];
 
 /* rdata */
 extern char path_directions[9];
+
+#endif /* __PATH_H__ */

--- a/Source/pfile.cpp
+++ b/Source/pfile.cpp
@@ -9,7 +9,6 @@ int save_prev_tc; // weak
 
 int pfile_inf = 0x7F800000; // weak
 
-//----- (004498F1) --------------------------------------------------------
 struct pfile_cpp_init
 {
 	pfile_cpp_init()
@@ -19,7 +18,6 @@ struct pfile_cpp_init
 } _pfile_cpp_init;
 // 47F1C0: using guessed type int pfile_inf;
 
-//----- (004498FC) --------------------------------------------------------
 void __cdecl pfile_init_save_directory()
 {
 	char Buffer[260]; // [esp+4h] [ebp-104h]
@@ -35,7 +33,6 @@ void __cdecl pfile_init_save_directory()
 	}
 }
 
-//----- (0044995B) --------------------------------------------------------
 void __fastcall pfile_check_available_space(char *pszDir)
 {
 	char *v1; // edi
@@ -71,7 +68,6 @@ LABEL_12:
 		DiskFreeDlg(v1);
 }
 
-//----- (004499C3) --------------------------------------------------------
 void __cdecl pfile_write_hero()
 {
 	int v0; // eax
@@ -91,7 +87,6 @@ void __cdecl pfile_write_hero()
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00449A33) --------------------------------------------------------
 int __fastcall pfile_get_save_num_from_name(char *name)
 {
 	char *v1; // ebx
@@ -112,7 +107,6 @@ int __fastcall pfile_get_save_num_from_name(char *name)
 	return v2;
 }
 
-//----- (00449A5B) --------------------------------------------------------
 void __fastcall pfile_encode_hero(PkPlayerStruct *pPack)
 {
 	int v1; // ebx
@@ -136,7 +130,6 @@ void __fastcall pfile_encode_hero(PkPlayerStruct *pPack)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00449ADF) --------------------------------------------------------
 bool __fastcall pfile_open_archive(bool a1, int save_num)
 {
 	int v2; // esi
@@ -159,7 +152,6 @@ bool __fastcall pfile_open_archive(bool a1, int save_num)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00449B30) --------------------------------------------------------
 void __fastcall pfile_get_save_path(char *pszBuf, int dwBufSize, int save_num)
 {
 	char *v3; // esi
@@ -184,7 +176,6 @@ void __fastcall pfile_get_save_path(char *pszBuf, int dwBufSize, int save_num)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00449BB2) --------------------------------------------------------
 void __fastcall pfile_flush(bool is_single_player, int save_num)
 {
 	int v2; // esi
@@ -197,7 +188,6 @@ void __fastcall pfile_flush(bool is_single_player, int save_num)
 	mpqapi_flush_and_close(FileName, v3, v2);
 }
 
-//----- (00449BE4) --------------------------------------------------------
 bool __fastcall pfile_create_player_description(char *dst, int len)
 {
 	int v2; // edi
@@ -224,7 +214,6 @@ LABEL_5:
 	return v4;
 }
 
-//----- (00449C5A) --------------------------------------------------------
 int __fastcall pfile_create_save_file(char *name_1, char *name_2)
 {
 	char *v2; // edi
@@ -260,7 +249,6 @@ int __fastcall pfile_create_save_file(char *name_1, char *name_2)
 	return 1;
 }
 
-//----- (00449D22) --------------------------------------------------------
 void __cdecl pfile_flush_W()
 {
 	int v0; // eax
@@ -269,7 +257,6 @@ void __cdecl pfile_flush_W()
 	pfile_flush(1, v0);
 }
 
-//----- (00449D43) --------------------------------------------------------
 void __fastcall game_2_ui_player(PlayerStruct *p, _uiheroinfo *heroinfo, bool bHasSaveFile)
 {
 	_uiheroinfo *v3; // esi
@@ -294,7 +281,6 @@ void __fastcall game_2_ui_player(PlayerStruct *p, _uiheroinfo *heroinfo, bool bH
 	v3->herorank = v5;
 }
 
-//----- (00449DD0) --------------------------------------------------------
 char __fastcall game_2_ui_class(PlayerStruct *p)
 {
 	char result; // al
@@ -305,7 +291,6 @@ char __fastcall game_2_ui_class(PlayerStruct *p)
 	return result;
 }
 
-//----- (00449DE3) --------------------------------------------------------
 bool __stdcall pfile_ui_set_hero_infos(void (__stdcall *ui_add_hero_info)(_uiheroinfo *))
 {
 	char *v1; // esi
@@ -395,7 +380,6 @@ LABEL_13:
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00449FAA) --------------------------------------------------------
 char *__fastcall GetSaveDirectory(char *dst, int dst_size, int save_num)
 {
 	char *v3; // esi
@@ -426,7 +410,6 @@ char *__fastcall GetSaveDirectory(char *dst, int dst_size, int save_num)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0044A036) --------------------------------------------------------
 bool __fastcall pfile_read_hero(void *archive, PkPlayerStruct *pPack)
 {
 	BOOL v2; // eax
@@ -498,7 +481,6 @@ LABEL_15:
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0044A158) --------------------------------------------------------
 void *__fastcall pfile_open_save_archive(int *unused, int save_num)
 {
 	//int v2; // eax
@@ -510,13 +492,11 @@ void *__fastcall pfile_open_save_archive(int *unused, int save_num)
 	return SFileOpenArchive(SrcStr, 0x7000, 0, &archive) != 0 ? archive : NULL;
 }
 
-//----- (0044A192) --------------------------------------------------------
 void __fastcall pfile_SFileCloseArchive(void *hsArchive)
 {
 	SFileCloseArchive(hsArchive);
 }
 
-//----- (0044A199) --------------------------------------------------------
 bool __fastcall pfile_archive_contains_game(void *hsArchive)
 {
 	//int v1; // eax
@@ -533,7 +513,6 @@ bool __fastcall pfile_archive_contains_game(void *hsArchive)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0044A1CC) --------------------------------------------------------
 bool __stdcall pfile_ui_set_class_stats(int player_class_nr, _uidefaultstats *class_stats)
 {
 	int v2; // eax
@@ -546,7 +525,6 @@ bool __stdcall pfile_ui_set_class_stats(int player_class_nr, _uidefaultstats *cl
 	return 1;
 }
 
-//----- (0044A210) --------------------------------------------------------
 int __fastcall pfile_get_player_class(int player_class_nr)
 {
 	int result; // eax
@@ -558,7 +536,6 @@ int __fastcall pfile_get_player_class(int player_class_nr)
 	return result;
 }
 
-//----- (0044A220) --------------------------------------------------------
 bool __stdcall pfile_ui_save_create(_uiheroinfo *heroinfo)
 {
 	unsigned int v1; // edi
@@ -600,7 +577,6 @@ bool __stdcall pfile_ui_save_create(_uiheroinfo *heroinfo)
 	return 1;
 }
 
-//----- (0044A2FF) --------------------------------------------------------
 bool __stdcall pfile_get_file_name(int lvl, char *dst)
 {
 	int v2; // ecx
@@ -642,7 +618,6 @@ LABEL_10:
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0044A356) --------------------------------------------------------
 bool __stdcall pfile_delete_save(_uiheroinfo *hero_info)
 {
 	unsigned int v1; // eax
@@ -658,7 +633,6 @@ bool __stdcall pfile_delete_save(_uiheroinfo *hero_info)
 	return 1;
 }
 
-//----- (0044A3A0) --------------------------------------------------------
 void __cdecl pfile_read_player_from_save()
 {
 	int dwChar; // edi
@@ -678,7 +652,6 @@ void __cdecl pfile_read_player_from_save()
 	pfile_SFileCloseArchive(v1);
 }
 
-//----- (0044A419) --------------------------------------------------------
 void __fastcall GetTempLevelNames(char *szTemp)
 {
 	char *v1; // esi
@@ -693,7 +666,6 @@ void __fastcall GetTempLevelNames(char *szTemp)
 // 5CCB10: using guessed type char setlvlnum;
 // 5CF31D: using guessed type char setlevel;
 
-//----- (0044A463) --------------------------------------------------------
 void __fastcall GetPermLevelNames(char *szPerm)
 {
 	char *v1; // esi
@@ -722,7 +694,6 @@ void __fastcall GetPermLevelNames(char *szPerm)
 // 5CCB10: using guessed type char setlvlnum;
 // 5CF31D: using guessed type char setlevel;
 
-//----- (0044A4E9) --------------------------------------------------------
 void __fastcall pfile_get_game_name(char *dst)
 {
 	char *v1; // esi
@@ -732,7 +703,6 @@ void __fastcall pfile_get_game_name(char *dst)
 	strcpy(v1, "game");
 }
 
-//----- (0044A512) --------------------------------------------------------
 void __cdecl pfile_remove_temp_files()
 {
 	int v0; // eax
@@ -752,7 +722,6 @@ void __cdecl pfile_remove_temp_files()
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0044A563) --------------------------------------------------------
 bool __stdcall GetTempSaveNames(int dwIndex, char *szTemp)
 {
 	int v2; // eax
@@ -775,7 +744,6 @@ LABEL_5:
 	return 0;
 }
 
-//----- (0044A598) --------------------------------------------------------
 void __cdecl pfile_rename_temp_to_perm()
 {
 	int v0; // eax
@@ -813,7 +781,6 @@ void __cdecl pfile_rename_temp_to_perm()
 	pfile_flush(1, v1);
 }
 
-//----- (0044A644) --------------------------------------------------------
 bool __stdcall GetPermSaveNames(int dwIndex, char *szPerm)
 {
 	int v2; // eax
@@ -836,7 +803,6 @@ LABEL_5:
 	return 0;
 }
 
-//----- (0044A679) --------------------------------------------------------
 void __fastcall pfile_write_save_file(char *pszName, void *pbData, int dwLen, int qwLen)
 {
 	void *v4; // ebx
@@ -865,13 +831,11 @@ void __fastcall pfile_write_save_file(char *pszName, void *pbData, int dwLen, in
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0044A727) --------------------------------------------------------
 void __fastcall pfile_strcpy(char *dst, char *src)
 {
 	strcpy(dst, src);
 }
 
-//----- (0044A731) --------------------------------------------------------
 char *__fastcall pfile_read(char *pszName, int *pdwLen)
 {
 	int *v2; // ebx
@@ -940,7 +904,6 @@ char *__fastcall pfile_read(char *pszName, int *pdwLen)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0044A8B3) --------------------------------------------------------
 void __fastcall pfile_update(bool force_save)
 {
 	BOOL v1; // esi

--- a/Source/pfile.h
+++ b/Source/pfile.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __PFILE_H__
+#define __PFILE_H__
 
-//pfile
 extern int pfile_cpp_init_value;
 extern char hero_names[320];
 extern bool gbValidSaveFile; // idb
@@ -47,3 +48,5 @@ void __fastcall pfile_update(bool force_save);
 /* data */
 
 extern int pfile_inf; // weak
+
+#endif /* __PFILE_H__ */

--- a/Source/player.cpp
+++ b/Source/player.cpp
@@ -101,7 +101,6 @@ int ExpLvlsTbl[51] =
 char *ClassStrTbl[3] = { "Warrior", "Rogue", "Sorceror" };
 unsigned char fix[9] = { 0u, 0u, 3u, 3u, 3u, 6u, 6u, 6u, 8u }; /* PM_ChangeLightOff local type */
 
-//----- (0044A8EB) --------------------------------------------------------
 struct player_cpp_init
 {
 	player_cpp_init()
@@ -112,7 +111,6 @@ struct player_cpp_init
 // 47F204: using guessed type int player_inf;
 // 68643C: using guessed type int player_cpp_init_value;
 
-//----- (0044A8F6) --------------------------------------------------------
 void __fastcall player_init_cl2_hdrs(char *src, char *dst)
 {
 	char *v2; // eax
@@ -131,7 +129,6 @@ void __fastcall player_init_cl2_hdrs(char *src, char *dst)
 	while ( v4 );
 }
 
-//----- (0044A911) --------------------------------------------------------
 void __fastcall LoadPlrGFX(int pnum, int gfxflag)
 {
 	int v2; // esi
@@ -291,7 +288,6 @@ LABEL_38:
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0044AB70) --------------------------------------------------------
 void __fastcall InitPlayerGFX(int pnum)
 {
 	int v1; // esi
@@ -312,7 +308,6 @@ void __fastcall InitPlayerGFX(int pnum)
 	LoadPlrGFX(v1, v2);
 }
 
-//----- (0044ABB4) --------------------------------------------------------
 void __fastcall InitPlrGFXMem(int pnum)
 {
 	int v1; // esi
@@ -424,7 +419,6 @@ void __fastcall InitPlrGFXMem(int pnum)
 // 686438: using guessed type char plr_gfx_flag;
 // 69B7BC: using guessed type char plr_gfx_bflag;
 
-//----- (0044ADC8) --------------------------------------------------------
 int __fastcall GetPlrGFXSize(char *szCel)
 {
 	unsigned int v1; // ebx
@@ -472,7 +466,6 @@ int __fastcall GetPlrGFXSize(char *szCel)
 	return v11;
 }
 
-//----- (0044AE89) --------------------------------------------------------
 void __fastcall FreePlayerGFX(int pnum)
 {
 	int v1; // esi
@@ -521,7 +514,6 @@ void __fastcall FreePlayerGFX(int pnum)
 	plr[v2]._pGFXLoad = 0;
 }
 
-//----- (0044AF37) --------------------------------------------------------
 void __fastcall NewPlrAnim(int pnum, int Peq, int numFrames, int Delay, int width)
 {
 	int v5; // edi
@@ -542,7 +534,6 @@ void __fastcall NewPlrAnim(int pnum, int Peq, int numFrames, int Delay, int widt
 	plr[v7]._pAnimWidth2 = (width - 64) >> 1;
 }
 
-//----- (0044AF9C) --------------------------------------------------------
 void __fastcall ClearPlrPVars(int pnum)
 {
 	int v1; // esi
@@ -562,7 +553,6 @@ void __fastcall ClearPlrPVars(int pnum)
 	plr[v2]._pVar8 = 0;
 }
 
-//----- (0044AFED) --------------------------------------------------------
 void __fastcall SetPlrAnims(int pnum)
 {
 	int v1; // esi
@@ -673,7 +663,6 @@ LABEL_11:
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0044B1FD) --------------------------------------------------------
 void __fastcall ClearPlrRVars(PlayerStruct *pPlayer)
 {
 	pPlayer->bReserved[0] = 0;
@@ -696,7 +685,6 @@ void __fastcall ClearPlrRVars(PlayerStruct *pPlayer)
 	pPlayer->dwReserved[6] = 0;
 }
 
-//----- (0044B274) --------------------------------------------------------
 void __fastcall CreatePlayer(int pnum, char c)
 {
 	unsigned int v2; // edi
@@ -862,7 +850,6 @@ LABEL_28:
 	SetRndSeed(0);
 }
 
-//----- (0044B582) --------------------------------------------------------
 int __fastcall CalcStatDiff(int pnum)
 {
 	int v1; // ecx
@@ -880,7 +867,6 @@ int __fastcall CalcStatDiff(int pnum)
 		 - plr[v1]._pBaseStr;
 }
 
-//----- (0044B5C3) --------------------------------------------------------
 void __fastcall NextPlrLevel(int pnum)
 {
 	int v1; // edi
@@ -936,7 +922,6 @@ void __fastcall NextPlrLevel(int pnum)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0044B6C8) --------------------------------------------------------
 void __fastcall AddPlrExperience(int pnum, int lvl, int exp)
 {
 	int v3; // eax
@@ -1029,7 +1014,6 @@ void __fastcall AddPlrExperience(int pnum, int lvl, int exp)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0044B7F8) --------------------------------------------------------
 void __fastcall AddPlrMonstExper(int lvl, int exp, char pmask)
 {
 	int v3; // ebx
@@ -1053,7 +1037,6 @@ void __fastcall AddPlrMonstExper(int lvl, int exp, char pmask)
 	}
 }
 
-//----- (0044B83C) --------------------------------------------------------
 void __fastcall InitPlayer(int pnum, bool FirstTime)
 {
 	int v2; // ebx
@@ -1216,7 +1199,6 @@ LABEL_33:
 // 52572C: using guessed type int leveldebug;
 // 69B7C4: using guessed type int deathdelay;
 
-//----- (0044BB33) --------------------------------------------------------
 void __cdecl InitMultiView()
 {
 	int v0; // eax
@@ -1228,7 +1210,6 @@ void __cdecl InitMultiView()
 	ViewY = v0;
 }
 
-//----- (0044BB6D) --------------------------------------------------------
 void __fastcall InitPlayerLoc(int pnum, bool flag)
 {
 	int v2; // esi
@@ -1293,7 +1274,6 @@ void __fastcall InitPlayerLoc(int pnum, bool flag)
 	}
 }
 
-//----- (0044BCC2) --------------------------------------------------------
 bool __fastcall SolidLoc(int x, int y)
 {
 	bool result; // eax
@@ -1305,7 +1285,6 @@ bool __fastcall SolidLoc(int x, int y)
 	return result;
 }
 
-//----- (0044BCEB) --------------------------------------------------------
 bool __fastcall PlrDirOK(int pnum, int dir)
 {
 	int v2; // esi
@@ -1351,7 +1330,6 @@ bool __fastcall PlrDirOK(int pnum, int dir)
 	return 0;
 }
 
-//----- (0044BD9A) --------------------------------------------------------
 void __fastcall PlrClrTrans(int x, int y)
 {
 	int v2; // esi
@@ -1389,7 +1367,6 @@ void __fastcall PlrClrTrans(int x, int y)
 	}
 }
 
-//----- (0044BDDD) --------------------------------------------------------
 void __fastcall PlrDoTrans(int x, int y)
 {
 	int v2; // edi
@@ -1440,7 +1417,6 @@ void __fastcall PlrDoTrans(int x, int y)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0044BE5E) --------------------------------------------------------
 void __fastcall SetPlayerOld(int pnum)
 {
 	int v1; // esi
@@ -1454,7 +1430,6 @@ void __fastcall SetPlayerOld(int pnum)
 	plr[v2]._poldy = plr[v1].WorldY;
 }
 
-//----- (0044BE95) --------------------------------------------------------
 void __fastcall FixPlayerLocation(int pnum, int dir)
 {
 	int v2; // edi
@@ -1494,7 +1469,6 @@ void __fastcall FixPlayerLocation(int pnum, int dir)
 	}
 }
 
-//----- (0044BF2D) --------------------------------------------------------
 void __fastcall StartStand(int pnum, int dir)
 {
 	int v2; // ebx
@@ -1523,7 +1497,6 @@ void __fastcall StartStand(int pnum, int dir)
 	}
 }
 
-//----- (0044BFE8) --------------------------------------------------------
 void __fastcall StartWalkStand(int pnum)
 {
 	int v1; // edi
@@ -1555,7 +1528,6 @@ void __fastcall StartWalkStand(int pnum)
 	}
 }
 
-//----- (0044C070) --------------------------------------------------------
 void __fastcall PM_ChangeLightOff(int pnum)
 {
 	int v1; // esi
@@ -1607,7 +1579,6 @@ void __fastcall PM_ChangeLightOff(int pnum)
 		ChangeLightOff(plr[v2]._plid, lx, v10);
 }
 
-//----- (0044C13D) --------------------------------------------------------
 void __fastcall PM_ChangeOffset(int pnum)
 {
 	int v1; // esi
@@ -1658,7 +1629,6 @@ void __fastcall PM_ChangeOffset(int pnum)
 	PM_ChangeLightOff(arglist);
 }
 
-//----- (0044C1E2) --------------------------------------------------------
 void __fastcall StartWalk(int pnum, int xvel, int yvel, int xadd, int yadd, int EndDir, int sdir)
 {
 	int v7; // edi
@@ -1755,7 +1725,6 @@ LABEL_20:
 }
 // 52569C: using guessed type int zoomflag;
 
-//----- (0044C3AC) --------------------------------------------------------
 void __fastcall StartWalk2(int pnum, int xvel, int yvel, int xoff, int yoff, int xadd, int yadd, int EndDir, int sdir)
 {
 	int v9; // edi
@@ -1866,7 +1835,6 @@ LABEL_22:
 }
 // 52569C: using guessed type int zoomflag;
 
-//----- (0044C5CF) --------------------------------------------------------
 void __fastcall StartWalk3(int pnum, int xvel, int yvel, int xoff, int yoff, int xadd, int yadd, int mapx, int mapy, int EndDir, int sdir)
 {
 	int v11; // edi
@@ -1983,7 +1951,6 @@ LABEL_22:
 // 52569C: using guessed type int zoomflag;
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0044C81E) --------------------------------------------------------
 void __fastcall StartAttack(int pnum, int d)
 {
 	int v2; // edi
@@ -2012,7 +1979,6 @@ void __fastcall StartAttack(int pnum, int d)
 	}
 }
 
-//----- (0044C8BB) --------------------------------------------------------
 void __fastcall StartRangeAttack(int pnum, int d, int cx, int cy)
 {
 	int v4; // edi
@@ -2043,7 +2009,6 @@ void __fastcall StartRangeAttack(int pnum, int d, int cx, int cy)
 	}
 }
 
-//----- (0044C973) --------------------------------------------------------
 void __fastcall StartPlrBlock(int pnum, int dir)
 {
 	int v2; // edi
@@ -2073,7 +2038,6 @@ void __fastcall StartPlrBlock(int pnum, int dir)
 	}
 }
 
-//----- (0044CA26) --------------------------------------------------------
 void __fastcall StartSpell(int pnum, int d, int cx, int cy)
 {
 	int v4; // edi
@@ -2129,7 +2093,6 @@ LABEL_20:
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0044CB95) --------------------------------------------------------
 void __fastcall FixPlrWalkTags(int pnum)
 {
 	int v1; // esi
@@ -2195,7 +2158,6 @@ void __fastcall FixPlrWalkTags(int pnum)
 	}
 }
 
-//----- (0044CC62) --------------------------------------------------------
 void __fastcall RemovePlrFromMap(int pnum)
 {
 	int v1; // esi
@@ -2250,7 +2212,6 @@ void __fastcall RemovePlrFromMap(int pnum)
 	while ( v6 < 112 );
 }
 
-//----- (0044CCD8) --------------------------------------------------------
 void __fastcall StartPlrHit(int pnum, int dam, unsigned char forcehit)
 {
 	int v3; // ebx
@@ -2305,7 +2266,6 @@ LABEL_13:
 	}
 }
 
-//----- (0044CDFD) --------------------------------------------------------
 void __fastcall RespawnDeadItem(ItemStruct *itm, int x, int y)
 {
 	ItemStruct *v3; // ebx
@@ -2337,7 +2297,6 @@ void __fastcall RespawnDeadItem(ItemStruct *itm, int x, int y)
 	}
 }
 
-//----- (0044CEC9) --------------------------------------------------------
 void __fastcall StartPlayerKill(int pnum, int earflag)
 {
 	unsigned int v2; // edi
@@ -2489,7 +2448,6 @@ LABEL_18:
 // 679660: using guessed type char gbMaxPlayers;
 // 69B7C4: using guessed type int deathdelay;
 
-//----- (0044D1F4) --------------------------------------------------------
 void __fastcall PlrDeadItem(int pnum, struct ItemStruct *itm, int xx, int yy)
 {
 	int v4; // edi
@@ -2573,7 +2531,6 @@ LABEL_14:
 	}
 }
 
-//----- (0044D2F3) --------------------------------------------------------
 void __fastcall DropHalfPlayersGold(int pnum)
 {
 	int v1; // ebx
@@ -2772,7 +2729,6 @@ LABEL_28:
 }
 // 52571C: using guessed type int drawpanflag;
 
-//----- (0044D70B) --------------------------------------------------------
 void __fastcall SyncPlrKill(int pnum, int earflag)
 {
 	int v2; // esi
@@ -2811,7 +2767,6 @@ LABEL_9:
 	}
 }
 
-//----- (0044D7A0) --------------------------------------------------------
 void __fastcall RemovePlrMissiles(int pnum)
 {
 	int v1; // ebx
@@ -2857,7 +2812,6 @@ void __fastcall RemovePlrMissiles(int pnum)
 	}
 }
 
-//----- (0044D8D1) --------------------------------------------------------
 void __fastcall InitLevelChange(int pnum)
 {
 	int v1; // esi
@@ -2887,7 +2841,6 @@ void __fastcall InitLevelChange(int pnum)
 }
 // 646D00: using guessed type char qtextflag;
 
-//----- (0044D973) --------------------------------------------------------
 void __fastcall StartNewLvl(int pnum, int fom, int lvl)
 {
 	int v3; // edi
@@ -2941,7 +2894,6 @@ LABEL_11:
 // 5CCB10: using guessed type char setlvlnum;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0044DA6F) --------------------------------------------------------
 void __fastcall RestartTownLvl(int pnum)
 {
 	unsigned int v1; // edi
@@ -2970,7 +2922,6 @@ void __fastcall RestartTownLvl(int pnum)
 	}
 }
 
-//----- (0044DAFC) --------------------------------------------------------
 void __fastcall StartWarpLvl(int pnum, int pidx)
 {
 	int v2; // edi
@@ -3002,13 +2953,11 @@ void __fastcall StartWarpLvl(int pnum, int pidx)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0044DB74) --------------------------------------------------------
 int __fastcall PM_DoStand(int pnum)
 {
 	return 0;
 }
 
-//----- (0044DB77) --------------------------------------------------------
 int __fastcall PM_DoWalk(int pnum)
 {
 	int v1; // ebx
@@ -3081,7 +3030,6 @@ LABEL_9:
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0044DCE5) --------------------------------------------------------
 int __fastcall PM_DoWalk2(int pnum)
 {
 	int v1; // ebx
@@ -3141,7 +3089,6 @@ LABEL_9:
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0044DE30) --------------------------------------------------------
 int __fastcall PM_DoWalk3(int pnum)
 {
 	int v1; // ebx
@@ -3213,7 +3160,6 @@ LABEL_9:
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0044DFB1) --------------------------------------------------------
 bool __fastcall WeaponDur(int pnum, int durrnd)
 {
 	unsigned int v2; // edi
@@ -3294,7 +3240,6 @@ LABEL_23:
 	return 0;
 }
 
-//----- (0044E0BC) --------------------------------------------------------
 bool __fastcall PlrHitMonst(int pnum, int m)
 {
 	int v2; // ebx
@@ -3532,7 +3477,6 @@ LABEL_85:
 	return v42;
 }
 
-//----- (0044E442) --------------------------------------------------------
 bool __fastcall PlrHitPlr(int pnum, char p)
 {
 	char v2; // bl
@@ -3660,7 +3604,6 @@ bool __fastcall PlrHitPlr(int pnum, char p)
 	return v30;
 }
 
-//----- (0044E669) --------------------------------------------------------
 bool __fastcall PlrHitObj(int pnum, int mx, int my)
 {
 	int oi; // edx
@@ -3677,7 +3620,6 @@ bool __fastcall PlrHitObj(int pnum, int mx, int my)
 	return 1;
 }
 
-//----- (0044E6A6) --------------------------------------------------------
 int __fastcall PM_DoAttack(int pnum)
 {
 	int v1; // esi
@@ -3793,7 +3735,6 @@ LABEL_48:
 }
 // 484368: using guessed type int FriendlyMode;
 
-//----- (0044E8B8) --------------------------------------------------------
 int __fastcall PM_DoRangeAttack(int pnum)
 {
 	int v1; // edi
@@ -3834,7 +3775,6 @@ LABEL_21:
 	return 1;
 }
 
-//----- (0044E9AC) --------------------------------------------------------
 void __fastcall ShieldDur(int pnum)
 {
 	int v1; // edi
@@ -3882,7 +3822,6 @@ void __fastcall ShieldDur(int pnum)
 	}
 }
 
-//----- (0044EA4D) --------------------------------------------------------
 int __fastcall PM_DoBlock(int pnum)
 {
 	int v1; // esi
@@ -3905,7 +3844,6 @@ int __fastcall PM_DoBlock(int pnum)
 	return 1;
 }
 
-//----- (0044EAC6) --------------------------------------------------------
 int __fastcall PM_DoSpell(int pnum)
 {
 	int v1; // edi
@@ -3965,7 +3903,6 @@ LABEL_16:
 // 52571C: using guessed type int drawpanflag;
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0044EC06) --------------------------------------------------------
 int __fastcall PM_DoGotHit(int pnum)
 {
 	int v1; // esi
@@ -3996,7 +3933,6 @@ int __fastcall PM_DoGotHit(int pnum)
 	return 1;
 }
 
-//----- (0044ECBC) --------------------------------------------------------
 void __fastcall ArmorDur(int pnum)
 {
 	int v1; // ebp
@@ -4057,7 +3993,6 @@ LABEL_23:
 	}
 }
 
-//----- (0044ED7B) --------------------------------------------------------
 int __fastcall PM_DoDeath(int pnum)
 {
 	int v1; // edi
@@ -4092,7 +4027,6 @@ int __fastcall PM_DoDeath(int pnum)
 // 679660: using guessed type char gbMaxPlayers;
 // 69B7C4: using guessed type int deathdelay;
 
-//----- (0044EE22) --------------------------------------------------------
 void __fastcall CheckNewPath(int pnum)
 {
 	int v1; // edi
@@ -4613,7 +4547,6 @@ LABEL_143:
 	}
 }
 
-//----- (0044F9BA) --------------------------------------------------------
 bool __fastcall PlrDeathModeOK(int pnum)
 {
 	int v1; // esi
@@ -4634,7 +4567,6 @@ LABEL_10:
 	return result;
 }
 
-//----- (0044F9FC) --------------------------------------------------------
 void __cdecl ValidatePlayer()
 {
 	int v0; // edi
@@ -4714,7 +4646,6 @@ void __cdecl ValidatePlayer()
 	*(_QWORD *)plr[v1]._pMemSpells &= v14;
 }
 
-//----- (0044FB32) --------------------------------------------------------
 void __cdecl ProcessPlayers()
 {
 	int v0; // eax
@@ -4845,7 +4776,6 @@ LABEL_38:
 }
 // 52A554: using guessed type int sfxdelay;
 
-//----- (0044FD31) --------------------------------------------------------
 void __fastcall CheckCheatStats(int pnum)
 {
 	int v1; // ecx
@@ -4867,7 +4797,6 @@ void __fastcall CheckCheatStats(int pnum)
 		*v2 = 128000;
 }
 
-//----- (0044FD8A) --------------------------------------------------------
 void __fastcall ClrPlrPath(int pnum)
 {
 	int v1; // esi
@@ -4878,7 +4807,6 @@ void __fastcall ClrPlrPath(int pnum)
 	memset(plr[v1].walkpath, -1, 0x19u);
 }
 
-//----- (0044FDBA) --------------------------------------------------------
 bool __fastcall PosOkPlayer(int pnum, int px, int py)
 {
 	char v8; // cl
@@ -4909,7 +4837,6 @@ bool __fastcall PosOkPlayer(int pnum, int px, int py)
 	return result;
 }
 
-//----- (0044FE9E) --------------------------------------------------------
 void __fastcall MakePlrPath(int pnum, int xx, int yy, unsigned char endspace)
 {
 	int v4; // esi
@@ -4978,7 +4905,6 @@ LABEL_15:
 	}
 }
 
-//----- (0044FF6F) --------------------------------------------------------
 void __fastcall CheckPlrSpell()
 {
 	int v0; // ecx
@@ -5129,7 +5055,6 @@ LABEL_53:
 // 4B8CC2: using guessed type char pcursplr;
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (00450217) --------------------------------------------------------
 void __fastcall SyncPlrAnim(int pnum)
 {
 	int v1; // esi
@@ -5190,7 +5115,6 @@ LABEL_19:
 	}
 }
 
-//----- (0045036D) --------------------------------------------------------
 void __fastcall SyncInitPlrPos(int pnum)
 {
 	int v1; // esi
@@ -5274,7 +5198,6 @@ void __fastcall SyncInitPlrPos(int pnum)
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (004504E4) --------------------------------------------------------
 void __fastcall SyncInitPlr(int pnum)
 {
 	int v1; // esi
@@ -5286,7 +5209,6 @@ void __fastcall SyncInitPlr(int pnum)
 	SyncInitPlrPos(v1);
 }
 
-//----- (00450508) --------------------------------------------------------
 void __fastcall CheckStats(int pnum)
 {
 	int v1; // esi
@@ -5395,7 +5317,6 @@ void __fastcall CheckStats(int pnum)
 	while ( v5 < 4 );
 }
 
-//----- (00450621) --------------------------------------------------------
 void __fastcall ModifyPlrStr(int pnum, int l)
 {
 	int v2; // esi
@@ -5439,7 +5360,6 @@ void __fastcall ModifyPlrStr(int pnum, int l)
 		NetSendCmdParam1(0, CMD_SETSTR, plr[v4]._pBaseStr);
 }
 
-//----- (004506DB) --------------------------------------------------------
 void __fastcall ModifyPlrMag(int pnum, int l)
 {
 	int v2; // esi
@@ -5481,7 +5401,6 @@ void __fastcall ModifyPlrMag(int pnum, int l)
 		NetSendCmdParam1(0, CMD_SETMAG, plr[v4]._pBaseMag);
 }
 
-//----- (00450788) --------------------------------------------------------
 void __fastcall ModifyPlrDex(int pnum, int l)
 {
 	int v2; // ebx
@@ -5508,7 +5427,6 @@ void __fastcall ModifyPlrDex(int pnum, int l)
 		NetSendCmdParam1(0, CMD_SETDEX, plr[v4]._pBaseDex);
 }
 
-//----- (0045082C) --------------------------------------------------------
 void __fastcall ModifyPlrVit(int pnum, int l)
 {
 	int v2; // esi
@@ -5547,7 +5465,6 @@ void __fastcall ModifyPlrVit(int pnum, int l)
 		NetSendCmdParam1(0, CMD_SETVIT, plr[v4]._pBaseVit);
 }
 
-//----- (004508CF) --------------------------------------------------------
 void __fastcall SetPlayerHitPoints(int pnum, int newhp)
 {
 	int v2; // esi
@@ -5569,7 +5486,6 @@ void __fastcall SetPlayerHitPoints(int pnum, int newhp)
 		drawhpflag = 1;
 }
 
-//----- (0045091E) --------------------------------------------------------
 void __fastcall SetPlrStr(int pnum, int v)
 {
 	int v2; // edi
@@ -5598,7 +5514,6 @@ void __fastcall SetPlrStr(int pnum, int v)
 	plr[v4]._pDamageMod = v5 / v6;
 }
 
-//----- (00450993) --------------------------------------------------------
 void __fastcall SetPlrMag(int pnum, int v)
 {
 	int v2; // edi
@@ -5620,7 +5535,6 @@ void __fastcall SetPlrMag(int pnum, int v)
 	CalcPlrInv(v2, 1u);
 }
 
-//----- (004509DF) --------------------------------------------------------
 void __fastcall SetPlrDex(int pnum, int v)
 {
 	int v2; // edi
@@ -5649,7 +5563,6 @@ void __fastcall SetPlrDex(int pnum, int v)
 	plr[v4]._pDamageMod = v5 / v6;
 }
 
-//----- (00450A54) --------------------------------------------------------
 void __fastcall SetPlrVit(int pnum, int v)
 {
 	int v2; // edi
@@ -5671,7 +5584,6 @@ void __fastcall SetPlrVit(int pnum, int v)
 	CalcPlrInv(v2, 1u);
 }
 
-//----- (00450AA0) --------------------------------------------------------
 void __fastcall InitDungMsgs(int pnum)
 {
 	int v1; // esi
@@ -5682,7 +5594,6 @@ void __fastcall InitDungMsgs(int pnum)
 	plr[v1].pDungMsgs = 0;
 }
 
-//----- (00450AC4) --------------------------------------------------------
 void __cdecl PlayDungMsgs()
 {
 	int v0; // eax

--- a/Source/player.h
+++ b/Source/player.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __PLAYER_H__
+#define __PLAYER_H__
 
-//player
 extern int plr_lframe_size; // idb
 extern int plr_wframe_size; // idb
 extern char plr_gfx_flag; // weak
@@ -134,3 +135,5 @@ extern int MaxStats[3][4];
 extern int ExpLvlsTbl[51];
 extern char *ClassStrTbl[3];
 extern unsigned char fix[9];
+
+#endif /* __PLAYER_H__ */

--- a/Source/plrmsg.cpp
+++ b/Source/plrmsg.cpp
@@ -8,7 +8,6 @@ _plrmsg plr_msgs[8];
 
 text_color text_color_from_player_num[2] = { COL_WHITE, COL_GOLD };
 
-//----- (00450D33) --------------------------------------------------------
 void __fastcall plrmsg_delay(int a1)
 {
 	_plrmsg *pMsg; // eax
@@ -34,7 +33,6 @@ void __fastcall plrmsg_delay(int a1)
 }
 // 69B7D0: using guessed type int plrmsg_ticks;
 
-//----- (00450D6A) --------------------------------------------------------
 char *__fastcall ErrorPlrMsg(char *pszMsg)
 {
 	_plrmsg *pMsg; // esi
@@ -52,7 +50,6 @@ char *__fastcall ErrorPlrMsg(char *pszMsg)
 }
 // 69B7D4: using guessed type char plr_msg_slot;
 
-//----- (00450DB3) --------------------------------------------------------
 size_t EventPlrMsg(char *pszFmt, ...)
 {
 	char *v1; // esi
@@ -69,7 +66,6 @@ size_t EventPlrMsg(char *pszFmt, ...)
 }
 // 69B7D4: using guessed type char plr_msg_slot;
 
-//----- (00450DFA) --------------------------------------------------------
 void __fastcall SendPlrMsg(int pnum, const char *pszStr)
 {
 	_plrmsg *pMsg; // esi
@@ -92,7 +88,6 @@ void __fastcall SendPlrMsg(int pnum, const char *pszStr)
 }
 // 69B7D4: using guessed type char plr_msg_slot;
 
-//----- (00450E64) --------------------------------------------------------
 void __cdecl ClearPlrMsg()
 {
 	_plrmsg *pMsg; // esi
@@ -112,7 +107,6 @@ void __cdecl ClearPlrMsg()
 	while ( v2 );
 }
 
-//----- (00450E8E) --------------------------------------------------------
 void __cdecl InitPlrMsg()
 {
 	memset(plr_msgs, 0, 0x4C0u);
@@ -120,7 +114,6 @@ void __cdecl InitPlrMsg()
 }
 // 69B7D4: using guessed type char plr_msg_slot;
 
-//----- (00450EAA) --------------------------------------------------------
 void __cdecl DrawPlrMsg()
 {
 	int v0; // ebx
@@ -157,7 +150,6 @@ LABEL_9:
 // 4B8968: using guessed type int sbookflag;
 // 69BD04: using guessed type int questlog;
 
-//----- (00450F37) --------------------------------------------------------
 void __fastcall PrintPlrMsg(int no, int x, int y, char *str, int just)
 {
 	char *v5; // edi

--- a/Source/plrmsg.h
+++ b/Source/plrmsg.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __PLRMSG_H__
+#define __PLRMSG_H__
 
-//plrmsg
 extern int plrmsg_ticks; // weak
 extern char plr_msg_slot; // weak
 extern _plrmsg plr_msgs[8];
@@ -17,3 +18,5 @@ void __fastcall PrintPlrMsg(int no, int x, int y, char *str, int just);
 /* data */
 
 extern text_color text_color_from_player_num[2];
+
+#endif /* __PLRMSG_H__ */

--- a/Source/portal.cpp
+++ b/Source/portal.cpp
@@ -8,7 +8,6 @@ int portalindex;
 int WarpDropX[4] = { 57, 59, 61, 63 };
 int WarpDropY[4] = { 40, 40, 40, 40 };
 
-//----- (00450FFE) --------------------------------------------------------
 void __cdecl InitPortals()
 {
 	int i; // edi
@@ -20,7 +19,6 @@ void __cdecl InitPortals()
 	}
 }
 
-//----- (00451024) --------------------------------------------------------
 void __fastcall SetPortalStats(int i, int o, int x, int y, int lvl, int lvltype)
 {
 	portal[i].x = x;
@@ -31,7 +29,6 @@ void __fastcall SetPortalStats(int i, int o, int x, int y, int lvl, int lvltype)
 	portal[i].ltype = lvltype;
 }
 
-//----- (00451062) --------------------------------------------------------
 void __fastcall AddWarpMissile(int i, int x, int y)
 {
 	int mi; // eax
@@ -51,7 +48,6 @@ void __fastcall AddWarpMissile(int i, int x, int y)
 	}
 }
 
-//----- (004510D6) --------------------------------------------------------
 void __cdecl SyncPortals()
 {
 	int v0; // edi
@@ -86,13 +82,11 @@ void __cdecl SyncPortals()
 // 5CF31D: using guessed type char setlevel;
 // 69BD04: using guessed type int questlog;
 
-//----- (00451131) --------------------------------------------------------
 void __fastcall AddInTownPortal(int i)
 {
 	AddWarpMissile(i, WarpDropX[i], WarpDropY[i]);
 }
 
-//----- (00451145) --------------------------------------------------------
 void __fastcall ActivatePortal(int i, int x, int y, int lvl, int lvltype, int sp)
 {
 	portal[i].open = 1;
@@ -107,13 +101,11 @@ void __fastcall ActivatePortal(int i, int x, int y, int lvl, int lvltype, int sp
 	}
 }
 
-//----- (0045118A) --------------------------------------------------------
 void __fastcall DeactivatePortal(int i)
 {
 	portal[i].open = 0;
 }
 
-//----- (00451196) --------------------------------------------------------
 bool __fastcall PortalOnLevel(int i)
 {
 	if ( portal[i].level == currlevel )
@@ -122,7 +114,6 @@ bool __fastcall PortalOnLevel(int i)
 		return currlevel == 0;
 }
 
-//----- (004511B8) --------------------------------------------------------
 void __fastcall RemovePortalMissile(int id)
 {
 	int i; // esi
@@ -144,13 +135,11 @@ void __fastcall RemovePortalMissile(int id)
 	}
 }
 
-//----- (00451234) --------------------------------------------------------
 void __fastcall SetCurrentPortal(int p)
 {
 	portalindex = p;
 }
 
-//----- (0045123B) --------------------------------------------------------
 void __cdecl GetPortalLevel()
 {
 	if ( currlevel )
@@ -187,7 +176,6 @@ void __cdecl GetPortalLevel()
 // 5CCB10: using guessed type char setlvlnum;
 // 5CF31D: using guessed type char setlevel;
 
-//----- (004512E3) --------------------------------------------------------
 void __cdecl GetPortalLvlPos()
 {
 	if ( currlevel )
@@ -208,7 +196,6 @@ void __cdecl GetPortalLvlPos()
 	}
 }
 
-//----- (00451346) --------------------------------------------------------
 bool __fastcall PosOkPortal(int level, int x, int y)
 {
 	int *v3; // eax

--- a/Source/portal.h
+++ b/Source/portal.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __PORTAL_H__
+#define __PORTAL_H__
 
-//portal
 extern PortalStruct portal[4];
 extern int portalindex;
 // int END_portalstruct; // weak
@@ -22,3 +23,5 @@ bool __fastcall PosOkPortal(int level, int x, int y);
 /* rdata */
 extern int WarpDropX[4];
 extern int WarpDropY[4];
+
+#endif /* __PORTAL_H__ */

--- a/Source/quests.cpp
+++ b/Source/quests.cpp
@@ -50,7 +50,6 @@ int QuestGroup2[3] = { QTYPE_BLIND, QTYPE_INFRA, QTYPE_BLOOD };
 int QuestGroup3[3] = { QTYPE_BLKM, QTYPE_ZHAR, QTYPE_ANVIL };
 int QuestGroup4[2] = { QTYPE_VEIL, QTYPE_WARLRD };
 
-//----- (0045138E) --------------------------------------------------------
 void __cdecl InitQuests()
 {
 	char v0; // dl
@@ -185,7 +184,6 @@ void __cdecl InitQuests()
 // 69BD04: using guessed type int questlog;
 // 69BE90: using guessed type int qline;
 
-//----- (0045155C) --------------------------------------------------------
 void __cdecl CheckQuests()
 {
 	//int v0; // eax
@@ -282,7 +280,6 @@ LABEL_29:
 // 679660: using guessed type char gbMaxPlayers;
 // 69BE90: using guessed type int qline;
 
-//----- (0045178F) --------------------------------------------------------
 bool __cdecl ForceQuests()
 {
 	QuestStruct *v0; // eax
@@ -315,7 +312,6 @@ LABEL_10:
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00451831) --------------------------------------------------------
 bool __fastcall QuestStatus(int i)
 {
 	bool result; // al
@@ -332,7 +328,6 @@ bool __fastcall QuestStatus(int i)
 // 5CF31D: using guessed type char setlevel;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00451871) --------------------------------------------------------
 void __fastcall CheckQuestKill(int m, unsigned char sendmsg)
 {
 	int v2; // ecx
@@ -567,13 +562,11 @@ LABEL_10:
 // 52A554: using guessed type int sfxdelay;
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00451BEA) --------------------------------------------------------
 void __cdecl DrawButcher()
 {
 	DRLG_RectTrans(2 * setpc_x + 19, 2 * setpc_y + 19, 2 * setpc_x + 26, 2 * setpc_y + 26);
 }
 
-//----- (00451C11) --------------------------------------------------------
 void __fastcall DrawSkelKing(int quest_id, int xx, int yy)
 {
 	int v3; // eax
@@ -583,7 +576,6 @@ void __fastcall DrawSkelKing(int quest_id, int xx, int yy)
 	quests[v3]._qty = 2 * yy + 23;
 }
 
-//----- (00451C32) --------------------------------------------------------
 void __fastcall DrawWarLord(int xx, int yy)
 {
 	int v2; // esi
@@ -644,7 +636,6 @@ void __fastcall DrawWarLord(int xx, int yy)
 // 5CF330: using guessed type int setpc_h;
 // 5CF334: using guessed type int setpc_w;
 
-//----- (00451CC2) --------------------------------------------------------
 void __fastcall DrawSChamber(int quest_id, int xx, int yy)
 {
 	int v3; // esi
@@ -708,7 +699,6 @@ void __fastcall DrawSChamber(int quest_id, int xx, int yy)
 // 5CF330: using guessed type int setpc_h;
 // 5CF334: using guessed type int setpc_w;
 
-//----- (00451D7C) --------------------------------------------------------
 void __fastcall DrawLTBanner(int xx, int yy)
 {
 	int v2; // ebx
@@ -768,7 +758,6 @@ void __fastcall DrawLTBanner(int xx, int yy)
 // 5CF330: using guessed type int setpc_h;
 // 5CF334: using guessed type int setpc_w;
 
-//----- (00451E08) --------------------------------------------------------
 void __fastcall DrawBlind(int xx, int yy)
 {
 	int v2; // ebx
@@ -828,7 +817,6 @@ void __fastcall DrawBlind(int xx, int yy)
 // 5CF330: using guessed type int setpc_h;
 // 5CF334: using guessed type int setpc_w;
 
-//----- (00451E94) --------------------------------------------------------
 void __fastcall DrawBlood(int xx, int yy)
 {
 	int v2; // ebx
@@ -888,7 +876,6 @@ void __fastcall DrawBlood(int xx, int yy)
 // 5CF330: using guessed type int setpc_h;
 // 5CF334: using guessed type int setpc_w;
 
-//----- (00451F20) --------------------------------------------------------
 void __fastcall DRLG_CheckQuests(int xx, int yy)
 {
 	int v2; // esi
@@ -938,7 +925,6 @@ void __fastcall DRLG_CheckQuests(int xx, int yy)
 }
 // 69BE90: using guessed type int qline;
 
-//----- (00451FB1) --------------------------------------------------------
 void __cdecl SetReturnLvlPos()
 {
 	int v0; // eax
@@ -975,7 +961,6 @@ LABEL_10:
 }
 // 5CCB10: using guessed type char setlvlnum;
 
-//----- (00452064) --------------------------------------------------------
 void __cdecl GetReturnLvlPos()
 {
 	if ( quests[15]._qactive == 3 )
@@ -987,7 +972,6 @@ void __cdecl GetReturnLvlPos()
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0045209D) --------------------------------------------------------
 void __cdecl ResyncMPQuests()
 {
 	if ( quests[12]._qactive == 1
@@ -1013,7 +997,6 @@ void __cdecl ResyncMPQuests()
 		AddObject(OBJ_ALTBOY, 2 * setpc_x + 20, 2 * setpc_y + 22);
 }
 
-//----- (00452159) --------------------------------------------------------
 void __cdecl ResyncQuests()
 {
 	char *v0; // ecx
@@ -1126,7 +1109,6 @@ void __cdecl ResyncQuests()
 // 5CF330: using guessed type int setpc_h;
 // 5CF334: using guessed type int setpc_w;
 
-//----- (0045247F) --------------------------------------------------------
 void __fastcall PrintQLString(int x, int y, unsigned char cjustflag, char *str, int col)
 {
 	int v5; // ebx
@@ -1210,7 +1192,6 @@ LABEL_24:
 }
 // 69BE90: using guessed type int qline;
 
-//----- (004525CD) --------------------------------------------------------
 void __cdecl DrawQuestLog()
 {
 	int v0; // edi
@@ -1229,7 +1210,6 @@ void __cdecl DrawQuestLog()
 }
 // 69BED4: using guessed type int numqlines;
 
-//----- (00452659) --------------------------------------------------------
 void __cdecl StartQuestlog()
 {
 	signed int v0; // eax
@@ -1265,7 +1245,6 @@ void __cdecl StartQuestlog()
 // 69BE90: using guessed type int qline;
 // 69BED4: using guessed type int numqlines;
 
-//----- (004526C9) --------------------------------------------------------
 void __cdecl QuestlogUp()
 {
 	if ( numqlines )
@@ -1288,7 +1267,6 @@ void __cdecl QuestlogUp()
 // 69BE90: using guessed type int qline;
 // 69BED4: using guessed type int numqlines;
 
-//----- (00452710) --------------------------------------------------------
 void __cdecl QuestlogDown()
 {
 	if ( numqlines )
@@ -1311,7 +1289,6 @@ void __cdecl QuestlogDown()
 // 69BE90: using guessed type int qline;
 // 69BED4: using guessed type int numqlines;
 
-//----- (0045275A) --------------------------------------------------------
 void __cdecl QuestlogEnter()
 {
 	PlaySFX(IS_TITLSLCT);
@@ -1323,7 +1300,6 @@ void __cdecl QuestlogEnter()
 // 69BE90: using guessed type int qline;
 // 69BED4: using guessed type int numqlines;
 
-//----- (0045279C) --------------------------------------------------------
 void __cdecl QuestlogESC()
 {
 	int v0; // esi
@@ -1350,7 +1326,6 @@ void __cdecl QuestlogESC()
 // 69BE90: using guessed type int qline;
 // 69BED4: using guessed type int numqlines;
 
-//----- (004527F1) --------------------------------------------------------
 void __fastcall SetMultiQuest(int q, int s, unsigned char l, int v1)
 {
 	int v4; // eax

--- a/Source/quests.h
+++ b/Source/quests.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __QUESTS_H__
+#define __QUESTS_H__
 
-//quests
 extern int qtopline; // idb
 extern int questlog; // weak
 extern void *pQLogCel;
@@ -50,3 +51,5 @@ extern int QuestGroup1[3];
 extern int QuestGroup2[3];
 extern int QuestGroup3[3];
 extern int QuestGroup4[2];
+
+#endif /* __QUESTS_H__ */

--- a/Source/restrict.cpp
+++ b/Source/restrict.cpp
@@ -2,7 +2,6 @@
 
 #include "../types.h"
 
-//----- (00452831) --------------------------------------------------------
 bool __cdecl SystemSupported()
 {
 	bool v0; // di
@@ -20,7 +19,6 @@ bool __cdecl SystemSupported()
 	return v0;
 }
 
-//----- (00452885) --------------------------------------------------------
 bool __cdecl RestrictedTest()
 {
 	bool v0; // si
@@ -45,7 +43,6 @@ bool __cdecl RestrictedTest()
 	return v0;
 }
 
-//----- (004528F7) --------------------------------------------------------
 bool __cdecl ReadOnlyTest()
 {
 	bool v0; // si

--- a/Source/restrict.h
+++ b/Source/restrict.h
@@ -1,5 +1,9 @@
 //HEADER_GOES_HERE
+#ifndef __RESTRICT_H__
+#define __RESTRICT_H__
 
 bool __cdecl SystemSupported();
 bool __cdecl RestrictedTest();
 bool __cdecl ReadOnlyTest();
+
+#endif /* __RESTRICT_H__ */

--- a/Source/scrollrt.cpp
+++ b/Source/scrollrt.cpp
@@ -66,7 +66,6 @@ char *szPlrModeAssert[12] =
 	"quitting"
 };
 
-//----- (0045297A) --------------------------------------------------------
 struct scrollrt_cpp_init
 {
 	scrollrt_cpp_init()
@@ -77,14 +76,12 @@ struct scrollrt_cpp_init
 // 47F238: using guessed type int scrollrt_inf;
 // 69CEFC: using guessed type int scrollrt_cpp_init_value;
 
-//----- (00452985) --------------------------------------------------------
 void __cdecl ClearCursor() // CODE_FIX: this was supposed to be in cursor.cpp
 {
 	sgdwCursWdt = 0;
 	sgdwCursWdtOld = 0;
 }
 
-//----- (00452994) --------------------------------------------------------
 void __fastcall DrawMissile(int x, int y, int sx, int sy, int a5, int a6, int del_flag)
 {
 	int v7; // ebx
@@ -184,7 +181,6 @@ void __fastcall DrawMissile(int x, int y, int sx, int sy, int a5, int a6, int de
 	}
 }
 
-//----- (00452B2A) --------------------------------------------------------
 void __fastcall DrawClippedMissile(int x, int y, int sx, int sy, int a5, int a6, int a7)
 {
 	int v7; // ebx
@@ -284,7 +280,6 @@ void __fastcall DrawClippedMissile(int x, int y, int sx, int sy, int a5, int a6,
 	}
 }
 
-//----- (00452CC0) --------------------------------------------------------
 void __fastcall DrawDeadPlayer(int x, int y, int sx, int sy, int a5, int a6, bool clipped)
 {
 	int v7; // ebx
@@ -323,7 +318,6 @@ LABEL_14:
 	while ( (signed int)v8 < (signed int)&plr[4]._pHitPoints );
 }
 
-//----- (00452DA0) --------------------------------------------------------
 void __fastcall DrawPlayer(int pnum, int x, int y, int px, int py, int animdata, int animframe, int animwidth, int a9, int a10)
 {
 	char *v10; // edx
@@ -405,7 +399,6 @@ void __fastcall DrawPlayer(int pnum, int x, int y, int px, int py, int animdata,
 // 5CF31D: using guessed type char setlevel;
 // 69BEF8: using guessed type int light_table_index;
 
-//----- (00452F8B) --------------------------------------------------------
 void __fastcall DrawClippedPlayer(int pnum, int x, int y, int px, int py, int animdata, int animframe, int animwidth, int a9, int a10)
 {
 	char *v10; // edx
@@ -486,7 +479,6 @@ void __fastcall DrawClippedPlayer(int pnum, int x, int y, int px, int py, int an
 // 4B8CC2: using guessed type char pcursplr;
 // 69BEF8: using guessed type int light_table_index;
 
-//----- (00453160) --------------------------------------------------------
 void __fastcall DrawView(int StartX, int StartY)
 {
 	if ( zoomflag )
@@ -545,7 +537,6 @@ void __fastcall DrawView(int StartX, int StartY)
 // 646D00: using guessed type char qtextflag;
 // 69BD04: using guessed type int questlog;
 
-//----- (00453272) --------------------------------------------------------
 void __fastcall DrawGame(int x, int y)
 {
 	int v2; // esi
@@ -678,7 +669,6 @@ LABEL_15:
 // 69CF0C: using guessed type int screen_buf_end;
 // 69CF20: using guessed type char arch_draw_type;
 
-//----- (00453477) --------------------------------------------------------
 void __fastcall scrollrt_draw_lower(int x, int y, int sx, int sy, int a5, int some_flag)
 {
 	unsigned int v6; // edi
@@ -915,7 +905,6 @@ LABEL_23:
 // 69CF94: using guessed type int cel_transparency_active;
 // 69CF98: using guessed type int level_piece_id;
 
-//----- (004538E2) --------------------------------------------------------
 void __fastcall scrollrt_draw_clipped_dungeon(char *a1, int sx, int sy, int a4, int a5, int a6)
 {
 	int v6; // eax
@@ -1185,7 +1174,6 @@ void __fastcall scrollrt_draw_clipped_dungeon(char *a1, int sx, int sy, int a4, 
 // 69CF94: using guessed type int cel_transparency_active;
 // 69EFA4: using guessed type int draw_monster_num;
 
-//----- (00453ED9) --------------------------------------------------------
 void __fastcall DrawClippedMonster(int x, int y, int a3, int a4, int mon_id, int a6, int a7)
 {
 	int v7; // eax
@@ -1239,7 +1227,6 @@ void __fastcall DrawClippedMonster(int x, int y, int a3, int a4, int mon_id, int
 }
 // 69BEF8: using guessed type int light_table_index;
 
-//----- (00453FCC) --------------------------------------------------------
 void __fastcall DrawClippedObject(int x, int y, int a3, int a4, int pre_flag, int a6, int dir)
 {
 	int v7; // edi
@@ -1306,7 +1293,6 @@ void __fastcall DrawClippedObject(int x, int y, int a3, int a4, int pre_flag, in
 }
 // 4B8CC1: using guessed type char pcursobj;
 
-//----- (004540E5) --------------------------------------------------------
 void __fastcall scrollrt_draw_clipped_e_flag(char *buffer, int x, int y, int a4, int a5)
 {
 	int v5; // eax
@@ -1379,7 +1365,6 @@ void __fastcall scrollrt_draw_clipped_e_flag(char *buffer, int x, int y, int a4,
 // 69CF94: using guessed type int cel_transparency_active;
 // 69CF98: using guessed type int level_piece_id;
 
-//----- (00454229) --------------------------------------------------------
 void __fastcall scrollrt_draw_lower_2(int x, int y, int sx, int sy, int a5, int a6, int some_flag)
 {
 	signed int v7; // ebx
@@ -1585,7 +1570,6 @@ void __fastcall scrollrt_draw_lower_2(int x, int y, int sx, int sy, int a5, int 
 // 69CF94: using guessed type int cel_transparency_active;
 // 69CF98: using guessed type int level_piece_id;
 
-//----- (004545D2) --------------------------------------------------------
 void __fastcall scrollrt_draw_clipped_dungeon_2(char *buffer, int x, int y, int a4, int a5, int sx, int sy, int me_flag)
 {
 	int v8; // eax
@@ -1865,7 +1849,6 @@ void __fastcall scrollrt_draw_clipped_dungeon_2(char *buffer, int x, int y, int 
 // 69CF94: using guessed type int cel_transparency_active;
 // 69EFA4: using guessed type int draw_monster_num;
 
-//----- (00454C09) --------------------------------------------------------
 void __fastcall scrollrt_draw_clipped_e_flag_2(char *buffer, int x, int y, int a4, signed int a5, int sx, int sy)
 {
 	int v7; // eax
@@ -1963,7 +1946,6 @@ LABEL_22:
 // 69CF94: using guessed type int cel_transparency_active;
 // 69CF98: using guessed type int level_piece_id;
 
-//----- (00454D9D) --------------------------------------------------------
 void __fastcall scrollrt_draw_upper(int x, int y, int sx, int sy, int a5, int a6, int some_flag)
 {
 	int v7; // edi
@@ -2198,7 +2180,6 @@ void __fastcall scrollrt_draw_upper(int x, int y, int sx, int sy, int a5, int a6
 // 69CF94: using guessed type int cel_transparency_active;
 // 69CF98: using guessed type int level_piece_id;
 
-//----- (00455217) --------------------------------------------------------
 void __fastcall scrollrt_draw_dungeon(char *buffer, int x, int y, int a4, int a5, int sx, int sy, int me_flag)
 {
 	int v8; // eax
@@ -2468,7 +2449,6 @@ void __fastcall scrollrt_draw_dungeon(char *buffer, int x, int y, int a4, int a5
 // 69CF94: using guessed type int cel_transparency_active;
 // 69EFA4: using guessed type int draw_monster_num;
 
-//----- (00455844) --------------------------------------------------------
 void __fastcall DrawMonster(int x, int y, int a3, int a4, int mon_id, int a6, int a7)
 {
 	int v7; // eax
@@ -2522,7 +2502,6 @@ void __fastcall DrawMonster(int x, int y, int a3, int a4, int mon_id, int a6, in
 }
 // 69BEF8: using guessed type int light_table_index;
 
-//----- (00455937) --------------------------------------------------------
 void __fastcall DrawObject(int x, int y, int a3, int a4, int pre_flag, int a6, int dir)
 {
 	int v7; // edi
@@ -2597,7 +2576,6 @@ void __fastcall DrawObject(int x, int y, int a3, int a4, int pre_flag, int a6, i
 }
 // 4B8CC1: using guessed type char pcursobj;
 
-//----- (00455A7D) --------------------------------------------------------
 void __fastcall scrollrt_draw_e_flag(char *buffer, int x, int y, int a4, int a5, int sx, int sy)
 {
 	int v7; // eax
@@ -2676,7 +2654,6 @@ void __fastcall scrollrt_draw_e_flag(char *buffer, int x, int y, int a4, int a5,
 // 69CF94: using guessed type int cel_transparency_active;
 // 69CF98: using guessed type int level_piece_id;
 
-//----- (00455BD4) --------------------------------------------------------
 void __fastcall DrawZoom(int x, int y)
 {
 	int v2; // edi
@@ -2847,7 +2824,6 @@ LABEL_24:
 // 69CF0C: using guessed type int screen_buf_end;
 // 69CF20: using guessed type char arch_draw_type;
 
-//----- (00455E32) --------------------------------------------------------
 void __cdecl ClearScreenBuffer()
 {
 	int i; // edx
@@ -2982,7 +2958,6 @@ void __cdecl EnableFrameCount()
 }
 #endif
 
-//----- (00455E65) --------------------------------------------------------
 void __fastcall scrollrt_draw_game_screen(bool draw_cursor)
 {
 	int dwHgt; // edi
@@ -3012,7 +2987,6 @@ void __fastcall scrollrt_draw_game_screen(bool draw_cursor)
 }
 // 52571C: using guessed type int drawpanflag;
 
-//----- (00455EC7) --------------------------------------------------------
 void __cdecl scrollrt_draw_cursor_back_buffer()
 {
 	int v0; // edx
@@ -3052,7 +3026,6 @@ void __cdecl scrollrt_draw_cursor_back_buffer()
 	}
 }
 
-//----- (00455F56) --------------------------------------------------------
 void __cdecl scrollrt_draw_cursor_item()
 {
 	int v0; // ebp
@@ -3156,7 +3129,6 @@ void __cdecl scrollrt_draw_cursor_item()
 // 4B8C9C: using guessed type int cursH;
 // 69CF0C: using guessed type int screen_buf_end;
 
-//----- (00456124) --------------------------------------------------------
 void __fastcall DrawMain(int dwHgt, int draw_desc, int draw_hp, int draw_mana, int draw_sbar, int draw_btn)
 {
 	signed int v6; // ebp
@@ -3288,7 +3260,6 @@ void __cdecl DrawFPS()
 }
 #endif
 
-//----- (004563B3) --------------------------------------------------------
 void __fastcall DoBlitScreen(int dwX, int dwY, int dwWdt, int dwHgt)
 {
 	int v4; // esi
@@ -3357,7 +3328,6 @@ void __fastcall DoBlitScreen(int dwX, int dwY, int dwWdt, int dwHgt)
 	}
 }
 
-//----- (004564F9) --------------------------------------------------------
 void __cdecl DrawAndBlit()
 {
 	bool ddsdesc; // ebp

--- a/Source/scrollrt.h
+++ b/Source/scrollrt.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __SCROLLRT_H__
+#define __SCROLLRT_H__
 
-//scrollrt
 extern int light_table_index; // weak
 extern int screen_y_times_768[1024];
 extern int scrollrt_cpp_init_value; // weak
@@ -69,3 +70,5 @@ extern int scrollrt_inf; // weak
 /* used in 1.00 debug */
 extern char *szMonModeAssert[18];
 extern char *szPlrModeAssert[12];
+
+#endif /* __SCROLLRT_H__ */

--- a/Source/setmaps.cpp
+++ b/Source/setmaps.cpp
@@ -47,7 +47,6 @@ char *quest_level_names[] =
   "Archbishop Lazarus' Lair"
 };
 
-//----- (00456625) --------------------------------------------------------
 int __fastcall ObjIndex(int x, int y)
 {
 	int i; // edi
@@ -70,7 +69,6 @@ int __fastcall ObjIndex(int x, int y)
 	return -1;
 }
 
-//----- (0045666B) --------------------------------------------------------
 void __cdecl AddSKingObjs()
 {
 	SetObjMapRange(ObjIndex(64, 34), 20, 7, 23, 10, 1);
@@ -81,14 +79,12 @@ void __cdecl AddSKingObjs()
 	SetObjMapRange(ObjIndex(27, 53), 8, 1, 15, 11, 3);
 }
 
-//----- (0045671A) --------------------------------------------------------
 void __cdecl AddSChamObjs()
 {
 	SetObjMapRange(ObjIndex(37, 30), 17, 0, 21, 5, 1);
 	SetObjMapRange(ObjIndex(37, 46), 13, 0, 16, 5, 2);
 }
 
-//----- (00456755) --------------------------------------------------------
 void __cdecl AddVileObjs()
 {
 	SetObjMapRange(ObjIndex(26, 45), 1, 1, 9, 10, 1);
@@ -96,7 +92,6 @@ void __cdecl AddVileObjs()
 	SetObjMapRange(ObjIndex(35, 36), 7, 11, 13, 18, 3);
 }
 
-//----- (004567AD) --------------------------------------------------------
 void __fastcall DRLG_SetMapTrans(char *sFileName)
 {
 	unsigned char *pLevelMap; // ecx
@@ -144,7 +139,6 @@ void __fastcall DRLG_SetMapTrans(char *sFileName)
 	mem_free_dbg(pLevelMap);
 }
 
-//----- (00456819) --------------------------------------------------------
 void __cdecl LoadSetMap()
 {
 	switch ( setlvlnum )

--- a/Source/setmaps.h
+++ b/Source/setmaps.h
@@ -1,4 +1,6 @@
 //HEADER_GOES_HERE
+#ifndef __SETMAPS_H__
+#define __SETMAPS_H__
 
 int __fastcall ObjIndex(int x, int y);
 void __cdecl AddSKingObjs();
@@ -10,3 +12,5 @@ void __cdecl LoadSetMap();
 /* rdata */
 extern RECT8 QSRects[32];
 extern char *quest_level_names[];
+
+#endif /* __SETMAPS_H__ */

--- a/Source/sha.cpp
+++ b/Source/sha.cpp
@@ -4,13 +4,11 @@
 
 SHA1Context sgSHA1[3];
 
-//----- (00456A16) --------------------------------------------------------
 void __cdecl SHA1Clear()
 {
 	memset(sgSHA1, 0, 0x114u);
 }
 
-//----- (00456A2B) --------------------------------------------------------
 void __fastcall SHA1Result(int n, char Message_Digest[SHA1HashSize])
 {
 	char *v2; // eax
@@ -35,7 +33,6 @@ void __fastcall SHA1Result(int n, char Message_Digest[SHA1HashSize])
 	}
 }
 
-//----- (00456A4D) --------------------------------------------------------
 void __fastcall SHA1Calculate(int n, const char *data, char Message_Digest[SHA1HashSize])
 {
 	int v3; // esi
@@ -46,7 +43,6 @@ void __fastcall SHA1Calculate(int n, const char *data, char Message_Digest[SHA1H
 		SHA1Result(v3, (char *)Message_Digest);
 }
 
-//----- (00456A73) --------------------------------------------------------
 void __fastcall SHA1Input(SHA1Context *context, const char *message_array, int len)
 {
 	SHA1Context *v3; // esi
@@ -77,7 +73,6 @@ void __fastcall SHA1Input(SHA1Context *context, const char *message_array, int l
 	}
 }
 
-//----- (00456AC4) --------------------------------------------------------
 void __fastcall SHA1ProcessMessageBlock(SHA1Context *context)
 {
 	int i; // [esp+158h] [ebp-4h]
@@ -145,7 +140,6 @@ void __fastcall SHA1ProcessMessageBlock(SHA1Context *context)
 	context->state[4] += E;
 }
 
-//----- (00456C82) --------------------------------------------------------
 void __fastcall SHA1Reset(int n)
 {
 	sgSHA1[n].count[0] = 0;

--- a/Source/sha.h
+++ b/Source/sha.h
@@ -1,4 +1,6 @@
 //HEADER_GOES_HERE
+#ifndef __SHA_H__
+#define __SHA_H__
 
 /*
  *  Define the SHA1 circular left shift macro
@@ -16,3 +18,5 @@ void __fastcall SHA1Calculate(int n, const char *data, char Message_Digest[SHA1H
 void __fastcall SHA1Input(SHA1Context *context, const char *message_array, int len);
 void __fastcall SHA1ProcessMessageBlock(SHA1Context *context);
 void __fastcall SHA1Reset(int n);
+
+#endif /* __SHA_H__ */

--- a/Source/sound.cpp
+++ b/Source/sound.cpp
@@ -31,7 +31,6 @@ char *sgszMusicTracks[6] =
 };
 RECT8 QSRect[2] = { { { 15, -16 }, { 15, -16 } }, { { 30, -31 }, { 30, -31 } } }; /* psx version? */
 
-//----- (00456CC0) --------------------------------------------------------
 struct sound_cpp_init
 {
 	sound_cpp_init()
@@ -41,7 +40,6 @@ struct sound_cpp_init
 } _sound_cpp_init;
 // 47F24C: using guessed type int sound_inf;
 
-//----- (00456CCB) --------------------------------------------------------
 void __fastcall snd_update(bool bStopAll)
 {
 	BOOL v1; // edi
@@ -65,7 +63,6 @@ void __fastcall snd_update(bool bStopAll)
 	while ( v2 < 8 );
 }
 
-//----- (00456D22) --------------------------------------------------------
 void __fastcall snd_stop_snd(TSnd *pSnd)
 {
 	IDirectSoundBuffer *v1; // eax
@@ -78,7 +75,6 @@ void __fastcall snd_stop_snd(TSnd *pSnd)
 	}
 }
 
-//----- (00456D34) --------------------------------------------------------
 bool __fastcall snd_playing(TSnd *pSnd)
 {
 	IDirectSoundBuffer *v1; // eax
@@ -99,7 +95,6 @@ bool __fastcall snd_playing(TSnd *pSnd)
 	return result;
 }
 
-//----- (00456D60) --------------------------------------------------------
 void __fastcall snd_play_snd(TSnd *pSnd, int lVolume, int lPan)
 {
 	TSnd *v3; // edi
@@ -162,7 +157,6 @@ void __fastcall snd_play_snd(TSnd *pSnd, int lVolume, int lPan)
 }
 // 4A22D5: using guessed type char gbSoundOn;
 
-//----- (00456E39) --------------------------------------------------------
 IDirectSoundBuffer *__fastcall sound_dup_channel(IDirectSoundBuffer *DSB)
 {
 	IDirectSoundBuffer *result; // eax
@@ -188,7 +182,6 @@ IDirectSoundBuffer *__fastcall sound_dup_channel(IDirectSoundBuffer *DSB)
 }
 // 4A22D6: using guessed type char gbDupSounds;
 
-//----- (00456E74) --------------------------------------------------------
 bool __fastcall sound_file_reload(TSnd *sound_file, IDirectSoundBuffer *DSB)
 {
 	IDirectSoundBuffer *v2; // edi
@@ -219,7 +212,6 @@ bool __fastcall sound_file_reload(TSnd *sound_file, IDirectSoundBuffer *DSB)
 	return v8;
 }
 
-//----- (00456F07) --------------------------------------------------------
 TSnd *__fastcall sound_file_load(char *path)
 {
 //	int v1; // esi
@@ -261,7 +253,6 @@ TSnd *__fastcall sound_file_load(char *path)
 }
 // 456F07: could not find valid save-restore pair for esi
 
-//----- (00457003) --------------------------------------------------------
 void __fastcall sound_CreateSoundBuffer(TSnd *sound_file)
 {
 	TSnd *v1; // esi
@@ -279,7 +270,6 @@ void __fastcall sound_CreateSoundBuffer(TSnd *sound_file)
 		DSErrDlg(v2, 282, "C:\\Src\\Diablo\\Source\\SOUND.CPP");
 }
 
-//----- (00457060) --------------------------------------------------------
 void __fastcall sound_file_cleanup(TSnd *sound_file)
 {
 	TSnd *v1; // esi
@@ -299,7 +289,6 @@ void __fastcall sound_file_cleanup(TSnd *sound_file)
 	}
 }
 
-//----- (0045708B) --------------------------------------------------------
 void __fastcall snd_init(HWND hWnd)
 {
 	sound_load_volume("Sound Volume", &sglSoundVolume);
@@ -317,7 +306,6 @@ void __fastcall snd_init(HWND hWnd)
 // 4A22D4: using guessed type char gbMusicOn;
 // 4A22D5: using guessed type char gbSoundOn;
 
-//----- (0045712B) --------------------------------------------------------
 void __fastcall sound_load_volume(char *value_name, int *value)
 {
 	int *v2; // esi
@@ -345,7 +333,6 @@ void __fastcall sound_load_volume(char *value_name, int *value)
 	*v2 -= *v2 % 100;
 }
 
-//----- (0045717C) --------------------------------------------------------
 void __fastcall sound_create_primary_buffer(int music_track)
 {
 	int v1; // eax
@@ -387,7 +374,6 @@ void __fastcall sound_create_primary_buffer(int music_track)
 }
 // 69F100: using guessed type int sglpDSB;
 
-//----- (0045727E) --------------------------------------------------------
 int __fastcall sound_DirectSoundCreate(GUID *guid, IDirectSound **DS, int always_null)
 {
 	IDirectSound **v3; // ebp
@@ -416,7 +402,6 @@ int __fastcall sound_DirectSoundCreate(GUID *guid, IDirectSound **DS, int always
 	return ((int (__stdcall *)(GUID *, IDirectSound **, int))v5)(v8, v3, always_null);
 }
 
-//----- (004572FF) --------------------------------------------------------
 void __cdecl sound_cleanup()
 {
 	snd_update(1);
@@ -435,13 +420,11 @@ void __cdecl sound_cleanup()
 	}
 }
 
-//----- (00457358) --------------------------------------------------------
 void __fastcall sound_store_volume(char *key, int value)
 {
 	SRegSaveValue("Diablo", key, 0, value);
 }
 
-//----- (00457367) --------------------------------------------------------
 void __cdecl music_stop()
 {
 	if ( sgpMusicTrack )
@@ -453,7 +436,6 @@ void __cdecl music_stop()
 	}
 }
 
-//----- (00457393) --------------------------------------------------------
 void __fastcall music_start(int nTrack)
 {
 	//int v1; // esi
@@ -480,7 +462,6 @@ void __fastcall music_start(int nTrack)
 }
 // 4A22D4: using guessed type char gbMusicOn;
 
-//----- (004573FE) --------------------------------------------------------
 void __fastcall sound_disable_music(bool disable)
 {
 	if ( disable )
@@ -493,7 +474,6 @@ void __fastcall sound_disable_music(bool disable)
 	}
 }
 
-//----- (00457418) --------------------------------------------------------
 int __fastcall sound_get_or_set_music_volume(int volume)
 {
 	if ( volume != 1 )
@@ -505,7 +485,6 @@ int __fastcall sound_get_or_set_music_volume(int volume)
 	return sglMusicVolume;
 }
 
-//----- (0045743B) --------------------------------------------------------
 int __fastcall sound_get_or_set_sound_volume(int volume)
 {
 	int result; // eax

--- a/Source/sound.h
+++ b/Source/sound.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __SOUND_H__
+#define __SOUND_H__
 
-//sound
 extern float sound_cpp_init_value;
 extern IDirectSoundBuffer *DSBs[8];
 extern IDirectSound *sglpDS;
@@ -45,3 +46,5 @@ extern char gbDupSounds; // weak
 extern int sgnMusicTrack;
 extern char *sgszMusicTracks[6];
 extern RECT8 QSRect[2]; /* psx version? */
+
+#endif /* __SOUND_H__ */

--- a/Source/spells.cpp
+++ b/Source/spells.cpp
@@ -43,7 +43,6 @@ SpellData spelldata[37] =
 	{ SPL_BONESPIRIT,  24,  STYPE_MAGIC,	 "Bone Spirit",	 NULL,			 9,  7,  0, 0, 34,  IS_CAST2, { MIS_BONESPIRIT,  0,		  0 }, 1, 12,  20, 60, 11500, 800 }
 };
 
-//----- (0045744E) --------------------------------------------------------
 int __fastcall GetManaAmount(int id, int sn)
 {
 	int v2; // eax
@@ -90,7 +89,6 @@ int __fastcall GetManaAmount(int id, int sn)
 	return v8 * (100 - plr[v2]._pISplCost) / 100;
 }
 
-//----- (0045753A) --------------------------------------------------------
 void __fastcall UseMana(int id, int sn)
 {
 	int v2; // esi
@@ -124,7 +122,6 @@ void __fastcall UseMana(int id, int sn)
 	}
 }
 
-//----- (00457584) --------------------------------------------------------
 bool __fastcall CheckSpell(int id, int sn, char st, bool manaonly)
 {
 	bool result; // al
@@ -149,7 +146,6 @@ bool __fastcall CheckSpell(int id, int sn, char st, bool manaonly)
 	return result;
 }
 
-//----- (004575D5) --------------------------------------------------------
 void __fastcall CastSpell(int id, int spl, int sx, int sy, int dx, int dy, int caster, int spllvl)
 {
 	int v8; // eax
@@ -206,7 +202,6 @@ LABEL_7:
 	}
 }
 
-//----- (004576B1) --------------------------------------------------------
 void __fastcall DoResurrect(int pnum, int rid)
 {
 	int v2; // ebx
@@ -254,7 +249,6 @@ void __fastcall DoResurrect(int pnum, int rid)
 	}
 }
 
-//----- (004577CB) --------------------------------------------------------
 void __fastcall PlacePlayer(int pnum)
 {
 	int v1; // ebx
@@ -330,7 +324,6 @@ void __fastcall PlacePlayer(int pnum)
 	}
 }
 
-//----- (004578EE) --------------------------------------------------------
 void __fastcall DoHealOther(int pnum, int rid)
 {
 	int v2; // ebx

--- a/Source/spells.h
+++ b/Source/spells.h
@@ -1,4 +1,6 @@
 //HEADER_GOES_HERE
+#ifndef __SPELLS_H__
+#define __SPELLS_H__
 
 int __fastcall GetManaAmount(int id, int sn);
 void __fastcall UseMana(int id, int sn);
@@ -11,3 +13,5 @@ void __fastcall DoHealOther(int pnum, int rid);
 /* rdata */
 
 extern SpellData spelldata[37];
+
+#endif /* __SPELLS_H__ */

--- a/Source/stores.cpp
+++ b/Source/stores.cpp
@@ -76,7 +76,6 @@ char *talkname[9] =
   "Wirt"
 };
 
-//----- (00457A01) --------------------------------------------------------
 void __cdecl InitStores()
 {
 	int i; // eax
@@ -104,7 +103,6 @@ void __cdecl InitStores()
 // 6A8A3C: using guessed type int boylevel;
 // 6AA705: using guessed type char stextflag;
 
-//----- (00457A87) --------------------------------------------------------
 void __cdecl SetupTownStores()
 {
 	int i; // eax
@@ -138,7 +136,6 @@ void __cdecl SetupTownStores()
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00457B42) --------------------------------------------------------
 void __cdecl FreeStoreMem()
 {
 	void *v0; // ecx
@@ -156,7 +153,6 @@ void __cdecl FreeStoreMem()
 	mem_free_dbg(v2);
 }
 
-//----- (00457B78) --------------------------------------------------------
 void __cdecl DrawSTextBack()
 {
 	char *v0; // edi
@@ -206,7 +202,6 @@ void __cdecl DrawSTextBack()
 	*v0 = 0;
 }
 
-//----- (00457BD6) --------------------------------------------------------
 void __fastcall PrintSString(int x, int y, unsigned char cjustflag, char *str, int col, int val)
 {
 	int v6; // edi
@@ -317,7 +312,6 @@ void __fastcall PrintSString(int x, int y, unsigned char cjustflag, char *str, i
 // 6A8A28: using guessed type int stextsel;
 // 457BD6: using guessed type char valstr[32];
 
-//----- (00457DE2) --------------------------------------------------------
 void __fastcall DrawSLine(int y)
 {
 	int v1; // eax
@@ -363,7 +357,6 @@ void __fastcall DrawSLine(int y)
 }
 // 6A09E0: using guessed type char stextsize;
 
-//----- (00457E62) --------------------------------------------------------
 void __fastcall DrawSArrows(int a1, int a2)
 {
 	int *v2; // ebp
@@ -408,7 +401,6 @@ void __fastcall DrawSArrows(int a1, int a2)
 // 6A8A2C: using guessed type char stextscrldbtn;
 // 6AA704: using guessed type char stextscrlubtn;
 
-//----- (00457F52) --------------------------------------------------------
 void __cdecl DrawSTextHelp()
 {
 	stextsel = -1;
@@ -417,7 +409,6 @@ void __cdecl DrawSTextHelp()
 // 6A09E0: using guessed type char stextsize;
 // 6A8A28: using guessed type int stextsel;
 
-//----- (00457F61) --------------------------------------------------------
 void __fastcall ClearSText(int s, int e)
 {
 	int v2; // edx
@@ -444,7 +435,6 @@ void __fastcall ClearSText(int s, int e)
 	}
 }
 
-//----- (00457FA6) --------------------------------------------------------
 void __fastcall AddSLine(int y)
 {
 	int v1; // ecx
@@ -456,19 +446,16 @@ void __fastcall AddSLine(int y)
 	stext[v1]._sline = 1;
 }
 
-//----- (00457FCB) --------------------------------------------------------
 void __fastcall AddSTextVal(int y, int val)
 {
 	stext[y]._sval = val;
 }
 
-//----- (00457FD8) --------------------------------------------------------
 void __fastcall OffsetSTextY(int y, int yo)
 {
 	stext[y]._syoff = yo;
 }
 
-//----- (00457FE5) --------------------------------------------------------
 void __fastcall AddSText(int x, int y, unsigned char j, char *str, int clr, int sel)
 {
 	int v6; // esi
@@ -483,7 +470,6 @@ void __fastcall AddSText(int x, int y, unsigned char j, char *str, int clr, int 
 	stext[v6]._ssel = sel;
 }
 
-//----- (00458036) --------------------------------------------------------
 void __cdecl StoreAutoPlace()
 {
 	int v0; // edi
@@ -684,7 +670,6 @@ LABEL_50:
 }
 // 48E9A8: using guessed type int AP2x2Tbl[10];
 
-//----- (004582B3) --------------------------------------------------------
 void __cdecl S_StartSmith()
 {
 	stextsize = 0;
@@ -705,7 +690,6 @@ void __cdecl S_StartSmith()
 // 6A09E0: using guessed type char stextsize;
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (0045837D) --------------------------------------------------------
 void __fastcall S_ScrollSBuy(int idx)
 {
 	int v1; // esi
@@ -747,7 +731,6 @@ void __fastcall S_ScrollSBuy(int idx)
 // 6A8A28: using guessed type int stextsel;
 // 6AA700: using guessed type int stextdown;
 
-//----- (00458439) --------------------------------------------------------
 void __fastcall PrintStoreItem(ItemStruct *x, int l, char iclr)
 {
 	ItemStruct *v3; // esi
@@ -839,7 +822,6 @@ void __fastcall PrintStoreItem(ItemStruct *x, int l, char iclr)
 	}
 }
 
-//----- (004586B3) --------------------------------------------------------
 void __cdecl S_StartSBuy()
 {
 	int v0; // ST10_4
@@ -879,7 +861,6 @@ void __cdecl S_StartSBuy()
 // 6A09E4: using guessed type int stextsmax;
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (00458773) --------------------------------------------------------
 void __fastcall S_ScrollSPBuy(int idx)
 {
 	int v1; // esi
@@ -940,7 +921,6 @@ void __fastcall S_ScrollSPBuy(int idx)
 // 6A8A28: using guessed type int stextsel;
 // 6AA700: using guessed type int stextdown;
 
-//----- (00458851) --------------------------------------------------------
 bool __cdecl S_StartSPBuy()
 {
 	int *v0; // eax
@@ -989,7 +969,6 @@ bool __cdecl S_StartSPBuy()
 // 6A6BB8: using guessed type int stextscrl;
 // 6A8A28: using guessed type int stextsel;
 
-//----- (00458931) --------------------------------------------------------
 bool __fastcall SmithSellOk(int i)
 {
 	if ( plr[myplr].InvList[i]._itype != ITYPE_NONE
@@ -1002,7 +981,6 @@ bool __fastcall SmithSellOk(int i)
 		return 0;
 }
 
-//----- (00458972) --------------------------------------------------------
 void __fastcall S_ScrollSSell(int idx)
 {
 	int v1; // esi
@@ -1057,7 +1035,6 @@ void __fastcall S_ScrollSSell(int idx)
 // 6A09E4: using guessed type int stextsmax;
 // 6AA700: using guessed type int stextdown;
 
-//----- (00458A59) --------------------------------------------------------
 void __cdecl S_StartSSell()
 {
 	int i; // eax
@@ -1117,7 +1094,6 @@ void __cdecl S_StartSSell()
 // 6A09E4: using guessed type int stextsmax;
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (00458C0B) --------------------------------------------------------
 bool __fastcall SmithRepairOk(int i)
 {
 	if ( plr[myplr].InvList[i]._itype != ITYPE_NONE
@@ -1129,7 +1105,6 @@ bool __fastcall SmithRepairOk(int i)
 		return 0;
 }
 
-//----- (00458C4E) --------------------------------------------------------
 void __cdecl S_StartSRepair()
 {
 	int v0; // ebp
@@ -1236,7 +1211,6 @@ void __cdecl S_StartSRepair()
 // 6A09E4: using guessed type int stextsmax;
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (00458E9A) --------------------------------------------------------
 void __fastcall AddStoreHoldRepair(ItemStruct *itm, int i)
 {
 	int v2; // ebx
@@ -1266,7 +1240,6 @@ void __fastcall AddStoreHoldRepair(ItemStruct *itm, int i)
 }
 // 69F10C: using guessed type int storenumh;
 
-//----- (00458F3D) --------------------------------------------------------
 void __cdecl S_StartWitch()
 {
 	stextsize = 0;
@@ -1285,7 +1258,6 @@ void __cdecl S_StartWitch()
 // 6A09E0: using guessed type char stextsize;
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (00458FE3) --------------------------------------------------------
 void __fastcall S_ScrollWBuy(int idx)
 {
 	int v1; // esi
@@ -1327,7 +1299,6 @@ void __fastcall S_ScrollWBuy(int idx)
 // 6A8A28: using guessed type int stextsel;
 // 6AA700: using guessed type int stextdown;
 
-//----- (0045909F) --------------------------------------------------------
 void __cdecl S_StartWBuy()
 {
 	int v0; // ST10_4
@@ -1368,7 +1339,6 @@ void __cdecl S_StartWBuy()
 // 6A09E4: using guessed type int stextsmax;
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (00459169) --------------------------------------------------------
 bool __fastcall WitchSellOk(int i)
 {
 	bool rv; // al
@@ -1392,7 +1362,6 @@ bool __fastcall WitchSellOk(int i)
 	return rv;
 }
 
-//----- (004591C4) --------------------------------------------------------
 void __cdecl S_StartWSell()
 {
 	int i; // eax
@@ -1469,7 +1438,6 @@ void __cdecl S_StartWSell()
 // 6A09E4: using guessed type int stextsmax;
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (00459431) --------------------------------------------------------
 bool __fastcall WitchRechargeOk(int i)
 {
 	bool rv; // al
@@ -1483,7 +1451,6 @@ bool __fastcall WitchRechargeOk(int i)
 	return rv;
 }
 
-//----- (00459460) --------------------------------------------------------
 void __fastcall AddStoreHoldRecharge(ItemStruct itm, int i)
 {
 	int v2; // ebx
@@ -1511,7 +1478,6 @@ void __fastcall AddStoreHoldRecharge(ItemStruct itm, int i)
 // 69F108: using guessed type int stextup;
 // 69F10C: using guessed type int storenumh;
 
-//----- (004594E6) --------------------------------------------------------
 void __cdecl S_StartWRecharge()
 {
 	int *v0; // eax
@@ -1589,7 +1555,6 @@ void __cdecl S_StartWRecharge()
 // 6A09E4: using guessed type int stextsmax;
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (00459693) --------------------------------------------------------
 void __cdecl S_StartNoMoney()
 {
 	StartStore((unsigned char)stextshold);
@@ -1601,7 +1566,6 @@ void __cdecl S_StartNoMoney()
 // 6A09E0: using guessed type char stextsize;
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (004596CD) --------------------------------------------------------
 void __cdecl S_StartNoRoom()
 {
 	StartStore((unsigned char)stextshold);
@@ -1611,7 +1575,6 @@ void __cdecl S_StartNoRoom()
 }
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (00459700) --------------------------------------------------------
 void __cdecl S_StartConfirm()
 {
 	BOOL idprint; // esi
@@ -1697,7 +1660,6 @@ LABEL_37:
 }
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (00459873) --------------------------------------------------------
 void __cdecl S_StartBoy()
 {
 	stextsize = 0;
@@ -1722,7 +1684,6 @@ void __cdecl S_StartBoy()
 // 6A09E0: using guessed type char stextsize;
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (00459930) --------------------------------------------------------
 void __cdecl S_StartBBoy()
 {
 	int iclr; // esi
@@ -1752,7 +1713,6 @@ void __cdecl S_StartBBoy()
 // 6A09E0: using guessed type char stextsize;
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (004599FD) --------------------------------------------------------
 void __cdecl S_StartHealer()
 {
 	stextsize = 0;
@@ -1771,7 +1731,6 @@ void __cdecl S_StartHealer()
 // 6A09E0: using guessed type char stextsize;
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (00459AA5) --------------------------------------------------------
 void __fastcall S_ScrollHBuy(int idx)
 {
 	int v1; // esi
@@ -1807,7 +1766,6 @@ void __fastcall S_ScrollHBuy(int idx)
 // 6A8A28: using guessed type int stextsel;
 // 6AA700: using guessed type int stextdown;
 
-//----- (00459B55) --------------------------------------------------------
 void __cdecl S_StartHBuy()
 {
 	int v0; // ST10_4
@@ -1847,7 +1805,6 @@ void __cdecl S_StartHBuy()
 // 6A09E4: using guessed type int stextsmax;
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (00459C15) --------------------------------------------------------
 void __cdecl S_StartStory()
 {
 	stextsize = 0;
@@ -1862,7 +1819,6 @@ void __cdecl S_StartStory()
 // 6A09E0: using guessed type char stextsize;
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (00459C8E) --------------------------------------------------------
 bool __fastcall IdItemOk(ItemStruct *i)
 {
 	bool result; // al
@@ -1876,7 +1832,6 @@ bool __fastcall IdItemOk(ItemStruct *i)
 	return result;
 }
 
-//----- (00459CA2) --------------------------------------------------------
 void __fastcall AddStoreHoldId(ItemStruct itm, int i)
 {
 	qmemcpy(&storehold[storenumh], &itm, sizeof(ItemStruct));
@@ -1887,7 +1842,6 @@ void __fastcall AddStoreHoldId(ItemStruct itm, int i)
 // 69F108: using guessed type int stextup;
 // 69F10C: using guessed type int storenumh;
 
-//----- (00459CE6) --------------------------------------------------------
 void __cdecl S_StartSIdentify()
 {
 	ItemStruct itm; // [esp-170h] [ebp-18Ch]
@@ -1982,7 +1936,6 @@ void __cdecl S_StartSIdentify()
 // 6A09E4: using guessed type int stextsmax;
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (00459F95) --------------------------------------------------------
 void __cdecl S_StartIdShow()
 {
 	char iclr; // [esp+4h] [ebp-4h]
@@ -2004,7 +1957,6 @@ void __cdecl S_StartIdShow()
 }
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (0045A046) --------------------------------------------------------
 void __cdecl S_StartTalk()
 {
 	int *v0; // edi
@@ -2069,7 +2021,6 @@ void __cdecl S_StartTalk()
 // 6A09E0: using guessed type char stextsize;
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (0045A168) --------------------------------------------------------
 void __cdecl S_StartTavern()
 {
 	stextsize = 0;
@@ -2086,7 +2037,6 @@ void __cdecl S_StartTavern()
 // 6A09E0: using guessed type char stextsize;
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (0045A1EC) --------------------------------------------------------
 void __cdecl S_StartBarMaid()
 {
 	stextsize = 0;
@@ -2102,7 +2052,6 @@ void __cdecl S_StartBarMaid()
 // 6A09E0: using guessed type char stextsize;
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (0045A25E) --------------------------------------------------------
 void __cdecl S_StartDrunk()
 {
 	stextsize = 0;
@@ -2118,7 +2067,6 @@ void __cdecl S_StartDrunk()
 // 6A09E0: using guessed type char stextsize;
 // 6A6BB8: using guessed type int stextscrl;
 
-//----- (0045A2D0) --------------------------------------------------------
 void __fastcall StartStore(char s)
 {
 	char t; // bl
@@ -2231,7 +2179,6 @@ void __fastcall StartStore(char s)
 // 6A8A28: using guessed type int stextsel;
 // 6AA705: using guessed type char stextflag;
 
-//----- (0045A48F) --------------------------------------------------------
 void __cdecl DrawSText()
 {
 	int i; // edi
@@ -2296,7 +2243,6 @@ LABEL_19:
 // 6A6BB8: using guessed type int stextscrl;
 // 6AA705: using guessed type char stextflag;
 
-//----- (0045A584) --------------------------------------------------------
 void __cdecl STextESC()
 {
 	char v0; // cl
@@ -2387,7 +2333,6 @@ LABEL_18:
 // 6A8A28: using guessed type int stextsel;
 // 6AA705: using guessed type char stextflag;
 
-//----- (0045A6AF) --------------------------------------------------------
 void __cdecl STextUp()
 {
 	int v0; // eax
@@ -2442,7 +2387,6 @@ LABEL_20:
 // 6A6BB8: using guessed type int stextscrl;
 // 6A8A28: using guessed type int stextsel;
 
-//----- (0045A757) --------------------------------------------------------
 void __cdecl STextDown()
 {
 	int v0; // eax
@@ -2498,7 +2442,6 @@ LABEL_20:
 // 6A8A28: using guessed type int stextsel;
 // 6AA700: using guessed type int stextdown;
 
-//----- (0045A804) --------------------------------------------------------
 void __cdecl STextPrior()
 {
 	PlaySFX(IS_TITLEMOV);
@@ -2523,7 +2466,6 @@ void __cdecl STextPrior()
 // 6A6BB8: using guessed type int stextscrl;
 // 6A8A28: using guessed type int stextsel;
 
-//----- (0045A84E) --------------------------------------------------------
 void __cdecl STextNext()
 {
 	PlaySFX(IS_TITLEMOV);
@@ -2547,7 +2489,6 @@ void __cdecl STextNext()
 // 6A8A28: using guessed type int stextsel;
 // 6AA700: using guessed type int stextdown;
 
-//----- (0045A89B) --------------------------------------------------------
 void __cdecl S_SmithEnter()
 {
 	int v0; // ecx
@@ -2591,7 +2532,6 @@ LABEL_13:
 // 6A8A30: using guessed type int gossipend;
 // 6AA705: using guessed type char stextflag;
 
-//----- (0045A904) --------------------------------------------------------
 void __fastcall SetGoldCurs(int pnum, int i)
 {
 	if ( plr[pnum].InvList[i]._ivalue < 2500 )
@@ -2607,7 +2547,6 @@ void __fastcall SetGoldCurs(int pnum, int i)
 	}
 }
 
-//----- (0045A94A) --------------------------------------------------------
 void __fastcall SetSpdbarGoldCurs(int pnum, int i)
 {
 	if ( plr[pnum].SpdList[i]._ivalue < 2500 )
@@ -2623,7 +2562,6 @@ void __fastcall SetSpdbarGoldCurs(int pnum, int i)
 	}
 }
 
-//----- (0045A990) --------------------------------------------------------
 void __fastcall TakePlrsMoney(int cost)
 {
 	int v1; // edi
@@ -2792,7 +2730,6 @@ LABEL_26:
 }
 // 52571C: using guessed type int drawpanflag;
 
-//----- (0045AB69) --------------------------------------------------------
 void __cdecl SmithBuyItem()
 {
 	int idx; // eax
@@ -2832,7 +2769,6 @@ void __cdecl SmithBuyItem()
 // 69F110: using guessed type int stextlhold;
 // 6A8A24: using guessed type int stextvhold;
 
-//----- (0045AC14) --------------------------------------------------------
 void __cdecl S_SBuyEnter()
 {
 	int v0; // eax
@@ -2889,7 +2825,6 @@ LABEL_11:
 // 6A8A24: using guessed type int stextvhold;
 // 6A8A28: using guessed type int stextsel;
 
-//----- (0045ACE9) --------------------------------------------------------
 void __cdecl SmithBuyPItem()
 {
 	int xx; // ecx
@@ -2929,7 +2864,6 @@ void __cdecl SmithBuyPItem()
 // 69F110: using guessed type int stextlhold;
 // 6A8A24: using guessed type int stextvhold;
 
-//----- (0045AD7E) --------------------------------------------------------
 void __cdecl S_SPBuyEnter()
 {
 	int v0; // eax
@@ -3012,7 +2946,6 @@ LABEL_16:
 // 6A8A24: using guessed type int stextvhold;
 // 6A8A28: using guessed type int stextsel;
 
-//----- (0045AE72) --------------------------------------------------------
 bool __fastcall StoreGoldFit(int idx)
 {
 	int cost; // edi
@@ -3057,7 +2990,6 @@ bool __fastcall StoreGoldFit(int idx)
 }
 // 4B8C9C: using guessed type int cursH;
 
-//----- (0045AF48) --------------------------------------------------------
 void __fastcall PlaceStoreGold(int v)
 {
 	bool done; // ecx
@@ -3088,7 +3020,6 @@ void __fastcall PlaceStoreGold(int v)
 	}
 }
 
-//----- (0045B010) --------------------------------------------------------
 void __cdecl StoreSellItem()
 {
 	int idx; // ebx
@@ -3175,7 +3106,6 @@ LABEL_15:
 // 69F110: using guessed type int stextlhold;
 // 6A8A24: using guessed type int stextvhold;
 
-//----- (0045B160) --------------------------------------------------------
 void __cdecl S_SSellEnter()
 {
 	int idx; // eax
@@ -3205,7 +3135,6 @@ void __cdecl S_SSellEnter()
 // 6A8A24: using guessed type int stextvhold;
 // 6A8A28: using guessed type int stextsel;
 
-//----- (0045B1DF) --------------------------------------------------------
 void __cdecl SmithRepairItem()
 {
 	int i; // edx
@@ -3237,7 +3166,6 @@ void __cdecl SmithRepairItem()
 // 69F110: using guessed type int stextlhold;
 // 6A8A24: using guessed type int stextvhold;
 
-//----- (0045B2B6) --------------------------------------------------------
 void __cdecl S_SRepairEnter()
 {
 	int idx; // eax
@@ -3274,7 +3202,6 @@ void __cdecl S_SRepairEnter()
 // 6A8A24: using guessed type int stextvhold;
 // 6A8A28: using guessed type int stextsel;
 
-//----- (0045B337) --------------------------------------------------------
 void __cdecl S_WitchEnter()
 {
 	int v0; // ecx
@@ -3316,7 +3243,6 @@ LABEL_12:
 // 6A8A30: using guessed type int gossipend;
 // 6AA705: using guessed type char stextflag;
 
-//----- (0045B39F) --------------------------------------------------------
 void __cdecl WitchBuyItem()
 {
 	int idx; // ebx
@@ -3360,7 +3286,6 @@ void __cdecl WitchBuyItem()
 // 69F110: using guessed type int stextlhold;
 // 6A8A24: using guessed type int stextvhold;
 
-//----- (0045B457) --------------------------------------------------------
 void __cdecl S_WBuyEnter()
 {
 	int idx; // ecx
@@ -3411,7 +3336,6 @@ void __cdecl S_WBuyEnter()
 // 6A8A24: using guessed type int stextvhold;
 // 6A8A28: using guessed type int stextsel;
 
-//----- (0045B52C) --------------------------------------------------------
 void __cdecl S_WSellEnter()
 {
 	int idx; // eax
@@ -3440,7 +3364,6 @@ void __cdecl S_WSellEnter()
 // 6A8A24: using guessed type int stextvhold;
 // 6A8A28: using guessed type int stextsel;
 
-//----- (0045B5AB) --------------------------------------------------------
 void __cdecl WitchRechargeItem()
 {
 	int i; // ecx
@@ -3463,7 +3386,6 @@ void __cdecl WitchRechargeItem()
 // 69F110: using guessed type int stextlhold;
 // 6A8A24: using guessed type int stextvhold;
 
-//----- (0045B634) --------------------------------------------------------
 void __cdecl S_WRechargeEnter()
 {
 	int idx; // eax
@@ -3500,7 +3422,6 @@ void __cdecl S_WRechargeEnter()
 // 6A8A24: using guessed type int stextvhold;
 // 6A8A28: using guessed type int stextsel;
 
-//----- (0045B6B5) --------------------------------------------------------
 void __cdecl S_BoyEnter()
 {
 	signed int v0; // ecx
@@ -3545,7 +3466,6 @@ LABEL_5:
 // 6A8A30: using guessed type int gossipend;
 // 6AA705: using guessed type char stextflag;
 
-//----- (0045B757) --------------------------------------------------------
 void __cdecl BoyBuyItem()
 {
 	TakePlrsMoney(plr[myplr].HoldItem._iIvalue);
@@ -3555,7 +3475,6 @@ void __cdecl BoyBuyItem()
 	CalcPlrInv(myplr, 1u);
 }
 
-//----- (0045B791) --------------------------------------------------------
 void __cdecl HealerBuyItem()
 {
 	int idx; // esi
@@ -3637,7 +3556,6 @@ void __cdecl HealerBuyItem()
 // 69F110: using guessed type int stextlhold;
 // 6A8A24: using guessed type int stextvhold;
 
-//----- (0045B895) --------------------------------------------------------
 void __cdecl S_BBuyEnter()
 {
 	int v0; // ecx
@@ -3695,7 +3613,6 @@ LABEL_10:
 // 6A8A28: using guessed type int stextsel;
 // 6AA705: using guessed type char stextflag;
 
-//----- (0045B968) --------------------------------------------------------
 void __cdecl StoryIdItem()
 {
 	int v0; // ecx
@@ -3734,7 +3651,6 @@ void __cdecl StoryIdItem()
 // 69F110: using guessed type int stextlhold;
 // 6A8A24: using guessed type int stextvhold;
 
-//----- (0045BA57) --------------------------------------------------------
 void __cdecl S_ConfirmEnter()
 {
 	char v0; // cl
@@ -3797,7 +3713,6 @@ LABEL_27:
 // 6A8A24: using guessed type int stextvhold;
 // 6A8A28: using guessed type int stextsel;
 
-//----- (0045BAF7) --------------------------------------------------------
 void __cdecl S_HealerEnter()
 {
 	int v0; // ecx
@@ -3841,7 +3756,6 @@ LABEL_12:
 // 6A8A30: using guessed type int gossipend;
 // 6AA705: using guessed type char stextflag;
 
-//----- (0045BB9F) --------------------------------------------------------
 void __cdecl S_HBuyEnter()
 {
 	int v0; // eax
@@ -3898,7 +3812,6 @@ LABEL_11:
 // 6A8A24: using guessed type int stextvhold;
 // 6A8A28: using guessed type int stextsel;
 
-//----- (0045BC74) --------------------------------------------------------
 void __cdecl S_StoryEnter()
 {
 	int v0; // ecx
@@ -3931,7 +3844,6 @@ LABEL_8:
 // 6A8A30: using guessed type int gossipend;
 // 6AA705: using guessed type char stextflag;
 
-//----- (0045BCCA) --------------------------------------------------------
 void __cdecl S_SIDEnter()
 {
 	int idx; // eax
@@ -3968,7 +3880,6 @@ void __cdecl S_SIDEnter()
 // 6A8A24: using guessed type int stextvhold;
 // 6A8A28: using guessed type int stextsel;
 
-//----- (0045BD4B) --------------------------------------------------------
 void __cdecl S_TalkEnter()
 {
 	int v0; // edx
@@ -4054,7 +3965,6 @@ void __cdecl S_TalkEnter()
 // 6A8A28: using guessed type int stextsel;
 // 6A8A30: using guessed type int gossipend;
 
-//----- (0045BE4A) --------------------------------------------------------
 void __cdecl S_TavernEnter()
 {
 	int v0; // ecx
@@ -4082,7 +3992,6 @@ void __cdecl S_TavernEnter()
 // 6A8A30: using guessed type int gossipend;
 // 6AA705: using guessed type char stextflag;
 
-//----- (0045BE98) --------------------------------------------------------
 void __cdecl S_BarmaidEnter()
 {
 	int v0; // ecx
@@ -4110,7 +4019,6 @@ void __cdecl S_BarmaidEnter()
 // 6A8A30: using guessed type int gossipend;
 // 6AA705: using guessed type char stextflag;
 
-//----- (0045BEE6) --------------------------------------------------------
 void __cdecl S_DrunkEnter()
 {
 	int v0; // ecx
@@ -4138,7 +4046,6 @@ void __cdecl S_DrunkEnter()
 // 6A8A30: using guessed type int gossipend;
 // 6AA705: using guessed type char stextflag;
 
-//----- (0045BF34) --------------------------------------------------------
 void __cdecl STextEnter()
 {
 	if ( qtextflag )
@@ -4233,7 +4140,6 @@ void __cdecl STextEnter()
 // 6A8A28: using guessed type int stextsel;
 // 6AA705: using guessed type char stextflag;
 
-//----- (0045C053) --------------------------------------------------------
 void __cdecl CheckStoreBtn()
 {
 	bool v0; // sf
@@ -4326,7 +4232,6 @@ void __cdecl CheckStoreBtn()
 // 6A8A2C: using guessed type char stextscrldbtn;
 // 6AA704: using guessed type char stextscrlubtn;
 
-//----- (0045C18A) --------------------------------------------------------
 void __cdecl ReleaseStoreBtn()
 {
 	stextscrlubtn = -1;

--- a/Source/stores.h
+++ b/Source/stores.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __STORES_H__
+#define __STORES_H__
 
-//stores
 extern int stextup; // weak
 extern int storenumh; // weak
 extern int stextlhold; // weak
@@ -135,3 +136,5 @@ void __cdecl ReleaseStoreBtn();
 
 extern int SStringY[24];
 extern char *talkname[9];
+
+#endif /* __STORES_H__ */

--- a/Source/sync.cpp
+++ b/Source/sync.cpp
@@ -8,7 +8,6 @@ short sync_word_6AA89C[200];
 int dword_6AAA2C[2];
 int sgnSyncPInv; // weak
 
-//----- (0045C199) --------------------------------------------------------
 int __fastcall sync_all_monsters(TSyncHeader *packet, int size)
 {
 	int result; // eax
@@ -47,7 +46,6 @@ int __fastcall sync_all_monsters(TSyncHeader *packet, int size)
 	return result;
 }
 
-//----- (0045C21E) --------------------------------------------------------
 void __cdecl sync_one_monster()
 {
 	int i; // ebx
@@ -81,7 +79,6 @@ void __cdecl sync_one_monster()
 	}
 }
 
-//----- (0045C2C4) --------------------------------------------------------
 int __fastcall sync_monster_active(TSyncMonster *packet)
 {
 	unsigned int v1; // ebx
@@ -111,7 +108,6 @@ int __fastcall sync_monster_active(TSyncMonster *packet)
 	return 1;
 }
 
-//----- (0045C317) --------------------------------------------------------
 int __fastcall sync_monster_pos(TSyncMonster *packet, int mon_id)
 {
 	int v2; // ebx
@@ -139,7 +135,6 @@ int __fastcall sync_monster_pos(TSyncMonster *packet, int mon_id)
 	return result * 2;
 }
 
-//----- (0045C386) --------------------------------------------------------
 int __fastcall sync_monster_active2(TSyncMonster *packet)
 {
 	int v1; // edx
@@ -176,7 +171,6 @@ int __fastcall sync_monster_active2(TSyncMonster *packet)
 }
 // 6AA898: using guessed type int dword_6AA898;
 
-//----- (0045C3E6) --------------------------------------------------------
 char __fastcall SyncPlrInv(TSyncHeader *pItem)
 {
 	int v1; // edx
@@ -251,7 +245,6 @@ char __fastcall SyncPlrInv(TSyncHeader *pItem)
 }
 // 6AAA34: using guessed type int sgnSyncPInv;
 
-//----- (0045C5C7) --------------------------------------------------------
 int __fastcall SyncData(int pnum, TSyncHeader *packet)
 {
 	TSyncHeader *v2; // esi
@@ -286,7 +279,6 @@ int __fastcall SyncData(int pnum, TSyncHeader *packet)
 }
 // 676194: using guessed type char gbBufferMsgs;
 
-//----- (0045C63B) --------------------------------------------------------
 void __fastcall sync_monster_data(int pnum, TSyncMonster *packet)
 {
 	TSyncMonster *v2; // edi
@@ -385,7 +377,6 @@ LABEL_23:
 	}
 }
 
-//----- (0045C84B) --------------------------------------------------------
 void __cdecl sync_clear_pkt()
 {
 	dword_6AA898 = 16 * myplr;

--- a/Source/sync.h
+++ b/Source/sync.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __SYNC_H__
+#define __SYNC_H__
 
-//sync
 extern short sync_word_6AA708[200];
 extern int dword_6AA898; // weak
 extern short sync_word_6AA89C[200];
@@ -16,3 +17,5 @@ char __fastcall SyncPlrInv(TSyncHeader *pItem);
 int __fastcall SyncData(int pnum, TSyncHeader *packet);
 void __fastcall sync_monster_data(int pnum, TSyncMonster *packet);
 void __cdecl sync_clear_pkt();
+
+#endif /* __SYNC_H__ */

--- a/Source/textdat.cpp
+++ b/Source/textdat.cpp
@@ -2,6 +2,8 @@
 
 #include "../types.h"
 
+/* todo: move text out of struct */
+
 TextDataStruct alltext[259] =
 {
   { " Ahh, the story of our King, is it? The tragic fall of Leoric was a harsh blow to this land. The people always loved the King, and now they live in mortal fear of him. The question that I keep asking myself is how he could have fallen so far from the Light, as Leoric had always been the holiest of men. Only the vilest powers of Hell could so utterly destroy a man from within... |",

--- a/Source/textdat.h
+++ b/Source/textdat.h
@@ -1,4 +1,8 @@
 //HEADER_GOES_HERE
+#ifndef __TEXTDAT_H__
+#define __TEXTDAT_H__
 
 extern TextDataStruct alltext[259];
 extern int gdwAllTextEntries;
+
+#endif /* __TEXTDAT_H__ */

--- a/Source/themes.cpp
+++ b/Source/themes.cpp
@@ -53,7 +53,6 @@ int trm3y[9] =
 	1, 1, 1
 };
 
-//----- (0045C870) --------------------------------------------------------
 bool __fastcall TFit_Shrine(int i)
 {
 	int v1; // ecx
@@ -114,7 +113,6 @@ LABEL_21:
 	return 1;
 }
 
-//----- (0045C993) --------------------------------------------------------
 bool __fastcall TFit_Obj5(int t)
 {
 	int v2; // ebx
@@ -181,7 +179,6 @@ LABEL_18:
 	}
 }
 
-//----- (0045CA72) --------------------------------------------------------
 bool __fastcall TFit_SkelRoom(int t)
 {
 	int i; // esi
@@ -203,7 +200,6 @@ bool __fastcall TFit_SkelRoom(int t)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0045CAC4) --------------------------------------------------------
 bool __fastcall TFit_GoatShrine(int t)
 {
 	int i; // esi
@@ -222,7 +218,6 @@ bool __fastcall TFit_GoatShrine(int t)
 	return TFit_Obj5(t);
 }
 
-//----- (0045CB09) --------------------------------------------------------
 bool __fastcall CheckThemeObj3(int xp, int yp, int t, int f)
 {
 	int i; // edi
@@ -252,7 +247,6 @@ bool __fastcall CheckThemeObj3(int xp, int yp, int t, int f)
 	return 0;
 }
 
-//----- (0045CB88) --------------------------------------------------------
 bool __fastcall TFit_Obj3(int t)
 {
 	int yp; // edi
@@ -286,7 +280,6 @@ bool __fastcall TFit_Obj3(int t)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0045CBE4) --------------------------------------------------------
 bool __fastcall CheckThemeReqs(int t)
 {
 	bool rv; // al
@@ -375,7 +368,6 @@ LABEL_16:
 // 6AAC08: using guessed type int pFountainFlag;
 // 6AAC0C: using guessed type int bFountainFlag;
 
-//----- (0045CC64) --------------------------------------------------------
 bool __fastcall SpecialThemeFit(int i, int t)
 {
 	bool rv; // eax
@@ -461,7 +453,6 @@ bool __fastcall SpecialThemeFit(int i, int t)
 // 6AAC08: using guessed type int pFountainFlag;
 // 6AAC0C: using guessed type int bFountainFlag;
 
-//----- (0045CD9A) --------------------------------------------------------
 bool __fastcall CheckThemeRoom(int tv)
 {
 	int v1; // esi
@@ -545,7 +536,6 @@ LABEL_16:
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0045CED2) --------------------------------------------------------
 void __cdecl InitThemes()
 {
 	int v0; // esi
@@ -682,7 +672,6 @@ LABEL_23:
 // 6AAC0C: using guessed type int bFountainFlag;
 // 6AAC10: using guessed type int bCrossFlag;
 
-//----- (0045D087) --------------------------------------------------------
 void __cdecl HoldThemeRooms()
 {
 	int v0; // ebx
@@ -726,7 +715,6 @@ void __cdecl HoldThemeRooms()
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0045D0E1) --------------------------------------------------------
 void __fastcall PlaceThemeMonsts(int t, int f)
 {
 	int numscattypes; // edx
@@ -763,7 +751,6 @@ void __fastcall PlaceThemeMonsts(int t, int f)
 }
 // 45D0E1: using guessed type int var_1D0[111];
 
-//----- (0045D1C2) --------------------------------------------------------
 void __fastcall Theme_Barrel(int t)
 {
 	int yp; // edi
@@ -800,7 +787,6 @@ void __fastcall Theme_Barrel(int t)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0045D29A) --------------------------------------------------------
 void __fastcall Theme_Shrine(int t)
 {
 	char monstrnd[5]; // [esp+3h] [ebp-5h]
@@ -826,7 +812,6 @@ void __fastcall Theme_Shrine(int t)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0045D34D) --------------------------------------------------------
 void __fastcall Theme_MonstPit(int t)
 {
 	int r; // eax
@@ -863,7 +848,6 @@ void __fastcall Theme_MonstPit(int t)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0045D3E6) --------------------------------------------------------
 void __fastcall Theme_SkelRoom(int t)
 {
 	int yp; // esi
@@ -920,7 +904,6 @@ void __fastcall Theme_SkelRoom(int t)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0045D5BC) --------------------------------------------------------
 void __fastcall Theme_Treasure(int t)
 {
 	int yp; // esi
@@ -964,7 +947,6 @@ void __fastcall Theme_Treasure(int t)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0045D707) --------------------------------------------------------
 void __fastcall Theme_Library(int t)
 {
 	int v1; // edi
@@ -1047,7 +1029,6 @@ void __fastcall Theme_Library(int t)
 // 5BB1ED: using guessed type char leveltype;
 // 6AAA64: using guessed type int zharlib;
 
-//----- (0045D88A) --------------------------------------------------------
 void __fastcall Theme_Torture(int t)
 {
 	int v1; // ebx
@@ -1102,7 +1083,6 @@ void __fastcall Theme_Torture(int t)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0045D95D) --------------------------------------------------------
 void __fastcall Theme_BloodFountain(int t)
 {
 	char monstrnd[5]; // [esp+3h] [ebp-5h]
@@ -1117,7 +1097,6 @@ void __fastcall Theme_BloodFountain(int t)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0045D9A3) --------------------------------------------------------
 void __fastcall Theme_Decap(int t)
 {
 	int v1; // ebx
@@ -1172,7 +1151,6 @@ void __fastcall Theme_Decap(int t)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0045DA76) --------------------------------------------------------
 void __fastcall Theme_PurifyingFountain(int t)
 {
 	char monstrnd[5]; // [esp+3h] [ebp-5h]
@@ -1187,7 +1165,6 @@ void __fastcall Theme_PurifyingFountain(int t)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0045DABC) --------------------------------------------------------
 void __fastcall Theme_ArmorStand(int t)
 {
 	int v1; // esi
@@ -1249,7 +1226,6 @@ void __fastcall Theme_ArmorStand(int t)
 // 5BB1ED: using guessed type char leveltype;
 // 6AAA3C: using guessed type int armorFlag;
 
-//----- (0045DBAD) --------------------------------------------------------
 void __fastcall Theme_GoatShrine(int t)
 {
 	int v1; // edx
@@ -1295,7 +1271,6 @@ void __fastcall Theme_GoatShrine(int t)
 	}
 }
 
-//----- (0045DC7B) --------------------------------------------------------
 void __fastcall Theme_Cauldron(int t)
 {
 	char monstrnd[5]; // [esp+3h] [ebp-5h]
@@ -1310,7 +1285,6 @@ void __fastcall Theme_Cauldron(int t)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0045DCC1) --------------------------------------------------------
 void __fastcall Theme_MurkyFountain(int t)
 {
 	char monstrnd[5]; // [esp+3h] [ebp-5h]
@@ -1325,7 +1299,6 @@ void __fastcall Theme_MurkyFountain(int t)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0045DD07) --------------------------------------------------------
 void __fastcall Theme_TearFountain(int t)
 {
 	char monstrnd[5]; // [esp+3h] [ebp-5h]
@@ -1340,7 +1313,6 @@ void __fastcall Theme_TearFountain(int t)
 }
 // 5BB1ED: using guessed type char leveltype;
 
-//----- (0045DD4D) --------------------------------------------------------
 void __fastcall Theme_BrnCross(int t)
 {
 	int v1; // esi
@@ -1397,7 +1369,6 @@ void __fastcall Theme_BrnCross(int t)
 // 5BB1ED: using guessed type char leveltype;
 // 6AAC10: using guessed type int bCrossFlag;
 
-//----- (0045DE20) --------------------------------------------------------
 void __fastcall Theme_WeaponRack(int t)
 {
 	int v1; // esi
@@ -1459,7 +1430,6 @@ void __fastcall Theme_WeaponRack(int t)
 // 5BB1ED: using guessed type char leveltype;
 // 6AAA50: using guessed type int weaponFlag;
 
-//----- (0045DF11) --------------------------------------------------------
 void __cdecl UpdateL4Trans()
 {
 	int i; // ecx
@@ -1475,7 +1445,6 @@ void __cdecl UpdateL4Trans()
 	}
 }
 
-//----- (0045DF31) --------------------------------------------------------
 void __cdecl CreateThemeRooms()
 {
 	int i; // esi

--- a/Source/themes.h
+++ b/Source/themes.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __THEMES_H__
+#define __THEMES_H__
 
-//themes
 extern int numthemes; // idb
 extern bool armorFlag; // weak
 extern int ThemeGoodIn[4];
@@ -57,3 +58,5 @@ extern int trm5x[25];
 extern int trm5y[25];
 extern int trm3x[9];
 extern int trm3y[9];
+
+#endif /* __THEMES_H__ */

--- a/Source/tmsg.cpp
+++ b/Source/tmsg.cpp
@@ -4,7 +4,6 @@
 
 TMsg *sgpTimedMsgHead;
 
-//----- (0045E08C) --------------------------------------------------------
 int __fastcall tmsg_get(unsigned char *pbMsg, char bLen)
 {
 	unsigned char *v2; // ebx
@@ -26,7 +25,6 @@ int __fastcall tmsg_get(unsigned char *pbMsg, char bLen)
 	return dwMaxLen;
 }
 
-//----- (0045E0D7) --------------------------------------------------------
 void __fastcall tmsg_add(unsigned char *pbMsg, char bLen)
 {
 	char v2; // bl
@@ -56,7 +54,6 @@ void __fastcall tmsg_add(unsigned char *pbMsg, char bLen)
 	*v9 = v6;
 }
 
-//----- (0045E12A) --------------------------------------------------------
 void __cdecl tmsg_cleanup()
 {
 	TMsg *v0; // eax

--- a/Source/tmsg.h
+++ b/Source/tmsg.h
@@ -1,8 +1,11 @@
 //HEADER_GOES_HERE
+#ifndef __TMSG_H__
+#define __TMSG_H__
 
-//tmsg
 extern TMsg *sgpTimedMsgHead;
 
 int __fastcall tmsg_get(unsigned char *pbMsg, char bLen);
 void __fastcall tmsg_add(unsigned char *pbMsg, char bLen);
 void __cdecl tmsg_cleanup();
+
+#endif /* __TMSG_H__ */

--- a/Source/town.cpp
+++ b/Source/town.cpp
@@ -2,7 +2,6 @@
 
 #include "../types.h"
 
-//----- (0045E151) --------------------------------------------------------
 void __fastcall town_clear_upper_buf(int a1)
 {
 	unsigned int v1; // edi
@@ -43,7 +42,6 @@ void __fastcall town_clear_upper_buf(int a1)
 }
 // 69CF0C: using guessed type int screen_buf_end;
 
-//----- (0045E1B7) --------------------------------------------------------
 void __fastcall town_clear_low_buf(int y_related)
 {
 	unsigned int v1; // edi
@@ -97,7 +95,6 @@ void __fastcall town_clear_low_buf(int y_related)
 }
 // 69CF0C: using guessed type int screen_buf_end;
 
-//----- (0045E226) --------------------------------------------------------
 void __fastcall town_draw_clipped_e_flag(void *buffer, int x, int y, int sx, int sy)
 {
 	int v5; // ebx
@@ -131,7 +128,6 @@ void __fastcall town_draw_clipped_e_flag(void *buffer, int x, int y, int sx, int
 }
 // 69CF14: using guessed type int level_cel_block;
 
-//----- (0045E2A5) --------------------------------------------------------
 void __fastcall town_draw_clipped_town(void *unused, int x, int y, int sx, int sy, int some_flag)
 {
 	unsigned int v6; // edx
@@ -251,7 +247,6 @@ void __fastcall town_draw_clipped_town(void *unused, int x, int y, int sx, int s
 // 4B8CC0: using guessed type char pcursitem;
 // 4B8CC2: using guessed type char pcursplr;
 
-//----- (0045E5B0) --------------------------------------------------------
 void __fastcall town_draw_lower(int x, int y, int sx, int sy, int a5, int some_flag)
 {
 	int v6; // ebx
@@ -390,7 +385,6 @@ void __fastcall town_draw_lower(int x, int y, int sx, int sy, int a5, int some_f
 }
 // 69CF14: using guessed type int level_cel_block;
 
-//----- (0045E898) --------------------------------------------------------
 void __fastcall town_draw_clipped_e_flag_2(void *buffer, int x, int y, int a4, int a5, int sx, int sy)
 {
 	int v7; // ebx
@@ -434,7 +428,6 @@ void __fastcall town_draw_clipped_e_flag_2(void *buffer, int x, int y, int a4, i
 }
 // 69CF14: using guessed type int level_cel_block;
 
-//----- (0045E939) --------------------------------------------------------
 void __fastcall town_draw_clipped_town_2(int x, int y, int a3, int a4, int a5, int sx, int sy, int some_flag)
 {
 	unsigned int v8; // edx
@@ -554,7 +547,6 @@ void __fastcall town_draw_clipped_town_2(int x, int y, int a3, int a4, int a5, i
 // 4B8CC0: using guessed type char pcursitem;
 // 4B8CC2: using guessed type char pcursplr;
 
-//----- (0045EC49) --------------------------------------------------------
 void __fastcall town_draw_lower_2(int x, int y, int sx, int sy, int a5, int a6, int some_flag)
 {
 	int v7; // esi
@@ -719,7 +711,6 @@ LABEL_18:
 }
 // 69CF14: using guessed type int level_cel_block;
 
-//----- (0045EF8A) --------------------------------------------------------
 void __fastcall town_draw_e_flag(void *buffer, int x, int y, int a4, int dir, int sx, int sy)
 {
 	int v7; // ebx
@@ -756,7 +747,6 @@ void __fastcall town_draw_e_flag(void *buffer, int x, int y, int a4, int dir, in
 }
 // 69CF14: using guessed type int level_cel_block;
 
-//----- (0045F013) --------------------------------------------------------
 void __fastcall town_draw_town_all(void *buffer, int x, int y, int a4, int dir, int sx, int sy, int some_flag)
 {
 	//int v9; // ebx
@@ -819,7 +809,6 @@ void __fastcall town_draw_town_all(void *buffer, int x, int y, int a4, int dir, 
 // 4B8CC0: using guessed type char pcursitem;
 // 4B8CC2: using guessed type char pcursplr;
 
-//----- (0045F323) --------------------------------------------------------
 void __fastcall town_draw_upper(int x, int y, int sx, int sy, int a5, int a6, int some_flag)
 {
 	signed int v7; // ebx
@@ -1002,7 +991,6 @@ LABEL_36:
 }
 // 69CF14: using guessed type int level_cel_block;
 
-//----- (0045F65D) --------------------------------------------------------
 void __fastcall T_DrawGame(int x, int y)
 {
 	int v2; // esi
@@ -1135,7 +1123,6 @@ LABEL_15:
 // 69BD04: using guessed type int questlog;
 // 69CF0C: using guessed type int screen_buf_end;
 
-//----- (0045F856) --------------------------------------------------------
 void __fastcall T_DrawZoom(int x, int y)
 {
 	int v2; // edi
@@ -1306,7 +1293,6 @@ LABEL_24:
 // 69BD04: using guessed type int questlog;
 // 69CF0C: using guessed type int screen_buf_end;
 
-//----- (0045FAAB) --------------------------------------------------------
 void __fastcall T_DrawView(int StartX, int StartY)
 {
 	light_table_index = 0;
@@ -1373,7 +1359,6 @@ void __fastcall T_DrawView(int StartX, int StartY)
 // 69CF94: using guessed type int cel_transparency_active;
 // 6AA705: using guessed type char stextflag;
 
-//----- (0045FBD7) --------------------------------------------------------
 void __cdecl town_init_dpiece_defs_map()
 {
 	int (*v0)[112]; // ebx
@@ -1439,7 +1424,6 @@ void __cdecl town_init_dpiece_defs_map()
 // 5C3000: using guessed type int scr_pix_width;
 // 5C3004: using guessed type int scr_pix_height;
 
-//----- (0045FCBF) --------------------------------------------------------
 void __fastcall T_FillSector(unsigned char *P3Tiles, unsigned char *pSector, int xi, int yi, int w, int h) /* check 7 params: int AddSec */
 {
 	int v7; // ebx
@@ -1513,7 +1497,6 @@ void __fastcall T_FillSector(unsigned char *P3Tiles, unsigned char *pSector, int
 	}
 }
 
-//----- (0045FD75) --------------------------------------------------------
 void __fastcall T_FillTile(unsigned char *P3Tiles, int xx, int yy, int t)
 {
 	unsigned char *v4; // esi
@@ -1540,7 +1523,6 @@ void __fastcall T_FillTile(unsigned char *P3Tiles, int xx, int yy, int t)
 	dPiece[xx + 1][yy + 1] = v6 + 1;
 }
 
-//----- (0045FDE6) --------------------------------------------------------
 void __cdecl T_Pass3()
 {
 	int *v1; // esi
@@ -1611,7 +1593,6 @@ void __cdecl T_Pass3()
 // 45FDE6: could not find valid save-restore pair for edi
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (0045FF83) --------------------------------------------------------
 void __fastcall CreateTown(int entry)
 {
 	int v1; // edi

--- a/Source/town.h
+++ b/Source/town.h
@@ -1,4 +1,6 @@
 //HEADER_GOES_HERE
+#ifndef __TOWN_H__
+#define __TOWN_H__
 
 void __fastcall town_clear_upper_buf(int a1);
 void __fastcall town_clear_low_buf(int y_related);
@@ -19,3 +21,5 @@ void __fastcall T_FillSector(unsigned char *P3Tiles, unsigned char *pSector, int
 void __fastcall T_FillTile(unsigned char *P3Tiles, int xx, int yy, int t);
 void __cdecl T_Pass3();
 void __fastcall CreateTown(int entry);
+
+#endif /* __TOWN_H__ */

--- a/Source/towners.cpp
+++ b/Source/towners.cpp
@@ -308,7 +308,6 @@ QuestTalkData Qtalklist[11] =
 };
 int CowPlaying = -1;
 
-//----- (0046019B) --------------------------------------------------------
 int __fastcall GetActiveTowner(int t)
 {
 	int i; // eax
@@ -326,7 +325,6 @@ int __fastcall GetActiveTowner(int t)
 	return i;
 }
 
-//----- (004601C1) --------------------------------------------------------
 void __fastcall SetTownerGPtrs(void *pData, void **pAnim)
 {
 	void **v2; // esi
@@ -345,7 +343,6 @@ void __fastcall SetTownerGPtrs(void *pData, void **pAnim)
 	while ( v5 < 8 );
 }
 
-//----- (004601FB) --------------------------------------------------------
 void __fastcall NewTownerAnim(int tnum, void *pAnim, int numFrames, int Delay)
 {
 	int v4; // ecx
@@ -358,7 +355,6 @@ void __fastcall NewTownerAnim(int tnum, void *pAnim, int numFrames, int Delay)
 	towner[v4]._tAnimDelay = Delay;
 }
 
-//----- (0046022F) --------------------------------------------------------
 void __fastcall InitTownerInfo(int i, int w, bool sel, int t, int x, int y, int ao, int tp)
 {
 	int v8; // ebx
@@ -382,7 +378,6 @@ void __fastcall InitTownerInfo(int i, int w, bool sel, int t, int x, int y, int 
 	towner[v9]._tSeed = GetRndSeed();
 }
 
-//----- (004602C4) --------------------------------------------------------
 void __fastcall InitQstSnds(int i)
 {
 	int v1; // eax
@@ -412,7 +407,6 @@ void __fastcall InitQstSnds(int i)
 // 69BE90: using guessed type int qline;
 // 6AAC2C: using guessed type int boyloadflag;
 
-//----- (00460311) --------------------------------------------------------
 void __cdecl InitSmith()
 {
 	int v0; // esi
@@ -442,7 +436,6 @@ void __cdecl InitSmith()
 	++numtowners;
 }
 
-//----- (004603A0) --------------------------------------------------------
 void __cdecl InitBarOwner()
 {
 	int v0; // esi
@@ -474,7 +467,6 @@ void __cdecl InitBarOwner()
 }
 // 6AAC28: using guessed type int bannerflag;
 
-//----- (00460436) --------------------------------------------------------
 void __cdecl InitTownDead()
 {
 	int v0; // esi
@@ -504,7 +496,6 @@ void __cdecl InitTownDead()
 	++numtowners;
 }
 
-//----- (004604C6) --------------------------------------------------------
 void __cdecl InitWitch()
 {
 	int v0; // esi
@@ -532,7 +523,6 @@ void __cdecl InitWitch()
 	++numtowners;
 }
 
-//----- (00460555) --------------------------------------------------------
 void __cdecl InitBarmaid()
 {
 	int v0; // esi
@@ -560,7 +550,6 @@ void __cdecl InitBarmaid()
 	++numtowners;
 }
 
-//----- (004605E4) --------------------------------------------------------
 void __cdecl InitBoy()
 {
 	int v0; // esi
@@ -590,7 +579,6 @@ void __cdecl InitBoy()
 }
 // 6AAC2C: using guessed type int boyloadflag;
 
-//----- (0046067A) --------------------------------------------------------
 void __cdecl InitHealer()
 {
 	int v0; // esi
@@ -620,7 +608,6 @@ void __cdecl InitHealer()
 	++numtowners;
 }
 
-//----- (00460709) --------------------------------------------------------
 void __cdecl InitTeller()
 {
 	int v0; // esi
@@ -648,7 +635,6 @@ void __cdecl InitTeller()
 	++numtowners;
 }
 
-//----- (00460798) --------------------------------------------------------
 void __cdecl InitDrunk()
 {
 	int v0; // esi
@@ -676,7 +662,6 @@ void __cdecl InitDrunk()
 	++numtowners;
 }
 
-//----- (00460827) --------------------------------------------------------
 void __cdecl InitCows()
 {
 	unsigned char *v0; // eax
@@ -740,7 +725,6 @@ void __cdecl InitCows()
 }
 // 6AAC2C: using guessed type int boyloadflag;
 
-//----- (00460976) --------------------------------------------------------
 void __cdecl InitTowners()
 {
 	numtowners = 0;
@@ -759,7 +743,6 @@ void __cdecl InitTowners()
 }
 // 6AAC2C: using guessed type int boyloadflag;
 
-//----- (004609C3) --------------------------------------------------------
 void __cdecl FreeTownerGFX()
 {
 	void **v0; // esi
@@ -788,7 +771,6 @@ void __cdecl FreeTownerGFX()
 }
 // 6ABB9C: using guessed type int dword_6ABB9C;
 
-//----- (00460A05) --------------------------------------------------------
 void __fastcall TownCtrlMsg(int i)
 {
 	int p; // edi
@@ -811,7 +793,6 @@ void __fastcall TownCtrlMsg(int i)
 }
 // 646D00: using guessed type char qtextflag;
 
-//----- (00460A78) --------------------------------------------------------
 void __cdecl TownBlackSmith()
 {
 	int v0; // eax
@@ -820,7 +801,6 @@ void __cdecl TownBlackSmith()
 	TownCtrlMsg(v0);
 }
 
-//----- (00460A86) --------------------------------------------------------
 void __cdecl TownBarOwner()
 {
 	int v0; // eax
@@ -829,7 +809,6 @@ void __cdecl TownBarOwner()
 	TownCtrlMsg(v0);
 }
 
-//----- (00460A95) --------------------------------------------------------
 void __cdecl TownDead()
 {
 	int v0; // esi
@@ -852,7 +831,6 @@ LABEL_6:
 }
 // 646D00: using guessed type char qtextflag;
 
-//----- (00460B0D) --------------------------------------------------------
 void __cdecl TownHealer()
 {
 	int v0; // eax
@@ -861,7 +839,6 @@ void __cdecl TownHealer()
 	TownCtrlMsg(v0);
 }
 
-//----- (00460B1C) --------------------------------------------------------
 void __cdecl TownStory()
 {
 	int v0; // eax
@@ -870,7 +847,6 @@ void __cdecl TownStory()
 	TownCtrlMsg(v0);
 }
 
-//----- (00460B2B) --------------------------------------------------------
 void __cdecl TownDrunk()
 {
 	int v0; // eax
@@ -879,7 +855,6 @@ void __cdecl TownDrunk()
 	TownCtrlMsg(v0);
 }
 
-//----- (00460B3A) --------------------------------------------------------
 void __cdecl TownBoy()
 {
 	int v0; // eax
@@ -888,7 +863,6 @@ void __cdecl TownBoy()
 	TownCtrlMsg(v0);
 }
 
-//----- (00460B49) --------------------------------------------------------
 void __cdecl TownWitch()
 {
 	int v0; // eax
@@ -897,7 +871,6 @@ void __cdecl TownWitch()
 	TownCtrlMsg(v0);
 }
 
-//----- (00460B58) --------------------------------------------------------
 void __cdecl TownBarMaid()
 {
 	int v0; // eax
@@ -906,7 +879,6 @@ void __cdecl TownBarMaid()
 	TownCtrlMsg(v0);
 }
 
-//----- (00460B67) --------------------------------------------------------
 void __cdecl TownCow()
 {
 	int v0; // eax
@@ -915,7 +887,6 @@ void __cdecl TownCow()
 	TownCtrlMsg(v0);
 }
 
-//----- (00460B76) --------------------------------------------------------
 void __cdecl ProcessTowners()
 {
 	int *v0; // esi
@@ -985,7 +956,6 @@ void __cdecl ProcessTowners()
 	while ( (signed int)v0 < (signed int)&towner[16]._tAnimCnt );
 }
 
-//----- (00460C5C) --------------------------------------------------------
 ItemStruct *__fastcall PlrHasItem(int pnum, int item, int *i)
 {
 	unsigned int v3; // eax
@@ -1005,7 +975,6 @@ ItemStruct *__fastcall PlrHasItem(int pnum, int item, int *i)
 	return (ItemStruct *)((char *)&plr[0].InvList[*i] + v3);
 }
 
-//----- (00460CAC) --------------------------------------------------------
 void __fastcall TownerTalk(int t)
 {
 	sgdwCowClicks = 0;
@@ -1017,7 +986,6 @@ void __fastcall TownerTalk(int t)
 // 6AAC1C: using guessed type int sgnCowMsg;
 // 6AAC24: using guessed type int sgdwCowClicks;
 
-//----- (00460CC9) --------------------------------------------------------
 void __fastcall TalkToTowner(int p, int t)
 {
 	int v2; // ebx
@@ -1508,7 +1476,6 @@ LABEL_86:
 // 679660: using guessed type char gbMaxPlayers;
 // 6AAC18: using guessed type int storeflag;
 
-//----- (004617E8) --------------------------------------------------------
 void __fastcall CowSFX(int pnum)
 {
 	if ( CowPlaying == -1 || !effect_is_playing(CowPlaying) )

--- a/Source/towners.h
+++ b/Source/towners.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __TOWNERS_H__
+#define __TOWNERS_H__
 
-//towners
 extern int storeflag; // weak
 extern int sgnCowMsg; // weak
 extern int numtowners; // idb
@@ -58,3 +59,5 @@ extern int cowoffx[8];
 extern int cowoffy[8];
 extern QuestTalkData Qtalklist[11];
 extern int CowPlaying;
+
+#endif /* __TOWNERS_H__ */

--- a/Source/track.cpp
+++ b/Source/track.cpp
@@ -9,7 +9,6 @@ bool sgbIsWalking; // weak
 
 int track_inf = 0x7F800000; // weak
 
-//----- (004618AA) --------------------------------------------------------
 struct track_cpp_init
 {
 	track_cpp_init()
@@ -20,7 +19,6 @@ struct track_cpp_init
 // 4802D0: using guessed type int track_inf;
 // 6ABABC: using guessed type int track_cpp_init_value;
 
-//----- (004618B5) --------------------------------------------------------
 void __cdecl track_process()
 {
 	int v0; // eax
@@ -50,7 +48,6 @@ void __cdecl track_process()
 // 6ABAC0: using guessed type int sgdwLastWalk;
 // 6ABAC4: using guessed type int sgbIsWalking;
 
-//----- (00461953) --------------------------------------------------------
 void __fastcall track_repeat_walk(bool rep)
 {
 	if ( sgbIsWalking != rep )
@@ -72,7 +69,6 @@ void __fastcall track_repeat_walk(bool rep)
 // 6ABAC0: using guessed type int sgdwLastWalk;
 // 6ABAC4: using guessed type int sgbIsWalking;
 
-//----- (0046199F) --------------------------------------------------------
 bool __cdecl track_isscrolling()
 {
 	return sgbIsScrolling;

--- a/Source/track.h
+++ b/Source/track.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __TRACK_H__
+#define __TRACK_H__
 
-//track
 extern bool sgbIsScrolling; // weak
 extern int track_cpp_init_value; // weak
 extern int sgdwLastWalk; // weak
@@ -14,3 +15,5 @@ bool __cdecl track_isscrolling();
 /* data */
 
 extern int track_inf; // weak
+
+#endif /* __TRACK_H__ */

--- a/Source/trigs.cpp
+++ b/Source/trigs.cpp
@@ -88,14 +88,12 @@ int L4PentaList[33] =
   -1
 };
 
-//----- (004619A7) --------------------------------------------------------
 void __cdecl InitNoTriggers()
 {
 	trigflag[4] = 0;
 	trigflag[3] = 0;
 }
 
-//----- (004619B6) --------------------------------------------------------
 void __cdecl InitTownTriggers()
 {
 	char v0; // bl
@@ -163,7 +161,6 @@ void __cdecl InitTownTriggers()
 }
 // 679660: using guessed type char gbMaxPlayers;
 
-//----- (00461B45) --------------------------------------------------------
 void __cdecl InitL1Triggers()
 {
 	int v0; // edi
@@ -217,7 +214,6 @@ void __cdecl InitL1Triggers()
 	trigflag[3] = 0;
 }
 
-//----- (00461BEE) --------------------------------------------------------
 void __cdecl InitL2Triggers()
 {
 	signed int v0; // edi
@@ -289,7 +285,6 @@ void __cdecl InitL2Triggers()
 	trigflag[3] = 0;
 }
 
-//----- (00461CF6) --------------------------------------------------------
 void __cdecl InitL3Triggers()
 {
 	int v0; // edi
@@ -353,7 +348,6 @@ void __cdecl InitL3Triggers()
 	trigflag[3] = 0;
 }
 
-//----- (00461DC6) --------------------------------------------------------
 void __cdecl InitL4Triggers()
 {
 	signed int v0; // edi
@@ -453,7 +447,6 @@ void __cdecl InitL4Triggers()
 	trigflag[3] = 0;
 }
 
-//----- (00461F0A) --------------------------------------------------------
 void __cdecl InitSKingTriggers()
 {
 	trigflag[3] = 0;
@@ -463,7 +456,6 @@ void __cdecl InitSKingTriggers()
 	trigs[0]._tmsg = 1028;
 }
 
-//----- (00461F3A) --------------------------------------------------------
 void __cdecl InitSChambTriggers()
 {
 	trigflag[3] = 0;
@@ -473,7 +465,6 @@ void __cdecl InitSChambTriggers()
 	trigs[0]._tmsg = 1028;
 }
 
-//----- (00461F6A) --------------------------------------------------------
 void __cdecl InitPWaterTriggers()
 {
 	trigflag[3] = 0;
@@ -483,7 +474,6 @@ void __cdecl InitPWaterTriggers()
 	trigs[0]._tmsg = 1028;
 }
 
-//----- (00461F9A) --------------------------------------------------------
 void __cdecl InitVPTriggers()
 {
 	trigflag[3] = 0;
@@ -493,7 +483,6 @@ void __cdecl InitVPTriggers()
 	trigs[0]._tmsg = 1028;
 }
 
-//----- (00461FCA) --------------------------------------------------------
 unsigned char __cdecl ForceTownTrig()
 {
 	int v0; // edx
@@ -570,7 +559,6 @@ LABEL_17:
 	return 0;
 }
 
-//----- (00462130) --------------------------------------------------------
 unsigned char __cdecl ForceL1Trig()
 {
 	int *v0; // eax
@@ -652,7 +640,6 @@ LABEL_11:
 	return 1;
 }
 
-//----- (0046224C) --------------------------------------------------------
 unsigned char __cdecl ForceL2Trig()
 {
 	int *v0; // eax
@@ -790,7 +777,6 @@ LABEL_37:
 	return 1;
 }
 
-//----- (0046244F) --------------------------------------------------------
 unsigned char __cdecl ForceL3Trig()
 {
 	int *v0; // eax
@@ -924,7 +910,6 @@ LABEL_29:
 	return 0;
 }
 
-//----- (0046262D) --------------------------------------------------------
 unsigned char __cdecl ForceL4Trig()
 {
 	int *v0; // eax
@@ -1093,7 +1078,6 @@ LABEL_40:
 	return 0;
 }
 
-//----- (00462876) --------------------------------------------------------
 void __cdecl Freeupstairs()
 {
 	int *v0; // ecx
@@ -1133,7 +1117,6 @@ void __cdecl Freeupstairs()
 	}
 }
 
-//----- (004628B7) --------------------------------------------------------
 unsigned char __cdecl ForceSKingTrig()
 {
 	int v0; // eax
@@ -1156,7 +1139,6 @@ unsigned char __cdecl ForceSKingTrig()
 	return 1;
 }
 
-//----- (0046291F) --------------------------------------------------------
 unsigned char __cdecl ForceSChambTrig()
 {
 	int v0; // eax
@@ -1179,7 +1161,6 @@ unsigned char __cdecl ForceSChambTrig()
 	return 1;
 }
 
-//----- (00462987) --------------------------------------------------------
 unsigned char __cdecl ForcePWaterTrig()
 {
 	int v0; // eax
@@ -1202,7 +1183,6 @@ unsigned char __cdecl ForcePWaterTrig()
 	return 1;
 }
 
-//----- (004629EF) --------------------------------------------------------
 void __cdecl CheckTrigForce()
 {
 	int v0; // eax
@@ -1276,7 +1256,6 @@ LABEL_24:
 // 5CCB10: using guessed type char setlvlnum;
 // 5CF31D: using guessed type char setlevel;
 
-//----- (00462A9D) --------------------------------------------------------
 void __cdecl CheckTriggers()
 {
 	int *v0; // edi

--- a/Source/trigs.h
+++ b/Source/trigs.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __TRIGS_H__
+#define __TRIGS_H__
 
-//trigs
 extern int trigflag[5];
 extern TriggerStruct trigs[5];
 extern int TWarpFrom; // weak
@@ -43,3 +44,5 @@ extern int L4UpList[4];
 extern int L4DownList[6];
 extern int L4TWarpUpList[4];
 extern int L4PentaList[33];
+
+#endif /* __TRIGS_H__ */

--- a/Source/wave.cpp
+++ b/Source/wave.cpp
@@ -6,7 +6,6 @@ int wave_cpp_init_value; // weak
 
 int wave_inf = 0x7F800000; // weak
 
-//----- (00462C72) --------------------------------------------------------
 struct wave_cpp_init
 {
 	wave_cpp_init()
@@ -17,13 +16,11 @@ struct wave_cpp_init
 // 4802D4: using guessed type int wave_inf;
 // 6ABB34: using guessed type int wave_cpp_init_value;
 
-//----- (00462C7D) --------------------------------------------------------
 bool __fastcall WCloseFile(void *file)
 {
 	return SFileCloseFile(file);
 }
 
-//----- (00462C84) --------------------------------------------------------
 int __fastcall WGetFileSize(HANDLE hsFile, unsigned long *a2)
 {
 	unsigned long *v2; // edi
@@ -42,7 +39,6 @@ int __fastcall WGetFileSize(HANDLE hsFile, unsigned long *a2)
 	return result;
 }
 
-//----- (00462CAF) --------------------------------------------------------
 void __fastcall WGetFileArchive(HANDLE hsFile, int *a2, char *dwInitParam)
 {
 	int *v3; // esi
@@ -68,7 +64,6 @@ void __fastcall WGetFileArchive(HANDLE hsFile, int *a2, char *dwInitParam)
 	}
 }
 
-//----- (00462D06) --------------------------------------------------------
 int __fastcall WOpenFile(char *dwInitParam, HANDLE *phsFile, int a3)
 {
 	HANDLE *v3; // edi
@@ -89,7 +84,6 @@ int __fastcall WOpenFile(char *dwInitParam, HANDLE *phsFile, int a3)
 	return 0;
 }
 
-//----- (00462D48) --------------------------------------------------------
 char __fastcall WReadFile(HANDLE hsFile, char *buf, int a3)
 {
 	char *v3; // ebx
@@ -112,7 +106,6 @@ char __fastcall WReadFile(HANDLE hsFile, char *buf, int a3)
 	return v5;
 }
 
-//----- (00462D9A) --------------------------------------------------------
 int __fastcall WSetFilePointer(HANDLE file1, int offset, HANDLE file2, int whence)
 {
 	int v4; // edi
@@ -131,7 +124,6 @@ int __fastcall WSetFilePointer(HANDLE file1, int offset, HANDLE file2, int whenc
 	return result;
 }
 
-//----- (00462DCE) --------------------------------------------------------
 int __fastcall LoadWaveFormat(HANDLE hsFile, WAVEFORMATEX *pwfx)
 {
 	WAVEFORMATEX *v2; // esi
@@ -145,7 +137,6 @@ int __fastcall LoadWaveFormat(HANDLE hsFile, WAVEFORMATEX *pwfx)
 	return v3;
 }
 
-//----- (00462DFC) --------------------------------------------------------
 void *__fastcall AllocateMemFile(HANDLE hsFile, MEMFILE *pMemFile, unsigned int a3)
 {
 	MEMFILE *v3; // esi
@@ -172,7 +163,6 @@ void *__fastcall AllocateMemFile(HANDLE hsFile, MEMFILE *pMemFile, unsigned int 
 	return result;
 }
 
-//----- (00462E45) --------------------------------------------------------
 void __fastcall FreeMemFile(MEMFILE *pMemFile)
 {
 	MEMFILE *v1; // eax
@@ -184,7 +174,6 @@ void __fastcall FreeMemFile(MEMFILE *pMemFile)
 	mem_free_dbg(v2);
 }
 
-//----- (00462E53) --------------------------------------------------------
 int __fastcall ReadWaveFile(MEMFILE *pMemFile, WAVEFORMATEX *pwfx, int *a3)
 {
 	WAVEFORMATEX *v3; // esi
@@ -222,7 +211,6 @@ int __fastcall ReadWaveFile(MEMFILE *pMemFile, WAVEFORMATEX *pwfx, int *a3)
 	return result;
 }
 
-//----- (00462F1D) --------------------------------------------------------
 int __fastcall ReadMemFile(MEMFILE *pMemFile, void *lpBuf, size_t a3)
 {
 	size_t v3; // ebx
@@ -255,7 +243,6 @@ int __fastcall ReadMemFile(MEMFILE *pMemFile, void *lpBuf, size_t a3)
 	return 0;
 }
 
-//----- (00462F73) --------------------------------------------------------
 void __fastcall FillMemFile(MEMFILE *pMemFile)
 {
 	MEMFILE *v1; // esi
@@ -272,7 +259,6 @@ void __fastcall FillMemFile(MEMFILE *pMemFile)
 	v1->bytes_to_read = v2;
 }
 
-//----- (00462FAE) --------------------------------------------------------
 int __fastcall SeekMemFile(MEMFILE *pMemFile, unsigned int lDist, int dwMethod)
 {
 	unsigned int v3; // eax
@@ -291,7 +277,6 @@ int __fastcall SeekMemFile(MEMFILE *pMemFile, unsigned int lDist, int dwMethod)
 	return pMemFile->offset;
 }
 
-//----- (00462FCC) --------------------------------------------------------
 int __fastcall ReadWaveSection(MEMFILE *pMemFile, int a2, int *a3)
 {
 	int v3; // esi
@@ -316,7 +301,6 @@ int __fastcall ReadWaveSection(MEMFILE *pMemFile, int a2, int *a3)
 	return v6 != -1;
 }
 
-//----- (00463023) --------------------------------------------------------
 void *__fastcall LoadWaveFile(HANDLE hsFile, WAVEFORMATEX *pwfx, int *a3)
 {
 	WAVEFORMATEX *v3; // esi

--- a/Source/wave.h
+++ b/Source/wave.h
@@ -1,6 +1,7 @@
 //HEADER_GOES_HERE
+#ifndef __WAVE_H__
+#define __WAVE_H__
 
-//wave
 extern int wave_cpp_init_value; // weak
 //int dword_6ABB9C; // weak
 
@@ -25,3 +26,5 @@ void __fastcall j_engine_mem_free(void *ptr);
 /* data */
 
 extern int wave_inf; // weak
+
+#endif /* __WAVE_H__ */

--- a/Source/world.cpp
+++ b/Source/world.cpp
@@ -74,7 +74,6 @@ int world_4B3501[17] = { 0, 32, 60, 88, 112, 136, 156, 176, 192, 208, 220, 232, 
 	|/
 */
 
-//----- (00463060) --------------------------------------------------------
 void __fastcall drawTopArchesUpperScreen(void *a1)
 {
 	char v1; // edx
@@ -2567,7 +2566,6 @@ LABEL_391:
 // 69CF0C: using guessed type int screen_buf_end;
 // 69CF14: using guessed type int level_cel_block;
 
-//----- (0046468D) --------------------------------------------------------
 void __fastcall drawBottomArchesUpperScreen(void *a1, int a2)
 {
 	char *v2; // edi
@@ -3683,7 +3681,6 @@ LABEL_208:
 // 69CF0C: using guessed type int screen_buf_end;
 // 69CF14: using guessed type int level_cel_block;
 
-//----- (004652C5) --------------------------------------------------------
 void __fastcall drawUpperScreen(void *a1)
 {
 	char v1; // edx
@@ -4879,7 +4876,6 @@ LABEL_205:
 // 69CF94: using guessed type int cel_transparency_active;
 // 69CF98: using guessed type int level_piece_id;
 
-//----- (00465F38) --------------------------------------------------------
 void __fastcall drawTopArchesLowerScreen(void *a1)
 {
 	char v1; // edx
@@ -7728,7 +7724,6 @@ LABEL_336:
 // 69CF0C: using guessed type int screen_buf_end;
 // 69CF14: using guessed type int level_cel_block;
 
-//----- (00467949) --------------------------------------------------------
 void __fastcall drawBottomArchesLowerScreen(void *a1, int a2)
 {
 	char *v2; // edi
@@ -9089,7 +9084,6 @@ LABEL_180:
 // 69CF0C: using guessed type int screen_buf_end;
 // 69CF14: using guessed type int level_cel_block;
 
-//----- (0046886B) --------------------------------------------------------
 void __fastcall drawLowerScreen(void *a1)
 {
 	char v1; // edx
@@ -10407,7 +10401,6 @@ LABEL_171:
 // 69CF94: using guessed type int cel_transparency_active;
 // 69CF98: using guessed type int level_piece_id;
 
-//----- (004696BE) --------------------------------------------------------
 void __fastcall world_draw_black_tile(char *dst_buf)
 {
 	char *v1; // edi

--- a/Source/world.h
+++ b/Source/world.h
@@ -1,4 +1,6 @@
 //HEADER_GOES_HERE
+#ifndef __WORLD_H__
+#define __WORLD_H__
 
 void __fastcall drawTopArchesUpperScreen(void *a1);
 void __fastcall drawBottomArchesUpperScreen(void *a1, int a2);
@@ -18,3 +20,5 @@ extern unsigned int tile_draw_masks[3][32];
 extern int world_4B33FD[48];
 extern int world_4B34BD[17];
 extern int world_4B3501[17];
+
+#endif /* __WORLD_H__ */

--- a/defs.h
+++ b/defs.h
@@ -1,3 +1,33 @@
+// some global definitions, found in debug release
+
+#define DMAXX					40
+#define DMAXY					40
+
+#define LIGHTSIZE				6912 // 27 * 256
+
+#define MAX_PLRS				4
+#define MAX_CHARACTERS			10
+#define MAX_LVLMTYPES			16
+// #define MAX_PATH				260
+#define MAX_SEND_STR_LEN		80
+
+#define MAXDEAD					31
+#define MAXDUNX					112
+#define MAXDUNY					112
+#define MAXITEMS				127
+#define MAXMISSILES				125
+#define MAXMONSTERS				200
+#define MAXMULTIQUESTS			4
+#define MAXOBJECTS				127
+#define MAXPORTAL				4
+#define MAXQUESTS				16
+#define MAXTHEMES				50
+#define MAXTILES				2048
+#define MAXTRIGGERS				5
+#define MDMAXX					40
+#define MDMAXY					40
+
+
 // Diablo uses a 256 color palette
 // Entry 0-127 (0x00-0x7F) are level specific
 // Entry 128-255 (0x80-0xFF) are global


### PR DESCRIPTION
This one removes all the function references and will be putting them into a spreadsheet.

Header guards for the header files, should compile (slightly) faster.

Also added a few global definitions, for maximum elements and such.