### PR TITLE
Makefile should clean *.lib files & as.exe needs linking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,6 @@ storm.dll:
 	$(error Please copy storm.dll (version 1.09b) here)
 
 clean:
-	@$(RM) -v $(OBJS) $(OBJS:.o=.d) $(PKWARE_OBJS)  $(PKWARE_OBJS:.o=d)
+	@$(RM) -v $(OBJS) $(OBJS:.o=.d) $(PKWARE_OBJS)  $(PKWARE_OBJS:.o=d) storm.lib diabloui.lib
 
 .PHONY: clean all

--- a/Support/INSTALL_windows.md
+++ b/Support/INSTALL_windows.md
@@ -8,6 +8,7 @@
 # Start the *MSYS2 MinGW 32-bit* terminal.
 pacman -Sy git make mingw-w64-i686-gcc mingw-w64-i686-binutils
 ln -s /mingw32/i686-w64-mingw32/bin/dlltool.exe /usr/bin/i686-w64-mingw32-dlltool.exe
+ln -s /mingw32/i686-w64-mingw32/bin/as.exe /usr/bin/i686-w64-mingw32-as.exe
 ```
 
 ## Building


### PR DESCRIPTION
Hello,

Regarding #46:

While compiling with `MSYS2`, linker silently fails for `storm.lib` and `diabloui.lib` targets. Those files end up as empty and never get regenerated unless deleted by user.

Whenever we run `dlltool` with `-v` flag, we see that it's failing to find `i686-w64-mingw32-as`. I've added necessary linking line.

Thanks!