### PR TITLE
Add debug lighting, add cmd line note

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,6 @@ storm.dll:
 #	$(error Please copy storm.dll (version 1.09[b]) here)
 
 clean:
-	@$(RM) -v $(OBJS) $(OBJS:.o=.d) $(PKWARE_OBJS) $(PKWARE_OBJS:.o=d) diabres.o storm.lib diabloui.lib
+	@$(RM) -v $(OBJS) $(OBJS:.o=.d) $(PKWARE_OBJS) $(PKWARE_OBJS:.o=d) diabres.o storm.lib diabloui.lib devilution.exe
 
 .PHONY: clean all

--- a/Source/diablo.cpp
+++ b/Source/diablo.cpp
@@ -1742,6 +1742,11 @@ LABEL_27:
 						NetSendCmdString(1 << myplr, tempstr);
 					}
 					return;
+				case 'L':
+				case 'l':
+					if ( debug_mode_key_inverted_v )
+						ToggleLighting();
+					return;
 				case 'M':
 					NextDebugMonster();
 					return;

--- a/Source/lighting.cpp
+++ b/Source/lighting.cpp
@@ -1391,6 +1391,31 @@ void __cdecl MakeLightTable()
 // 525728: using guessed type int light4flag;
 // 5BB1ED: using guessed type char leveltype;
 
+#ifdef _DEBUG
+void __cdecl ToggleLighting()
+{
+	int i;
+
+	lightflag ^= 1;
+	if ( lightflag )
+	{
+		memset(dTransVal, 0, 0x3100u);
+	}
+	else
+	{
+		memcpy(dTransVal, dTransVal2, 0x3100u);
+		for(i = 0; i < 4; i++)
+		{
+			if ( plr[i].plractive )
+			{
+				if ( currlevel == plr[i].plrlevel )
+					DoLighting(plr[i].WorldX, plr[i].WorldY, plr[i]._pLightRad, -1);
+			}
+		}
+	}
+}
+#endif
+
 void __cdecl InitLightMax()
 {
 	lightmax = light4flag == 0 ? 15 : 3;

--- a/Source/lighting.h
+++ b/Source/lighting.h
@@ -24,6 +24,9 @@ void __fastcall DoVision(int nXPos, int nYPos, int nRadius, unsigned char doauto
 void __cdecl FreeLightTable();
 void __cdecl InitLightTable();
 void __cdecl MakeLightTable();
+#ifdef _DEBUG
+void __cdecl ToggleLighting();
+#endif
 void __cdecl InitLightMax();
 void __cdecl InitLighting();
 int __fastcall AddLight(int x, int y, int r);

--- a/Support/debug.md
+++ b/Support/debug.md
@@ -39,7 +39,7 @@ In-game hotkeys
 - `d` -> print debug player info
 - `D` -> switch current debug player
 - `e` -> display "EFlag"
-- `l`/`L` -> toggle lighting in dungeon [NOT YET IMPLEMENTED]
+- `l`/`L` -> toggle lighting in dungeon
 - `m` -> print debug monster info
 - `M` -> switch current debug monster
 - `r`/`R` -> display game seeds

--- a/types.h
+++ b/types.h
@@ -45,7 +45,10 @@
 // If defined, use copy protection [Default -> Defined]
 //#define COPYPROT
 // If defined, don't reload for debuggers [Default -> Undefined]
-//#define DEBUGGER
+// Note that with patch 1.03 the command line was hosed, this is required to pass arguments to the game
+#ifdef _DEBUG
+#define DEBUGGER
+#endif
 // If defined, don't fry the CPU [Default -> Undefined]
 #define SLEEP
 


### PR DESCRIPTION
First is a feature from the debug build. It allows you to toggle full light radius in the dungeon using `l`/`L`.

Second is the game now forces `DEBUGGER` if using `make debug`. Reason being is that part of Blizzard's "**Make Diablo Hack Free(TM)**" agenda, they hosed the command line in 1.03 so nothing works after the process reloads. This actually broke the built in `dd_emulate` `dd_backbuf` and `ds_noduplicates` that were right there in the instruction manual.

How funny...