### PR TITLE
Fedora 28 dependencies for build

### DIFF
--- a/Support/INSTALL_linux.md
+++ b/Support/INSTALL_linux.md
@@ -12,6 +12,11 @@ Fedora 28:
 sudo dnf install mingw32-gcc-c++ wine
 ```
 
+elementary OS:
+```bash
+sudo apt install mingw-w64 wine
+```
+
 
 ## Building
 

--- a/Support/INSTALL_linux.md
+++ b/Support/INSTALL_linux.md
@@ -7,6 +7,12 @@ Arch Linux
 pacman -S mingw-w64-gcc mingw-w64-binutils
 ```
 
+Fedora 28:
+```bash
+sudo dnf install mingw32-gcc-c++ wine
+```
+
+
 ## Building
 
 ```bash


### PR DESCRIPTION
Added information about required dependencies on Fedora 28 (x86_64) in order to build project.