### PR TITLE
WIP: add install instructions for mac

### DIFF
--- a/Support/INSTALL_mac.md
+++ b/Support/INSTALL_mac.md
@@ -1,0 +1,32 @@
+# Installation
+
+## Dependencies
+
+[Homebrew](https://brew.sh/)
+
+```bash
+brew install wine
+brew install mingw-w64
+```
+
+## Building
+
+```bash
+git clone https://github.com/galaxyhaxz/devilution
+cd devilution
+cp /path/to/diablo_game_dir/diabloui.dll .
+cp /path/to/diablo_game_dir/Storm.dll .
+make
+```
+
+## Install
+
+```bash
+cp devilution.exe /path/to/diablo_game_dir/
+```
+
+## Run
+
+```bash
+wine devilution.exe
+```


### PR DESCRIPTION
Added a `INSTALL_mac.md` similar to Linux and Windows. OS X build was added to Travis with #44 
however running to this error.

```
tanner@tanners-mbp:~/.wine/drive_c/Diablo$ wine devilution.exe 
0009:err:module:import_dll Library libgcc_s_sjlj-1.dll (which is needed by L"C:\\Diablo\\devilution.exe") not found
0009:err:module:attach_dlls Importing dlls for L"C:\\Diablo\\devilution.exe" failed, status c0000135
```