### PR TITLE
Revert "update mac install (#51)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,7 @@ addons:
 
 before_install:
   # Packages for OSX
-  - |
-    if [ $TRAVIS_OS_NAME = osx ]; then
-      brew install mingw-w64;
-      ln -s /usr/local/Cellar/mingw-w64/5.0.4/toolchain-x86_64/bin/x86_64-w64-mingw32-windres /usr/local/bin/;
-    fi
+  - if [ $TRAVIS_OS_NAME = osx ]; then brew install mingw-w64; fi
 
 before_script:
   - touch storm.dll

--- a/Support/INSTALL_mac.md
+++ b/Support/INSTALL_mac.md
@@ -7,7 +7,6 @@
 ```bash
 brew install wine
 brew install mingw-w64
-ln -s /usr/local/Cellar/mingw-w64/5.0.4/toolchain-x86_64/bin/x86_64-w64-mingw32-windres /usr/local/bin/windres
 ```
 
 ## Building


### PR DESCRIPTION
This reverts commit e488eca732bf0ffe26d81a5530de922af788fc94.

With commit a925dbb413e67a0f817c37c836d42da02db51df2 it is not necessary to create symlink for OSX.

Travis CI build status: https://travis-ci.org/Saibamen/devilution/builds/395868457