### PR TITLE
allow CXXFLAGS to be appended

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ endif
 #     static_cast<NEW_TYPE>(reinterpret_cast<uintptr_t>(ptr))
 # instead of
 #     (NEW_TYPE)(ptr)
-CXXFLAGS=-fpermissive -Wno-write-strings
+override CXXFLAGS += -fpermissive -Wno-write-strings
 CPPFLAGS=-MMD -MF $*.d
 LDLIBS=-lgdi32 -lversion -ldiabloui -lstorm
 LDFLAGS=-L./ -static-libgcc -mwindows


### PR DESCRIPTION
In order to enable `_DEBUG` sections, we should pass that definition
somewhere. However current Makefile didn't allow that.

I've modified `CXXFLAGS` in Makefile to flexible so that we can compile
with temporary flags such as:

```
$ make CXXFLAGS=-D_DEBUG=1
```

Leaving the CXXFLAGS as default does not break compilation.

Thanks!