### PR TITLE
update mac install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,11 @@ addons:
 
 before_install:
   # Packages for OSX
-  - if [ $TRAVIS_OS_NAME = osx ]; then brew install mingw-w64; fi
+  - |
+    if [ $TRAVIS_OS_NAME = osx ]; then
+      brew install mingw-w64;
+      ln -s /usr/local/Cellar/mingw-w64/5.0.4/toolchain-x86_64/bin/x86_64-w64-mingw32-windres /usr/local/bin/;
+    fi
 
 before_script:
   - touch storm.dll

--- a/Support/INSTALL_mac.md
+++ b/Support/INSTALL_mac.md
@@ -7,6 +7,7 @@
 ```bash
 brew install wine
 brew install mingw-w64
+ln -s /usr/local/Cellar/mingw-w64/5.0.4/toolchain-x86_64/bin/x86_64-w64-mingw32-windres /usr/local/bin/windres
 ```
 
 ## Building


### PR DESCRIPTION
Updated install instructions to include symlink to `windres`. However now when running make this error occurs.

```
Diablo.rc:10:10: fatal error: 'afxres.h' file not found
#include "afxres.h"
         ^~~~~~~~~~
1 error generated.
windres: Diablo.rc:65: syntax error
windres: preprocessing failed.
make: *** [diabres.o] Error 1
```
Also now that Travis is setup what needs to be done to start running CI builds?

